### PR TITLE
Format and lint with precommit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
 				"@typescript-eslint/parser": "^6.19.0",
 				"esbuild": "^0.19.11",
 				"eslint": "^8.56.0",
+				"husky": "^8.0.0",
+				"lint-staged": "^15.2.0",
 				"prettier": "^3.2.4",
 				"ts-node": "^10.9.2",
 				"typescript": "^5.3.3"
@@ -33,9 +35,8 @@
 		},
 		"node_modules/@alloc/quick-lru": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-			"integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -150,14 +151,15 @@
 			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/client-sqs": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.504.0.tgz",
+			"integrity": "sha512-fPL9ndLXYEvWGIMiHW9q9J6sOmqvKwKHXW7qAqV6Y8S81Ku5VkqcalRL03rbbG3dp0gBET9FdgDp+H0mmWJOVw==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/client-sts": "3.502.0",
+				"@aws-sdk/client-sts": "3.504.0",
 				"@aws-sdk/core": "3.496.0",
-				"@aws-sdk/credential-provider-node": "3.502.0",
+				"@aws-sdk/credential-provider-node": "3.504.0",
 				"@aws-sdk/middleware-host-header": "3.502.0",
 				"@aws-sdk/middleware-logger": "3.502.0",
 				"@aws-sdk/middleware-recursion-detection": "3.502.0",
@@ -202,7 +204,8 @@
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.502.0.tgz",
+			"integrity": "sha512-OZAYal1+PQgUUtWiHhRayDtX0OD+XpXHKAhjYgEIPbyhQaCMp3/Bq1xDX151piWXvXqXLJHFKb8DUEqzwGO9QA==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
@@ -246,9 +249,62 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.504.0.tgz",
+			"integrity": "sha512-ODA33/nm2srhV08EW0KZAP577UgV0qjyr7Xp2yEo8MXWL4ZqQZprk1c+QKBhjr4Djesrm0VPmSD/np0mtYP68A==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.504.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-signing": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.504.0"
+			}
+		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sts": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.504.0.tgz",
+			"integrity": "sha512-IESs8FkL7B/uY+ml4wgoRkrr6xYo4PizcNw6JX17eveq1gRBCPKeGMjE6HTDOcIYZZ8rqz/UeuH3JD4UhrMOnA==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
@@ -294,12 +350,13 @@
 				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/credential-provider-node": "*"
