### PR TITLE
Fix riffraff upload step for worker app

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,7 @@ jobs:
               - packages/cdk/cdk.out/TranscriptionService-PROD.template.json
             transcription-service:
               - packages/api/target/api.zip
+            transcription-service-worker:
               - packages/worker/target/worker.zip
       - name: Upload repository project to riff-raff
         uses: guardian/actions-riff-raff@v3


### PR DESCRIPTION
## What does this change?
Fixes a naming bug introduced in https://github.com/guardian/transcription-service/pull/4 - riffraff expects the artifact for the worker to be in a directory called transcription-service-worker

## How to test
I've tested this by deploying it using riffraff, it resolves deployment errors like this one https://riffraff.gutools.co.uk/deployment/view/f0de3b31-faba-4396-bf35-ff0d383cd927
