### PR TITLE
fix emulate prod locally and check auth for api endpoints

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -4,7 +4,7 @@ import serverlessExpress from '@codegenie/serverless-express';
 import bodyParser from 'body-parser';
 import path from 'path';
 import { getConfig } from './config';
-import { initPassportAuth } from './services/passport';
+import { checkAuth, initPassportAuth } from './services/passport';
 import { GoogleAuth } from './controllers/GoogleAuth';
 import passport from 'passport';
 import { Request, Response } from 'express';
@@ -29,11 +29,13 @@ const getApp = async () => {
 	apiRouter.get('/auth/google', ...auth.googleAuth());
 	apiRouter.get('/auth/oauth-callback', ...auth.oauthCallback());
 
+	// checkAuth is the pattern of checking auth 
+	// for every api endpoint that's added
 	apiRouter.get(
 		'/healthcheck',
-		asyncHandler(async (req, res) => {
+		[checkAuth, asyncHandler(async (req, res) => {
 			res.send('It lives!');
-		}),
+		})],
 	);
 
 	app.use('/api', apiRouter);
@@ -47,7 +49,7 @@ const getApp = async () => {
 		if (emulateProductionLocally) {
 			app.use(
 				express.static(
-					path.resolve(__dirname, '..', '..', '..', 'packages/client/dist/client'),
+					path.resolve(__dirname, '..', '..', '..', 'packages/client/out'),
 				),
 			);
 			app.get('/*', (req: Request, res: Response) => {
@@ -57,7 +59,7 @@ const getApp = async () => {
 						'..',
 						'..',
 						'..',
-						'packages/client/dist/client',
+						'packages/client/out',
 						'index.html',
 					),
 				);

--- a/packages/api/src/services/passport.ts
+++ b/packages/api/src/services/passport.ts
@@ -12,6 +12,8 @@ const validateEmail = (email: string) => {
 	);
 };
 
+export const checkAuth = passport.authenticate("jwt", { session: false });
+
 export const initPassportAuth = (config: TranscriptionConfig) => {
 	passport.use(
 		new GoogleStrategy(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
A fix that was missed in previous PR https://github.com/guardian/transcription-service/pull/7
- checkAuth is added and pattern on using it is to add it to every api endpoint
- the emulate prod locally was looking at the wrong location for static client files