### PR TITLE
Auto update worker AMI with RiffRaff

### DIFF
--- a/packages/cdk/riff-raff.yaml
+++ b/packages/cdk/riff-raff.yaml
@@ -28,6 +28,10 @@ deployments:
       templateStagePaths:
         CODE: TranscriptionService-CODE.template.json
         PROD: TranscriptionService-PROD.template.json
+      amiTags:
+        Recipe: investigations-transcription-service
+        AmigoStage: PROD
+      amiEncrypted: true
     dependencies:
       - lambda-upload-eu-west-1-investigations-transcription-service
   lambda-update-eu-west-1-investigations-transcription-service:

--- a/packages/cdk/riff-raff.yaml
+++ b/packages/cdk/riff-raff.yaml
@@ -31,6 +31,7 @@ deployments:
       amiTags:
         Recipe: investigations-transcription-service
         AmigoStage: PROD
+      amiParameter: AMITranscriptionserviceworker
       amiEncrypted: true
     dependencies:
       - lambda-upload-eu-west-1-investigations-transcription-service


### PR DESCRIPTION
## What does this change?
Let's make use of riffraff's auto AMI update functionality to make sure our transcription workers are always using the latest AMI baked by AMIgo.

## How to test
Tested on CODE