### PR TITLE
Correctly indicate which encrypted AMI to use

### DIFF
--- a/packages/cdk/riff-raff.yaml
+++ b/packages/cdk/riff-raff.yaml
@@ -31,8 +31,9 @@ deployments:
       amiTags:
         Recipe: investigations-transcription-service
         AmigoStage: PROD
+        Encrypted: investigations
       amiParameter: AMITranscriptionserviceworker
-      amiEncrypted: investigations
+      amiEncrypted: true
     dependencies:
       - lambda-upload-eu-west-1-investigations-transcription-service
   lambda-update-eu-west-1-investigations-transcription-service:


### PR DESCRIPTION
## What does this change?
RiffRaff has the capability to automatically update the AMI a stack uses based on an AMI in AMIgo. This is documented [here](https://riffraff.gutools.co.uk/docs/magenta-lib/types#amicloudformationparameter).

In https://github.com/guardian/transcription-service/pull/9 I attempted to add this functionality, but did so incorrectly. In https://github.com/guardian/transcription-service/pull/14 I attempted to fix it. 

This PR should be the last one in the saga. It takes inspiration from [the way we do this in giant](https://github.com/guardian/giant/blob/c34c91c2f7f2690cf16c1a81211887cc34a852e0/riff-raff.yaml#L17)