+				"@aws-sdk/credential-provider-node": "^3.504.0"
 			}
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-env": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.502.0.tgz",
+			"integrity": "sha512-KIB8Ae1Z7domMU/jU4KiIgK4tmYgvuXlhR54ehwlVHxnEoFPoPuGHFZU7oFn79jhhSLUFQ1lRYMxP0cEwb7XeQ==",
 			"dependencies": {
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/property-provider": "^2.1.1",
@@ -311,14 +368,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.504.0.tgz",
+			"integrity": "sha512-ODICLXfr8xTUd3wweprH32Ge41yuBa+u3j0JUcLdTUO1N9ldczSMdo8zOPlP0z4doqD3xbnqMkjNQWgN/Q+5oQ==",
 			"dependencies": {
-				"@aws-sdk/client-sts": "3.502.0",
+				"@aws-sdk/client-sts": "3.504.0",
 				"@aws-sdk/credential-provider-env": "3.502.0",
 				"@aws-sdk/credential-provider-process": "3.502.0",
-				"@aws-sdk/credential-provider-sso": "3.502.0",
-				"@aws-sdk/credential-provider-web-identity": "3.502.0",
+				"@aws-sdk/credential-provider-sso": "3.504.0",
+				"@aws-sdk/credential-provider-web-identity": "3.504.0",
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/credential-provider-imds": "^2.2.1",
 				"@smithy/property-provider": "^2.1.1",
@@ -331,14 +389,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.504.0.tgz",
+			"integrity": "sha512-6+V5hIh+tILmUjf2ZQWQINR3atxQVgH/bFrGdSR/sHSp/tEgw3m0xWL3IRslWU1e4/GtXrfg1iYnMknXy68Ikw==",
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "3.502.0",
-				"@aws-sdk/credential-provider-ini": "3.502.0",
+				"@aws-sdk/credential-provider-http": "3.503.1",
+				"@aws-sdk/credential-provider-ini": "3.504.0",
 				"@aws-sdk/credential-provider-process": "3.502.0",
-				"@aws-sdk/credential-provider-sso": "3.502.0",
-				"@aws-sdk/credential-provider-web-identity": "3.502.0",
+				"@aws-sdk/credential-provider-sso": "3.504.0",
+				"@aws-sdk/credential-provider-web-identity": "3.504.0",
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/credential-provider-imds": "^2.2.1",
 				"@smithy/property-provider": "^2.1.1",
@@ -352,7 +412,8 @@
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-process": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.502.0.tgz",
+			"integrity": "sha512-fJJowOjQ4infYQX0E1J3xFVlmuwEYJAFk0Mo1qwafWmEthsBJs+6BR2RiWDELHKrSK35u4Pf3fu3RkYuCtmQFw==",
 			"dependencies": {
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/property-provider": "^2.1.1",
@@ -365,11 +426,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.504.0.tgz",
+			"integrity": "sha512-4MgH2or2SjPzaxM08DCW+BjaX4DSsEGJlicHKmz6fh+w9JmLh750oXcTnbvgUeVz075jcs6qTKjvUcsdGM/t8Q==",
 			"dependencies": {
 				"@aws-sdk/client-sso": "3.502.0",
-				"@aws-sdk/token-providers": "3.502.0",
+				"@aws-sdk/token-providers": "3.504.0",
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/property-provider": "^2.1.1",
 				"@smithy/shared-ini-file-loader": "^2.3.1",
@@ -381,10 +443,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.504.0.tgz",
+			"integrity": "sha512-L1ljCvGpIEFdJk087ijf2ohg7HBclOeB1UgBxUBBzf4iPRZTQzd2chGaKj0hm2VVaXz7nglswJeURH5PFcS5oA==",
 			"dependencies": {
-				"@aws-sdk/client-sts": "3.502.0",
+				"@aws-sdk/client-sts": "3.504.0",
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/property-provider": "^2.1.1",
 				"@smithy/types": "^2.9.1",
@@ -396,7 +459,8 @@
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.502.0.tgz",
+			"integrity": "sha512-EjnG0GTYXT/wJBmm5/mTjDcAkzU8L7wQjOzd3FTXuTCNNyvAvwrszbOj5FlarEw5XJBbQiZtBs+I5u9+zy560w==",
 			"dependencies": {
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/protocol-http": "^3.1.1",
@@ -409,7 +473,8 @@
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.502.0.tgz",
+			"integrity": "sha512-FDyv6K4nCoHxbjLGS2H8ex8I0KDIiu4FJgVRPs140ZJy6gE5Pwxzv6YTzZGLMrnqcIs9gh065Lf6DjwMelZqaw==",
 			"dependencies": {
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/types": "^2.9.1",
@@ -421,7 +486,8 @@
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.502.0.tgz",
+			"integrity": "sha512-hvbyGJbxeuezxOu8VfFmcV4ql1hKXLxHTe5FNYfEBat2KaZXVhc1Hg+4TvB06/53p+E8J99Afmumkqbxs2esUA==",
 			"dependencies": {
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/protocol-http": "^3.1.1",
@@ -432,9 +498,27 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-signing": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.502.0.tgz",
+			"integrity": "sha512-4hF08vSzJ7L6sB+393gOFj3s2N6nLusYS0XrMW6wYNFU10IDdbf8Z3TZ7gysDJJHEGQPmTAesPEDBsasGWcMxg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/signature-v4": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.502.0.tgz",
+			"integrity": "sha512-TxbBZbRiXPH0AUxegqiNd9aM9zNSbfjtBs5MEfcBsweeT/B2O7K1EjP9+CkB8Xmk/5FLKhAKLr19b1TNoE27rw==",
 			"dependencies": {
 				"@aws-sdk/types": "3.502.0",
 				"@aws-sdk/util-endpoints": "3.502.0",
@@ -448,7 +532,8 @@
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/region-config-resolver": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.502.0.tgz",
+			"integrity": "sha512-mxmsX2AGgnSM+Sah7mcQCIneOsJQNiLX0COwEttuf8eO+6cLMAZvVudH3BnWTfea4/A9nuri9DLCqBvEmPrilg==",
 			"dependencies": {
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/node-config-provider": "^2.2.1",
@@ -462,10 +547,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.504.0.tgz",
+			"integrity": "sha512-YIJWWsZi2ClUiILS1uh5L6VjmCUSTI6KKMuL9DkGjYqJ0aI6M8bd8fT9Wm7QmXCyjcArTgr/Atkhia4T7oKvzQ==",
 			"dependencies": {
-				"@aws-sdk/client-sso-oidc": "3.502.0",
+				"@aws-sdk/client-sso-oidc": "3.504.0",
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/property-provider": "^2.1.1",
 				"@smithy/shared-ini-file-loader": "^2.3.1",
@@ -478,7 +564,8 @@
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
 			"dependencies": {
 				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
@@ -489,7 +576,8 @@
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.502.0.tgz",
+			"integrity": "sha512-6LKFlJPp2J24r1Kpfoz5ESQn+1v5fEjDB3mtUKRdpwarhm3syu7HbKlHCF3KbcCOyahobvLvhoedT78rJFEeeg==",
 			"dependencies": {
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/types": "^2.9.1",
@@ -502,7 +590,8 @@
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.502.0.tgz",
+			"integrity": "sha512-v8gKyCs2obXoIkLETAeEQ3AM+QmhHhst9xbM1cJtKUGsRlVIak/XyyD+kVE6kmMm1cjfudHpHKABWk9apQcIZQ==",
 			"dependencies": {
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/types": "^2.9.1",
@@ -512,7 +601,8 @@
 		},
 		"node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.502.0.tgz",
+			"integrity": "sha512-9RjxpkGZKbTdl96tIJvAo+vZoz4P/cQh36SBUt9xfRfW0BtsaLyvSrvlR5wyUYhvRcC12Axqh/8JtnAPq//+Vw==",
 			"dependencies": {
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/node-config-provider": "^2.2.1",
@@ -635,246 +725,6 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "3.0.0",
-				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/client-sts": "3.502.0",
-				"@aws-sdk/core": "3.496.0",
-				"@aws-sdk/middleware-host-header": "3.502.0",
-				"@aws-sdk/middleware-logger": "3.502.0",
-				"@aws-sdk/middleware-recursion-detection": "3.502.0",
-				"@aws-sdk/middleware-signing": "3.502.0",
-				"@aws-sdk/middleware-user-agent": "3.502.0",
-				"@aws-sdk/region-config-resolver": "3.502.0",
-				"@aws-sdk/types": "3.502.0",
-				"@aws-sdk/util-endpoints": "3.502.0",
-				"@aws-sdk/util-user-agent-browser": "3.502.0",
-				"@aws-sdk/util-user-agent-node": "3.502.0",
-				"@smithy/config-resolver": "^2.1.1",
-				"@smithy/core": "^1.3.1",
-				"@smithy/fetch-http-handler": "^2.4.1",
-				"@smithy/hash-node": "^2.1.1",
-				"@smithy/invalid-dependency": "^2.1.1",
-				"@smithy/middleware-content-length": "^2.1.1",
-				"@smithy/middleware-endpoint": "^2.4.1",
-				"@smithy/middleware-retry": "^2.1.1",
-				"@smithy/middleware-serde": "^2.1.1",
-				"@smithy/middleware-stack": "^2.1.1",
-				"@smithy/node-config-provider": "^2.2.1",
-				"@smithy/node-http-handler": "^2.3.1",
-				"@smithy/protocol-http": "^3.1.1",
-				"@smithy/smithy-client": "^2.3.1",
-				"@smithy/types": "^2.9.1",
-				"@smithy/url-parser": "^2.1.1",
-				"@smithy/util-base64": "^2.1.1",
-				"@smithy/util-body-length-browser": "^2.1.1",
-				"@smithy/util-body-length-node": "^2.2.1",
-				"@smithy/util-defaults-mode-browser": "^2.1.1",
-				"@smithy/util-defaults-mode-node": "^2.1.1",
-				"@smithy/util-endpoints": "^1.1.1",
-				"@smithy/util-retry": "^2.1.1",
-				"@smithy/util-utf8": "^2.1.1",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"@aws-sdk/credential-provider-node": "*"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/client-sts": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "3.0.0",
-				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/core": "3.496.0",
-				"@aws-sdk/middleware-host-header": "3.502.0",
-				"@aws-sdk/middleware-logger": "3.502.0",
-				"@aws-sdk/middleware-recursion-detection": "3.502.0",
-				"@aws-sdk/middleware-user-agent": "3.502.0",
-				"@aws-sdk/region-config-resolver": "3.502.0",
-				"@aws-sdk/types": "3.502.0",
-				"@aws-sdk/util-endpoints": "3.502.0",
-				"@aws-sdk/util-user-agent-browser": "3.502.0",
-				"@aws-sdk/util-user-agent-node": "3.502.0",
-				"@smithy/config-resolver": "^2.1.1",
-				"@smithy/core": "^1.3.1",
-				"@smithy/fetch-http-handler": "^2.4.1",
-				"@smithy/hash-node": "^2.1.1",
-				"@smithy/invalid-dependency": "^2.1.1",
-				"@smithy/middleware-content-length": "^2.1.1",
-				"@smithy/middleware-endpoint": "^2.4.1",
-				"@smithy/middleware-retry": "^2.1.1",
-				"@smithy/middleware-serde": "^2.1.1",
-				"@smithy/middleware-stack": "^2.1.1",
-				"@smithy/node-config-provider": "^2.2.1",
-				"@smithy/node-http-handler": "^2.3.1",
-				"@smithy/protocol-http": "^3.1.1",
-				"@smithy/smithy-client": "^2.3.1",
-				"@smithy/types": "^2.9.1",
-				"@smithy/url-parser": "^2.1.1",
-				"@smithy/util-base64": "^2.1.1",
-				"@smithy/util-body-length-browser": "^2.1.1",
-				"@smithy/util-body-length-node": "^2.2.1",
-				"@smithy/util-defaults-mode-browser": "^2.1.1",
-				"@smithy/util-defaults-mode-node": "^2.1.1",
-				"@smithy/util-endpoints": "^1.1.1",
-				"@smithy/util-middleware": "^2.1.1",
-				"@smithy/util-retry": "^2.1.1",
-				"@smithy/util-utf8": "^2.1.1",
-				"fast-xml-parser": "4.2.5",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"@aws-sdk/credential-provider-node": "*"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "3.502.0",
-				"@smithy/protocol-http": "^3.1.1",
-				"@smithy/types": "^2.9.1",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "3.502.0",
-				"@smithy/types": "^2.9.1",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "3.502.0",
-				"@smithy/protocol-http": "^3.1.1",
-				"@smithy/types": "^2.9.1",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-signing": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "3.502.0",
-				"@smithy/property-provider": "^2.1.1",
-				"@smithy/protocol-http": "^3.1.1",
-				"@smithy/signature-v4": "^2.1.1",
-				"@smithy/types": "^2.9.1",
-				"@smithy/util-middleware": "^2.1.1",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "3.502.0",
-				"@aws-sdk/util-endpoints": "3.502.0",
-				"@smithy/protocol-http": "^3.1.1",
-				"@smithy/types": "^2.9.1",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "3.502.0",
-				"@smithy/node-config-provider": "^2.2.1",
-				"@smithy/types": "^2.9.1",
-				"@smithy/util-config-provider": "^2.2.1",
-				"@smithy/util-middleware": "^2.1.1",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^2.9.1",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "3.502.0",
-				"@smithy/types": "^2.9.1",
-				"@smithy/util-endpoints": "^1.1.1",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "3.502.0",
-				"@smithy/types": "^2.9.1",
-				"bowser": "^2.11.0",
-				"tslib": "^2.5.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.502.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "3.502.0",
-				"@smithy/node-config-provider": "^2.2.1",
-				"@smithy/types": "^2.9.1",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"aws-crt": ">=1.0.0"
-			},
-			"peerDependenciesMeta": {
-				"aws-crt": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@aws-sdk/client-sts": {
 			"version": "3.496.0",
 			"license": "Apache-2.0",
@@ -945,6 +795,37 @@
 			"dependencies": {
 				"@aws-sdk/types": "3.496.0",
 				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.503.1",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.503.1.tgz",
+			"integrity": "sha512-rTdlFFGoPPFMF2YjtlfRuSgKI+XsF49u7d98255hySwhsbwd3Xp+utTTPquxP+CwDxMHbDlI7NxDzFiFdsoZug==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-stream": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+			"dependencies": {
 				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
@@ -1074,7 +955,8 @@
 		},
 		"node_modules/@aws-sdk/middleware-sdk-sqs": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.502.0.tgz",
+			"integrity": "sha512-rPwBgTD8fxsE6Y9CcOc4fnTLbuqbA5KZi5++PrkfJx9XKrmWKvGnTj+l9Rnm3JwCIztelPho7ZM1Uaa78VsAHQ==",
 			"dependencies": {
 				"@aws-sdk/types": "3.502.0",
 				"@smithy/types": "^2.9.1",
@@ -1088,7 +970,8 @@
 		},
 		"node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
 			"version": "3.502.0",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
 			"dependencies": {
 				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
@@ -1820,8 +1703,7 @@
 		},
 		"node_modules/@babel/runtime": {
 			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
-			"integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+			"license": "MIT",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -2107,9 +1989,8 @@
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"string-width": "^5.1.2",
 				"string-width-cjs": "npm:string-width@^4.2.0",
@@ -2124,9 +2005,8 @@
 		},
 		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -2136,9 +2016,8 @@
 		},
 		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
 			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -2148,15 +2027,13 @@
 		},
 		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
 			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@isaacs/cliui/node_modules/string-width": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"eastasianwidth": "^0.2.0",
 				"emoji-regex": "^9.2.2",
@@ -2171,9 +2048,8 @@
 		},
 		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
 			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.0.1"
 			},
@@ -2186,9 +2062,8 @@
 		},
 		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
 			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^6.1.0",
 				"string-width": "^5.0.1",
@@ -2644,139 +2519,17 @@
 		},
 		"node_modules/@next/env": {
 			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.0.tgz",
-			"integrity": "sha512-Py8zIo+02ht82brwwhTg36iogzFqGLPXlRGKQw5s+qP/kMNc4MAyDeEwBKDijk6zTIbegEgu8Qy7C1LboslQAw=="
+			"license": "MIT"
 		},
 		"node_modules/@next/swc-darwin-arm64": {
 			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.0.tgz",
-			"integrity": "sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@next/swc-darwin-x64": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.0.tgz",
-			"integrity": "sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.0.tgz",
-			"integrity": "sha512-RHo7Tcj+jllXUbK7xk2NyIDod3YcCPDZxj1WLIYxd709BQ7WuRYl3OWUNG+WUfqeQBds6kvZYlc42NJJTNi4tQ==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.0.tgz",
-			"integrity": "sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.0.tgz",
-			"integrity": "sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.0.tgz",
-			"integrity": "sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.0.tgz",
-			"integrity": "sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.0.tgz",
-			"integrity": "sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==",
-			"cpu": [
-				"ia32"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.0.tgz",
-			"integrity": "sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
 			],
 			"engines": {
 				"node": ">= 10"
@@ -2888,9 +2641,8 @@
 		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=14"
@@ -3027,7 +2779,8 @@
 		},
 		"node_modules/@smithy/md5-js": {
 			"version": "2.1.1",
-			"license": "Apache-2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.1.1.tgz",
+			"integrity": "sha512-L3MbIYBIdLlT+MWTYrdVSv/dow1+6iZ1Ad7xS0OHxTTs17d753ZcpOV4Ro7M7tRAVWML/sg2IAp/zzCb6aAttg==",
 			"dependencies": {
 				"@smithy/types": "^2.9.1",
 				"@smithy/util-utf8": "^2.1.1",
@@ -3429,8 +3182,7 @@
 		},
 		"node_modules/@swc/helpers": {
 			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
-			"integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -3599,9 +3351,8 @@
 		},
 		"node_modules/@types/jsonwebtoken": {
 			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.5.tgz",
-			"integrity": "sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -3626,27 +3377,24 @@
 		},
 		"node_modules/@types/passport": {
 			"version": "1.0.16",
-			"resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.16.tgz",
-			"integrity": "sha512-FD0qD5hbPWQzaM0wHUnJ/T0BBCJBxCeemtnCwc/ThhTg3x9jfrAcRUmj5Dopza+MfFS9acTe3wk7rcVnRIp/0A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/express": "*"
 			}
 		},
 		"node_modules/@types/passport-google-oauth2": {
 			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/@types/passport-google-oauth2/-/passport-google-oauth2-0.1.8.tgz",
-			"integrity": "sha512-0lgGOVbGNTw7NcmrPh3pRwtGJXf1XZG7FZkYtM5DuQ8HJjHzi5mMIq28x7v/q5NNDIrFvhjE0CnyTv7hn4DIjg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/express": "*"
 			}
 		},
 		"node_modules/@types/passport-jwt": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
-			"integrity": "sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/jsonwebtoken": "*",
 				"@types/passport-strategy": "*"
@@ -3654,9 +3402,8 @@
 		},
 		"node_modules/@types/passport-strategy": {
 			"version": "0.2.38",
-			"resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
-			"integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/express": "*",
 				"@types/passport": "*"
@@ -3664,9 +3411,8 @@
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.11",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-			"integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/qs": {
 			"version": "6.9.11",
@@ -3680,9 +3426,8 @@
 		},
 		"node_modules/@types/react": {
 			"version": "18.2.51",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.51.tgz",
-			"integrity": "sha512-XeoMaU4CzyjdRr3c4IQQtiH7Rpo18V07rYZUucEZQwOUEtGgTXv7e6igQiQ+xnV6MbMe1qjEmKdgMNnfppnXfg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -3691,18 +3436,16 @@
 		},
 		"node_modules/@types/react-dom": {
 			"version": "18.2.18",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
-			"integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/react": "*"
 			}
 		},
 		"node_modules/@types/scheduler": {
 			"version": "0.16.8",
-			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-			"integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.6",
@@ -3935,9 +3678,8 @@
 		},
 		"node_modules/abbrev": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -4046,9 +3788,8 @@
 		},
 		"node_modules/any-promise": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
@@ -4205,8 +3946,6 @@
 		},
 		"node_modules/autoprefixer": {
 			"version": "10.4.17",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
-			"integrity": "sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==",
 			"dev": true,
 			"funding": [
 				{
@@ -4222,6 +3961,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.22.2",
 				"caniuse-lite": "^1.0.30001578",
@@ -4822,8 +4562,7 @@
 		},
 		"node_modules/base64url": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -4953,8 +4692,7 @@
 		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
@@ -4963,8 +4701,6 @@
 		},
 		"node_modules/busboy": {
 			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
 			"dependencies": {
 				"streamsearch": "^1.1.0"
 			},
@@ -5012,9 +4748,8 @@
 		},
 		"node_modules/camelcase-css": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
 			}
@@ -5146,6 +4881,20 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/cli-cursor": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/cli-progress": {
 			"version": "3.12.0",
 			"dev": true,
@@ -5157,14 +4906,111 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/cli-truncate": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"slice-ansi": "^5.0.0",
+				"string-width": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-truncate/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/cli-truncate/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/cli-truncate/node_modules/emoji-regex": {
+			"version": "10.3.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-truncate/node_modules/slice-ansi": {
+			"version": "5.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.0.0",
+				"is-fullwidth-code-point": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/cli-truncate/node_modules/string-width": {
+			"version": "7.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-truncate/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/client": {
 			"resolved": "packages/client",
 			"link": true
 		},
 		"node_modules/client-only": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-			"integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+			"license": "MIT"
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
@@ -5219,6 +5065,11 @@
 		},
 		"node_modules/color-name": {
 			"version": "1.1.4",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/colorette": {
+			"version": "2.0.20",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5312,9 +5163,8 @@
 		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"cssesc": "bin/cssesc"
 			},
@@ -5324,9 +5174,8 @@
 		},
 		"node_modules/csstype": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -5434,9 +5283,8 @@
 		},
 		"node_modules/didyoumean": {
 			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-			"dev": true
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/diff": {
 			"version": "4.0.2",
@@ -5467,9 +5315,8 @@
 		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
@@ -5484,14 +5331,12 @@
 		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -6063,6 +5908,11 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/eventemitter3": {
+			"version": "5.0.1",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/events": {
 			"version": "1.1.1",
 			"license": "MIT",
@@ -6356,9 +6206,8 @@
 		},
 		"node_modules/foreground-child": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-			"integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"cross-spawn": "^7.0.0",
 				"signal-exit": "^4.0.1"
@@ -6372,9 +6221,8 @@
 		},
 		"node_modules/foreground-child/node_modules/signal-exit": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=14"
 			},
@@ -6391,9 +6239,8 @@
 		},
 		"node_modules/fraction.js": {
 			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-			"integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			},
@@ -6485,6 +6332,17 @@
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.2.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-intrinsic": {
@@ -6753,8 +6611,7 @@
 		},
 		"node_modules/history": {
 			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-			"integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.7.6"
 			}
@@ -6791,6 +6648,20 @@
 				"node": ">=10.17.0"
 			}
 		},
