### PR TITLE
Tell riffraff which encrypted AMI to use

### DIFF
--- a/packages/cdk/riff-raff.yaml
+++ b/packages/cdk/riff-raff.yaml
@@ -32,7 +32,7 @@ deployments:
         Recipe: investigations-transcription-service
         AmigoStage: PROD
       amiParameter: AMITranscriptionserviceworker
-      amiEncrypted: true
+      amiEncrypted: investigations
     dependencies:
       - lambda-upload-eu-west-1-investigations-transcription-service
   lambda-update-eu-west-1-investigations-transcription-service:


### PR DESCRIPTION

## What does this change?
AMIgo bakes 3 encrypted AMIs for our account so we need to tell riffraff which one to use 