### PR TITLE
Add SQS queue and target-tracking scaling policy

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -27,6 +27,7 @@ import {
 } from 'aws-cdk-lib/aws-ec2';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
 
 export class TranscriptionService extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
@@ -146,38 +147,58 @@ export class TranscriptionService extends GuStack {
 			: [InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM)];
 
 		// unfortunately GuAutoscalingGroup doesn't support having a mixedInstancesPolicy so using the basic ASG here
-		new AutoScalingGroup(this, 'TranscriptionWorkerASG', {
-			minCapacity: 0,
-			maxCapacity: isProd ? 20 : 4,
-			autoScalingGroupName: `transcription-service-workers-${this.stage}`,
-			vpc: GuVpc.fromIdParameter(this, 'InvestigationsInternetEnabledVpc', {
-				availabilityZones: ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
-			}),
-			vpcSubnets: {
-				subnets: GuVpc.subnetsFromParameter(this, {
-					type: SubnetType.PRIVATE,
-					app: workerApp,
+		const transcriptionWorkerASG = new AutoScalingGroup(
+			this,
+			'TranscriptionWorkerASG',
+			{
+				minCapacity: 0,
+				maxCapacity: isProd ? 20 : 4,
+				autoScalingGroupName: `transcription-service-workers-${this.stage}`,
+				vpc: GuVpc.fromIdParameter(this, 'InvestigationsInternetEnabledVpc', {
+					availabilityZones: ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
 				}),
-			},
-			// initially protect instances from scale events till they have had a chance to pick up a transcription job
-			// scale in protection will be removed by the worker once it has finished a job
-			newInstancesProtectedFromScaleIn: true,
-			mixedInstancesPolicy: {
-				launchTemplate,
-				instancesDistribution: {
-					// 0 is the default, including this here just to make it more obvious what's happening
-					onDemandBaseCapacity: 0,
-					// if this value is set to 100, then we won't use spot instances at all, if it is 0 then we use 100% spot
-					onDemandPercentageAboveBaseCapacity: 100,
-					spotAllocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
-					spotMaxPrice: '0.6202',
-				},
-				launchTemplateOverrides: acceptableInstanceTypes.map(
-					(instanceType) => ({
-						instanceType,
+				vpcSubnets: {
+					subnets: GuVpc.subnetsFromParameter(this, {
+						type: SubnetType.PRIVATE,
+						app: workerApp,
 					}),
-				),
+				},
+				// initially protect instances from scale events till they have had a chance to pick up a transcription job
+				// scale in protection will be removed by the worker once it has finished a job
+				newInstancesProtectedFromScaleIn: true,
+				mixedInstancesPolicy: {
+					launchTemplate,
+					instancesDistribution: {
+						// 0 is the default, including this here just to make it more obvious what's happening
+						onDemandBaseCapacity: 0,
+						// if this value is set to 100, then we won't use spot instances at all, if it is 0 then we use 100% spot
+						onDemandPercentageAboveBaseCapacity: 100,
+						spotAllocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
+						spotMaxPrice: '0.6202',
+					},
+					launchTemplateOverrides: acceptableInstanceTypes.map(
+						(instanceType) => ({
+							instanceType,
+						}),
+					),
+				},
 			},
+		);
+
+		// SQS queue for transcription tasks from API lambda to worker EC2 instances
+		const transcriptionTaskQueue = new Queue(this, `${APP_NAME}-task-queue`, {
+			fifo: true,
+			queueName: `${APP_NAME}-task-queue-${this.stage}.fifo`,
+			// this is the default. 30 seconds should be enough time to get the
+			// size of the file from s3 and estimate transcription time. If it's
+			// not, we'll need to increase visibilityTimeout
+			visibilityTimeout: Duration.seconds(30),
 		});
+
+		// allow API lambda to write to queue
+		transcriptionTaskQueue.grantSendMessages(apiLambda);
+
+		// allow worker to receive message from queue
+		transcriptionTaskQueue.grantConsumeMessages(transcriptionWorkerASG);
 	}
 }

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -16,6 +16,7 @@ import {
 	AutoScalingGroup,
 	BlockDeviceVolume,
 	SpotAllocationStrategy,
+	GroupMetrics,
 } from 'aws-cdk-lib/aws-autoscaling';
 import {
 	InstanceClass,
@@ -182,6 +183,7 @@ export class TranscriptionService extends GuStack {
 						}),
 					),
 				},
+				groupMetrics: [GroupMetrics.all()],
 			},
 		);
 

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -15,8 +15,8 @@ import { EndpointType } from 'aws-cdk-lib/aws-apigateway';
 import {
 	AutoScalingGroup,
 	BlockDeviceVolume,
-	SpotAllocationStrategy,
 	GroupMetrics,
+	SpotAllocationStrategy,
 } from 'aws-cdk-lib/aws-autoscaling';
 import {
 	InstanceClass,

--- a/packages/cdk/target_tracking_scaling_policy/README.md
+++ b/packages/cdk/target_tracking_scaling_policy/README.md
@@ -1,0 +1,19 @@
+## Target tracking scaling policy for ASG
+
+We set a target-tracking scaling policy for the worker autoscaling group so that
+the number of worker instances is equal to the number of messages in the queue
+following an approach documented [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-target-tracking-metric-math.html).
+
+At the time of writing, AWS supports this feature only through the cli, but not
+in CDK. Instead we have to resort to a bash script `put-scaling-policy.sh` and
+configuration files `config-CODE.json` `config-PROD.json`.
+
+> "You can create a target tracking scaling policy using metric math only if you
+> use the AWS CLI or an SDK. This feature is not yet available in the console and
+> AWS CloudFormation."
+
+To update a scaling policy, run `put-scaling-policy.sh`, passing the stage as a
+parameter e.g. `put-scaling-policy.sh CODE`.
+
+Once target-tracking scaling policies are supported in cloudformation and CDK,
+we can remove this directory and reimplement the policy in `cdk.ts`

--- a/packages/cdk/target_tracking_scaling_policy/config-CODE.json
+++ b/packages/cdk/target_tracking_scaling_policy/config-CODE.json
@@ -1,0 +1,67 @@
+{
+	"CustomizedMetricSpecification": {
+		"Metrics": [
+			{
+				"Label": "Number of visible messages",
+				"Id": "m1",
+				"MetricStat": {
+					"Metric": {
+						"MetricName": "ApproximateNumberOfMessagesVisible",
+						"Namespace": "AWS/SQS",
+						"Dimensions": [
+							{
+								"Name": "QueueName",
+								"Value": "transcription-service-task-queue-CODE.fifo"
+							}
+						]
+					},
+					"Stat": "Sum"
+				},
+				"ReturnData": false
+			},
+			{
+				"Label": "Number of invisible (in-flight) messages",
+				"Id": "m2",
+				"MetricStat": {
+					"Metric": {
+						"MetricName": "ApproximateNumberOfMessagesNotVisible",
+						"Namespace": "AWS/SQS",
+						"Dimensions": [
+							{
+								"Name": "QueueName",
+								"Value": "transcription-service-task-queue-CODE.fifo"
+							}
+						]
+					},
+					"Stat": "Sum"
+				},
+				"ReturnData": false
+			},
+			{
+				"Label": "Get the group size (the number of InService instances)",
+				"Id": "m3",
+				"MetricStat": {
+					"Metric": {
+						"MetricName": "GroupInServiceInstances",
+						"Namespace": "AWS/AutoScaling",
+						"Dimensions": [
+							{
+								"Name": "AutoScalingGroupName",
+								"Value": "transcription-service-workers-CODE"
+							}
+						]
+					},
+					"Stat": "Average"
+				},
+				"ReturnData": false
+			},
+			{
+				"Label": "Calculate the backlog per instance",
+				"Id": "e1",
+				"Expression": "(m1 + m2) / m3",
+				"ReturnData": true
+			}
+		]
+	},
+	"TargetValue": 1
+}

--- a/packages/cdk/target_tracking_scaling_policy/config-PROD.json
+++ b/packages/cdk/target_tracking_scaling_policy/config-PROD.json
@@ -1,0 +1,67 @@
+{
+	"CustomizedMetricSpecification": {
+		"Metrics": [
+			{
+				"Label": "Number of visible messages",
+				"Id": "m1",
+				"MetricStat": {
+					"Metric": {
+						"MetricName": "ApproximateNumberOfMessagesVisible",
+						"Namespace": "AWS/SQS",
+						"Dimensions": [
+							{
+								"Name": "QueueName",
+								"Value": "transcription-service-task-queue-PROD.fifo"
+							}
+						]
+					},
+					"Stat": "Sum"
+				},
+				"ReturnData": false
+			},
+			{
+				"Label": "Number of invisible (in-flight) messages",
+				"Id": "m2",
+				"MetricStat": {
+					"Metric": {
+						"MetricName": "ApproximateNumberOfMessagesNotVisible",
+						"Namespace": "AWS/SQS",
+						"Dimensions": [
+							{
+								"Name": "QueueName",
+								"Value": "transcription-service-task-queue-PROD.fifo"
+							}
+						]
+					},
+					"Stat": "Sum"
+				},
+				"ReturnData": false
+			},
+			{
+				"Label": "Get the group size (the number of InService instances)",
+				"Id": "m3",
+				"MetricStat": {
+					"Metric": {
+						"MetricName": "GroupInServiceInstances",
+						"Namespace": "AWS/AutoScaling",
+						"Dimensions": [
+							{
+								"Name": "AutoScalingGroupName",
+								"Value": "transcription-service-workers-PROD"
+							}
+						]
+					},
+					"Stat": "Average"
+				},
+				"ReturnData": false
+			},
+			{
+				"Label": "Calculate the backlog per instance",
+				"Id": "e1",
+				"Expression": "(m1 + m2) / m3",
+				"ReturnData": true
+			}
+		]
+	},
+	"TargetValue": 1
+}

--- a/packages/cdk/target_tracking_scaling_policy/put-scaling-policy.sh
+++ b/packages/cdk/target_tracking_scaling_policy/put-scaling-policy.sh
@@ -1,0 +1,11 @@
+STAGE=$1
+dirname=$(dirname "$0")
+
+if [[ $STAGE != 'CODE' && $STAGE != 'PROD' ]]; then
+  echo "Stage is invalid - must be 'CODE' or 'PROD', actual value was '$STAGE'"
+  exit
+fi
+
+aws autoscaling put-scaling-policy --policy-name sqs-backlog-target-tracking-scaling-policy-$STAGE \
+  --auto-scaling-group-name transcription-service-workers-$STAGE --policy-type TargetTrackingScaling \
+  --target-tracking-configuration file://$dirname/config-$STAGE.json


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Adds an SQS queue to the stack which can be written to by the API lambda and read from by the worker ASG
- Adds bash script and config files to create and update a target-tracking scaling policy following [this approach](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-target-tracking-metric-math.html). This policy will make the autoscaling group scale in and out so that the number of instances at any given time matches the number of transcription jobs in the queue. Unfortunately this feature hasn't been added to cloudformation or CDK yet so we need to create the policy manually. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
tested on CODE infra by 
- creating sqs messages `aws sqs send-message --queue-url [...]transcription-service-task-queue-CODE.fifo --message-body 'this is a test'`
- watching ASG scale out
- reading, then deleting messages
  - `aws sqs receive-message --queue-url [...]transcription-service-task-queue-CODE.fifo`
  - `aws sqs delete-message --queue-url [...]transcription-service-task-queue-CODE.fifo --receipt-handle [value]`
- ASG scales in (after scale-in protection removed from instances)