+		"node_modules/husky": {
+			"version": "8.0.3",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"husky": "lib/bin.js"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/typicode"
+			}
+		},
 		"node_modules/hyperlinker": {
 			"version": "1.0.0",
 			"dev": true,
@@ -6823,9 +6694,8 @@
 		},
 		"node_modules/ignore-by-default": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-			"integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -7296,9 +7166,8 @@
 		},
 		"node_modules/jackspeak": {
 			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-			"integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
 			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
 			},
@@ -7876,9 +7745,8 @@
 		},
 		"node_modules/jiti": {
 			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
-			"integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
@@ -7960,8 +7828,7 @@
 		},
 		"node_modules/jsonwebtoken": {
 			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-			"integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+			"license": "MIT",
 			"dependencies": {
 				"jws": "^3.2.2",
 				"lodash.includes": "^4.3.0",
@@ -7981,8 +7848,7 @@
 		},
 		"node_modules/jwa": {
 			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+			"license": "MIT",
 			"dependencies": {
 				"buffer-equal-constant-time": "1.0.1",
 				"ecdsa-sig-formatter": "1.0.11",
@@ -7991,8 +7857,7 @@
 		},
 		"node_modules/jws": {
 			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+			"license": "MIT",
 			"dependencies": {
 				"jwa": "^1.4.1",
 				"safe-buffer": "^5.0.1"
@@ -8000,8 +7865,7 @@
 		},
 		"node_modules/jwt-decode": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-			"integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
@@ -8043,18 +7907,275 @@
 			}
 		},
 		"node_modules/lilconfig": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-			"integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+			"version": "3.0.0",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			}
 		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/lint-staged": {
+			"version": "15.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "5.3.0",
+				"commander": "11.1.0",
+				"debug": "4.3.4",
+				"execa": "8.0.1",
+				"lilconfig": "3.0.0",
+				"listr2": "8.0.0",
+				"micromatch": "4.0.5",
+				"pidtree": "0.6.0",
+				"string-argv": "0.3.2",
+				"yaml": "2.3.4"
+			},
+			"bin": {
+				"lint-staged": "bin/lint-staged.js"
+			},
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/lint-staged"
+			}
+		},
+		"node_modules/lint-staged/node_modules/chalk": {
+			"version": "5.3.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/lint-staged/node_modules/commander": {
+			"version": "11.1.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/lint-staged/node_modules/execa": {
+			"version": "8.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/lint-staged/node_modules/get-stream": {
+			"version": "8.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lint-staged/node_modules/human-signals": {
+			"version": "5.0.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=16.17.0"
+			}
+		},
+		"node_modules/lint-staged/node_modules/is-stream": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lint-staged/node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lint-staged/node_modules/npm-run-path": {
+			"version": "5.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lint-staged/node_modules/onetime": {
+			"version": "6.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lint-staged/node_modules/path-key": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lint-staged/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/lint-staged/node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/listr2": {
+			"version": "8.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cli-truncate": "^4.0.0",
+				"colorette": "^2.0.20",
+				"eventemitter3": "^5.0.1",
+				"log-update": "^6.0.0",
+				"rfdc": "^1.3.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/listr2/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/listr2/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/listr2/node_modules/emoji-regex": {
+			"version": "10.3.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/listr2/node_modules/string-width": {
+			"version": "7.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/listr2/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/listr2/node_modules/wrap-ansi": {
+			"version": "9.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
@@ -8077,33 +8198,27 @@
 		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+			"license": "MIT"
 		},
 		"node_modules/lodash.isboolean": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+			"license": "MIT"
 		},
 		"node_modules/lodash.isinteger": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+			"license": "MIT"
 		},
 		"node_modules/lodash.isnumber": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+			"license": "MIT"
 		},
 		"node_modules/lodash.isplainobject": {
 			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+			"license": "MIT"
 		},
 		"node_modules/lodash.isstring": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+			"license": "MIT"
 		},
 		"node_modules/lodash.kebabcase": {
 			"version": "4.1.1",
@@ -8122,18 +8237,161 @@
 		},
 		"node_modules/lodash.once": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+			"license": "MIT"
 		},
 		"node_modules/lodash.upperfirst": {
 			"version": "4.3.1",
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/log-update": {
+			"version": "6.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-escapes": "^6.2.0",
+				"cli-cursor": "^4.0.0",
+				"slice-ansi": "^7.0.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/ansi-escapes": {
+			"version": "6.2.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/log-update/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/log-update/node_modules/emoji-regex": {
+			"version": "10.3.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/log-update/node_modules/is-fullwidth-code-point": {
+			"version": "5.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/slice-ansi": {
+			"version": "7.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"is-fullwidth-code-point": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/log-update/node_modules/string-width": {
+			"version": "7.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/log-update/node_modules/type-fest": {
+			"version": "3.13.1",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/wrap-ansi": {
+			"version": "9.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"license": "MIT",
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			},
@@ -8280,9 +8538,8 @@
 		},
 		"node_modules/minipass": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-			"integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
@@ -8293,9 +8550,8 @@
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.0.0",
 				"object-assign": "^4.0.1",
@@ -8304,14 +8560,13 @@
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.7",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -8341,8 +8596,7 @@
 		},
 		"node_modules/next": {
 			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/next/-/next-14.1.0.tgz",
-			"integrity": "sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==",
+			"license": "MIT",
 			"dependencies": {
 				"@next/env": "14.1.0",
 				"@swc/helpers": "0.5.2",
@@ -8386,8 +8640,6 @@
 		},
 		"node_modules/next/node_modules/postcss": {
 			"version": "8.4.31",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -8402,6 +8654,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"nanoid": "^3.3.6",
 				"picocolors": "^1.0.0",
@@ -8423,9 +8676,8 @@
 		},
 		"node_modules/nodemon": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.3.tgz",
-			"integrity": "sha512-7jH/NXbFPxVaMwmBCC2B9F/V6X1VkEdNgx3iu9jji8WxWcvhMWkmhNWhI5077zknOnZnBzba9hZP6bCPJLSReQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^3.5.2",
 				"debug": "^4",
@@ -8451,9 +8703,8 @@
 		},
 		"node_modules/nodemon/node_modules/brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -8461,18 +8712,16 @@
 		},
 		"node_modules/nodemon/node_modules/has-flag": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/nodemon/node_modules/minimatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -8482,9 +8731,8 @@
 		},
 		"node_modules/nodemon/node_modules/supports-color": {
 			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -8494,17 +8742,13 @@
 		},
 		"node_modules/nopt": {
 			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-			"integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"abbrev": "1"
 			},
 			"bin": {
 				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/normalize-package-data": {
@@ -8536,9 +8780,8 @@
 		},
 		"node_modules/normalize-range": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8556,23 +8799,20 @@
 		},
 		"node_modules/oauth": {
 			"version": "0.9.15",
-			"resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-			"integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+			"license": "MIT"
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/object-hash": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
 			}
@@ -8797,8 +9037,7 @@
 		},
 		"node_modules/passport": {
 			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
-			"integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+			"license": "MIT",
 			"dependencies": {
 				"passport-strategy": "1.x.x",
 				"pause": "0.0.1",
@@ -8814,16 +9053,14 @@
 		},
 		"node_modules/passport-google-oauth2": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/passport-google-oauth2/-/passport-google-oauth2-0.2.0.tgz",
-			"integrity": "sha512-62EdPtbfVdc55nIXi0p1WOa/fFMM8v/M8uQGnbcXA4OexZWCnfsEi3wo2buag+Is5oqpuHzOtI64JpHk0Xi5RQ==",
+			"license": "MIT",
 			"dependencies": {
 				"passport-oauth2": "^1.1.2"
 			}
 		},
 		"node_modules/passport-jwt": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.1.tgz",
-			"integrity": "sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==",
+			"license": "MIT",
 			"dependencies": {
 				"jsonwebtoken": "^9.0.0",
 				"passport-strategy": "^1.0.0"
@@ -8831,8 +9068,7 @@
 		},
 		"node_modules/passport-oauth2": {
 			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.7.0.tgz",
-			"integrity": "sha512-j2gf34szdTF2Onw3+76alNnaAExlUmHvkc7cL+cmaS5NzHzDP/BvFHJruueQ9XAeNOdpI+CH+PWid8RA7KCwAQ==",
+			"license": "MIT",
 			"dependencies": {
 				"base64url": "3.x.x",
 				"oauth": "0.9.x",
@@ -8850,8 +9086,6 @@
 		},
 		"node_modules/passport-strategy": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
-			"integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
 			"engines": {
 				"node": ">= 0.4.0"
 			}
@@ -8896,9 +9130,8 @@
 		},
 		"node_modules/path-scurry": {
 			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
-			"integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
 			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"lru-cache": "^9.1.1 || ^10.0.0",
 				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -8912,9 +9145,8 @@
 		},
 		"node_modules/path-scurry/node_modules/lru-cache": {
 			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-			"integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": "14 || >=16.14"
 			}
@@ -8932,9 +9164,7 @@
 			}
 		},
 		"node_modules/pause": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-			"integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
