### PR TITLE
Fix build number following workflow file rename, allow manual build triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           configPath: packages/cdk/riff-raff.yaml
+          buildNumberOffset: 120
           projectName: investigations::transcription-service
           contentDirectories: |
             cdk.out:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: 'CI: API'
-on: [push]
+on: [push, workflow_dispatch]
 jobs:
   ci:
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: 'CI: API'
+name: 'CI'
 on: [push, workflow_dispatch]
 jobs:
   ci:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 name: 'CI'
-on: [push, workflow_dispatch]
+on:
+  workflow_dispatch:
+  push:
 jobs:
   ci:
     permissions:


### PR DESCRIPTION
## What does this change?
This adds an offset to the build number of our main github actions CI build after the changes in https://github.com/guardian/transcription-service/pull/4 caused it to be reset to 0 (I renamed the gha workflow yml file)

This also adds the [workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) trigger so we can manually trigger builds

## How to test
I've tested this by running a few builds on a different branch -seems to do the job