+			"version": "0.0.1"
 		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
@@ -8951,11 +9181,21 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/pidtree": {
+			"version": "0.6.0",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"pidtree": "bin/pidtree.js"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/pify": {
 			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9029,8 +9269,6 @@
 		},
 		"node_modules/postcss": {
 			"version": "8.4.33",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
-			"integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
 			"dev": true,
 			"funding": [
 				{
@@ -9046,6 +9284,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
@@ -9057,9 +9296,8 @@
 		},
 		"node_modules/postcss-import": {
 			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-			"integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.0.0",
 				"read-cache": "^1.0.0",
@@ -9074,9 +9312,8 @@
 		},
 		"node_modules/postcss-js": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
-			"integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"camelcase-css": "^2.0.1"
 			},
@@ -9093,8 +9330,6 @@
 		},
 		"node_modules/postcss-load-config": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
-			"integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -9106,6 +9341,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"lilconfig": "^3.0.0",
 				"yaml": "^2.3.4"
@@ -9126,20 +9362,10 @@
 				}
 			}
 		},
-		"node_modules/postcss-load-config/node_modules/lilconfig": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
-			"integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
-			"dev": true,
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/postcss-nested": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
-			"integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "^6.0.11"
 			},
@@ -9156,9 +9382,8 @@
 		},
 		"node_modules/postcss-selector-parser": {
 			"version": "6.0.15",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
-			"integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -9169,9 +9394,8 @@
 		},
 		"node_modules/postcss-value-parser": {
 			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -9249,9 +9473,8 @@
 		},
 		"node_modules/pstree.remy": {
 			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-			"integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
@@ -9336,8 +9559,7 @@
 		},
 		"node_modules/react": {
 			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -9347,8 +9569,7 @@
 		},
 		"node_modules/react-dom": {
 			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.0"
@@ -9364,9 +9585,8 @@
 		},
 		"node_modules/read-cache": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"pify": "^2.3.0"
 			}
@@ -9486,8 +9706,7 @@
 		},
 		"node_modules/regenerator-runtime": {
 			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+			"license": "MIT"
 		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.1",
@@ -9572,6 +9791,21 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/restore-cursor": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"dev": true,
@@ -9580,6 +9814,11 @@
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/rfdc": {
+			"version": "1.3.1",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
@@ -9683,8 +9922,7 @@
 		},
 		"node_modules/scheduler": {
 			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-			"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			}
@@ -9821,9 +10059,8 @@
 		},
 		"node_modules/simple-update-notifier": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
-			"integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.5.3"
 			},
@@ -9870,8 +10107,7 @@
 		},
 		"node_modules/source-map-js": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9945,10 +10181,16 @@
 		},
 		"node_modules/streamsearch": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/string-argv": {
+			"version": "0.3.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6.19"
 			}
 		},
 		"node_modules/string-length": {
@@ -9979,9 +10221,8 @@
 		"node_modules/string-width-cjs": {
 			"name": "string-width",
 			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -10047,9 +10288,8 @@
 		"node_modules/strip-ansi-cjs": {
 			"name": "strip-ansi",
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -10090,8 +10330,7 @@
 		},
 		"node_modules/styled-jsx": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
-			"integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+			"license": "MIT",
 			"dependencies": {
 				"client-only": "0.0.1"
 			},
@@ -10112,9 +10351,8 @@
 		},
 		"node_modules/sucrase": {
 			"version": "3.35.0",
-			"resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-			"integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"commander": "^4.0.0",
@@ -10134,18 +10372,16 @@
 		},
 		"node_modules/sucrase/node_modules/commander": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
 			}
 		},
 		"node_modules/sucrase/node_modules/glob": {
 			"version": "10.3.10",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-			"integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"foreground-child": "^3.1.0",
 				"jackspeak": "^2.3.5",
@@ -10199,9 +10435,8 @@
 		},
 		"node_modules/tailwindcss": {
 			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
-			"integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
 				"arg": "^5.0.2",
@@ -10236,9 +10471,16 @@
 		},
 		"node_modules/tailwindcss/node_modules/arg": {
 			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-			"integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tailwindcss/node_modules/lilconfig": {
+			"version": "2.1.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/tapable": {
 			"version": "2.2.1",
@@ -10288,18 +10530,16 @@
 		},
 		"node_modules/thenify": {
 			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.0.0"
 			}
 		},
 		"node_modules/thenify-all": {
 			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"thenify": ">= 3.1.0 < 4"
 			},
@@ -10340,9 +10580,8 @@
 		},
 		"node_modules/touch": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-			"integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"nopt": "~1.0.10"
 			},
@@ -10363,9 +10602,8 @@
 		},
 		"node_modules/ts-interface-checker": {
 			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-			"dev": true
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/ts-jest": {
 			"version": "29.1.1",
@@ -10601,8 +10839,7 @@
 		},
 		"node_modules/uid2": {
 			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
-			"integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
+			"license": "MIT"
 		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
@@ -10620,9 +10857,8 @@
 		},
 		"node_modules/undefsafe": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-			"integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/undici-types": {
 			"version": "5.26.5",
@@ -10706,9 +10942,8 @@
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/utils-merge": {
 			"version": "1.0.1",
@@ -10871,9 +11106,8 @@
 		"node_modules/wrap-ansi-cjs": {
 			"name": "wrap-ansi",
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -10935,9 +11169,8 @@
 		},
 		"node_modules/yaml": {
 			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-			"integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">= 14"
 			}
@@ -10988,7 +11221,8 @@
 		},
 		"node_modules/zod": {
 			"version": "3.22.4",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+			"integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"description": "",
 	"main": "index.js",
 	"scripts": {
-		"format": "prettier --write 'packages/**/*.ts'",
+		"prettier:check": "prettier . --check",
+		"prettier:fix": "prettier . --write",
 		"api::build": "npm run build --workspace api",
 		"api::package": "npm run package --workspace api",
 		"api::start": "AWS_REGION=eu-west-1 STAGE=DEV npm run start --workspace api",
@@ -19,7 +20,14 @@
 		"cdk::test": "npm run test --workspace cdk",
 		"cdk::test-update": "npm run test-update --workspace cdk",
 		"package": "mkdir -p build/client; mkdir -p target; mv packages/api/dist/index.js build; mv packages/client/out/* build/client; cd build; zip -qr ../target/api.zip *",
-		"emulate-prod-locally": "npm run build --workspace client; EMULATE_PRODUCTION_SERVER=true npm run start --workspace api"
+		"emulate-prod-locally": "npm run build --workspace client; EMULATE_PRODUCTION_SERVER=true npm run start --workspace api",
+		"prepare": "husky install"
+	},
+	"lint-staged": {
+		"*": "prettier --ignore-unknown --write",
+		"*.ts": [
+			"eslint --fix"
+		]
 	},
 	"keywords": [],
 	"author": "",
@@ -34,6 +42,8 @@
 		"@typescript-eslint/parser": "^6.19.0",
 		"esbuild": "^0.19.11",
 		"eslint": "^8.56.0",
+		"husky": "^8.0.0",
+		"lint-staged": "^15.2.0",
 		"prettier": "^3.2.4",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.3.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,109 @@
+{
+	"compilerOptions": {
+		/* Visit https://aka.ms/tsconfig to read more about this file */
+
+		/* Projects */
+		// "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+		// "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+		// "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+		// "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+		// "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+		// "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+		/* Language and Environment */
+		"target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		// "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+		// "jsx": "preserve",                                /* Specify what JSX code is generated. */
+		// "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+		// "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+		// "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+		// "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+		// "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+		// "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+		// "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+		/* Modules */
+		"module": "commonjs" /* Specify what module code is generated. */,
+		// "rootDir": "./",                                  /* Specify the root folder within your source files. */
+		// "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+		// "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+		// "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+		// "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+		// "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+		// "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+		// "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+		// "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+		// "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+		// "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+		// "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+		// "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+		// "resolveJsonModule": true,                        /* Enable importing .json files. */
+		// "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+		// "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+		/* JavaScript Support */
+		// "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+		// "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+		// "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+		/* Emit */
+		// "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+		// "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+		// "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+		// "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+		// "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+		// "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+		// "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+		// "removeComments": true,                           /* Disable emitting comments. */
+		// "noEmit": true,                                   /* Disable emitting files from a compilation. */
+		// "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+		// "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+		// "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+		// "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+		// "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+		// "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+		// "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+		// "newLine": "crlf",                                /* Set the newline character for emitting files. */
+		// "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+		// "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+		// "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+		// "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+		// "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+		// "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+		/* Interop Constraints */
+		// "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+		// "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+		// "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+		// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+		/* Type Checking */
+		"strict": true /* Enable all strict type-checking options. */,
+		// "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+		// "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+		// "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+		// "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+		// "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+		// "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+		// "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+		// "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+		// "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+		// "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+		// "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+		// "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+		// "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+		// "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+		// "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+		// "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+		// "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+		// "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+		/* Completeness */
+		// "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+		"skipLibCheck": true /* Skip type checking all .d.ts files. */,
+	},
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"extends": "@guardian/tsconfig/tsconfig.json",
 	"compilerOptions": {
 		/* Visit https://aka.ms/tsconfig to read more about this file */
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Adds a [pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to format staged files with prettier and lint them with eslint
  - installs [`husky`](https://typicode.github.io/husky/#/), a tool to configure git hooks
  - installs [`lint-staged`](https://github.com/okonet/lint-staged), [recommended by prettier](https://prettier.io/docs/en/precommit.html) for projects that also want to run eslint in a hook and support partially staged files.

## Why?
This should help us avoid noisy git history due to formatting and linting changes unrelated to the main motivation of a commit. 
Automatic formatting should allow contributors and reviewers to ignore formatting and focus on more substantial code changes.

## How to test
- try to commit changes that break eslint rules. Fixable changes like incorrect import order should be fixed automatically when they're committed. Unfixable ones like @typescript-eslint/no-explicit-any will stop the commit.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

