### PR TITLE
Add initial s3 infrastructure, zod types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,21 @@
 			"version": "1.14.1",
 			"license": "0BSD"
 		},
+		"node_modules/@aws-crypto/crc32c": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+			"integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+			"dependencies": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
 		"node_modules/@aws-crypto/ie11-detection": {
 			"version": "3.0.0",
 			"license": "Apache-2.0",
@@ -94,6 +109,25 @@
 		"node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
 			"version": "1.14.1",
 			"license": "0BSD"
+		},
+		"node_modules/@aws-crypto/sha1-browser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+			"integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
+			"dependencies": {
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
 			"version": "3.0.0",
@@ -149,6 +183,493 @@
 		"node_modules/@aws-crypto/util/node_modules/tslib": {
 			"version": "1.14.1",
 			"license": "0BSD"
+		},
+		"node_modules/@aws-sdk/client-s3": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.504.0.tgz",
+			"integrity": "sha512-J8xPsnk7EDwalFSaDxPFNT2+x99nG2uQTpsLXAV3bWbT1nD/JZ+fase9GqxM11v6WngzqRvTQg26ljMn5hQSKA==",
+			"dependencies": {
+				"@aws-crypto/sha1-browser": "3.0.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.504.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/credential-provider-node": "3.504.0",
+				"@aws-sdk/middleware-bucket-endpoint": "3.502.0",
+				"@aws-sdk/middleware-expect-continue": "3.502.0",
+				"@aws-sdk/middleware-flexible-checksums": "3.502.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-location-constraint": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-sdk-s3": "3.502.0",
+				"@aws-sdk/middleware-signing": "3.502.0",
+				"@aws-sdk/middleware-ssec": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/signature-v4-multi-region": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@aws-sdk/xml-builder": "3.496.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/eventstream-serde-browser": "^2.1.1",
+				"@smithy/eventstream-serde-config-resolver": "^2.1.1",
+				"@smithy/eventstream-serde-node": "^2.1.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-blob-browser": "^2.1.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/hash-stream-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/md5-js": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-stream": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"@smithy/util-waiter": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.502.0.tgz",
+			"integrity": "sha512-OZAYal1+PQgUUtWiHhRayDtX0OD+XpXHKAhjYgEIPbyhQaCMp3/Bq1xDX151piWXvXqXLJHFKb8DUEqzwGO9QA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.504.0.tgz",
+			"integrity": "sha512-ODA33/nm2srhV08EW0KZAP577UgV0qjyr7Xp2yEo8MXWL4ZqQZprk1c+QKBhjr4Djesrm0VPmSD/np0mtYP68A==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.504.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-signing": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.504.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.504.0.tgz",
+			"integrity": "sha512-IESs8FkL7B/uY+ml4wgoRkrr6xYo4PizcNw6JX17eveq1gRBCPKeGMjE6HTDOcIYZZ8rqz/UeuH3JD4UhrMOnA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.504.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.502.0.tgz",
+			"integrity": "sha512-KIB8Ae1Z7domMU/jU4KiIgK4tmYgvuXlhR54ehwlVHxnEoFPoPuGHFZU7oFn79jhhSLUFQ1lRYMxP0cEwb7XeQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.504.0.tgz",
+			"integrity": "sha512-ODICLXfr8xTUd3wweprH32Ge41yuBa+u3j0JUcLdTUO1N9ldczSMdo8zOPlP0z4doqD3xbnqMkjNQWgN/Q+5oQ==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.504.0",
+				"@aws-sdk/credential-provider-env": "3.502.0",
+				"@aws-sdk/credential-provider-process": "3.502.0",
+				"@aws-sdk/credential-provider-sso": "3.504.0",
+				"@aws-sdk/credential-provider-web-identity": "3.504.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.504.0.tgz",
+			"integrity": "sha512-6+V5hIh+tILmUjf2ZQWQINR3atxQVgH/bFrGdSR/sHSp/tEgw3m0xWL3IRslWU1e4/GtXrfg1iYnMknXy68Ikw==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.502.0",
+				"@aws-sdk/credential-provider-http": "3.503.1",
+				"@aws-sdk/credential-provider-ini": "3.504.0",
+				"@aws-sdk/credential-provider-process": "3.502.0",
+				"@aws-sdk/credential-provider-sso": "3.504.0",
+				"@aws-sdk/credential-provider-web-identity": "3.504.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.502.0.tgz",
+			"integrity": "sha512-fJJowOjQ4infYQX0E1J3xFVlmuwEYJAFk0Mo1qwafWmEthsBJs+6BR2RiWDELHKrSK35u4Pf3fu3RkYuCtmQFw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.504.0.tgz",
+			"integrity": "sha512-4MgH2or2SjPzaxM08DCW+BjaX4DSsEGJlicHKmz6fh+w9JmLh750oXcTnbvgUeVz075jcs6qTKjvUcsdGM/t8Q==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.502.0",
+				"@aws-sdk/token-providers": "3.504.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.504.0.tgz",
+			"integrity": "sha512-L1ljCvGpIEFdJk087ijf2ohg7HBclOeB1UgBxUBBzf4iPRZTQzd2chGaKj0hm2VVaXz7nglswJeURH5PFcS5oA==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.504.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.502.0.tgz",
+			"integrity": "sha512-EjnG0GTYXT/wJBmm5/mTjDcAkzU8L7wQjOzd3FTXuTCNNyvAvwrszbOj5FlarEw5XJBbQiZtBs+I5u9+zy560w==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.502.0.tgz",
+			"integrity": "sha512-FDyv6K4nCoHxbjLGS2H8ex8I0KDIiu4FJgVRPs140ZJy6gE5Pwxzv6YTzZGLMrnqcIs9gh065Lf6DjwMelZqaw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.502.0.tgz",
+			"integrity": "sha512-hvbyGJbxeuezxOu8VfFmcV4ql1hKXLxHTe5FNYfEBat2KaZXVhc1Hg+4TvB06/53p+E8J99Afmumkqbxs2esUA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-signing": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.502.0.tgz",
+			"integrity": "sha512-4hF08vSzJ7L6sB+393gOFj3s2N6nLusYS0XrMW6wYNFU10IDdbf8Z3TZ7gysDJJHEGQPmTAesPEDBsasGWcMxg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/signature-v4": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.502.0.tgz",
+			"integrity": "sha512-TxbBZbRiXPH0AUxegqiNd9aM9zNSbfjtBs5MEfcBsweeT/B2O7K1EjP9+CkB8Xmk/5FLKhAKLr19b1TNoE27rw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.502.0.tgz",
+			"integrity": "sha512-mxmsX2AGgnSM+Sah7mcQCIneOsJQNiLX0COwEttuf8eO+6cLMAZvVudH3BnWTfea4/A9nuri9DLCqBvEmPrilg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.504.0.tgz",
+			"integrity": "sha512-YIJWWsZi2ClUiILS1uh5L6VjmCUSTI6KKMuL9DkGjYqJ0aI6M8bd8fT9Wm7QmXCyjcArTgr/Atkhia4T7oKvzQ==",
+			"dependencies": {
+				"@aws-sdk/client-sso-oidc": "3.504.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.502.0.tgz",
+			"integrity": "sha512-6LKFlJPp2J24r1Kpfoz5ESQn+1v5fEjDB3mtUKRdpwarhm3syu7HbKlHCF3KbcCOyahobvLvhoedT78rJFEeeg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.502.0.tgz",
+			"integrity": "sha512-v8gKyCs2obXoIkLETAeEQ3AM+QmhHhst9xbM1cJtKUGsRlVIak/XyyD+kVE6kmMm1cjfudHpHKABWk9apQcIZQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/types": "^2.9.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.502.0.tgz",
+			"integrity": "sha512-9RjxpkGZKbTdl96tIJvAo+vZoz4P/cQh36SBUt9xfRfW0BtsaLyvSrvlR5wyUYhvRcC12Axqh/8JtnAPq//+Vw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@aws-sdk/client-sqs": {
 			"version": "3.504.0",
@@ -915,12 +1436,122 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/middleware-bucket-endpoint": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.502.0.tgz",
+			"integrity": "sha512-mUSP2DUcjhO5zM2b21CvZ9AqwI8DaAeZA6NYHOxWGTV9BUxHcdGWXEjDkcVj9CQ0gvNwTtw6B5L/q52rVAnZbw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-arn-parser": "3.495.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-expect-continue": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.502.0.tgz",
+			"integrity": "sha512-DxfAuBVuPSt8as9xP57o8ks6ySVSjwO2NNNAdpLwk4KhEAPYEpHlf2yWYorYLrS+dDmwfYgOhRNoguuBdCu6ow==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-flexible-checksums": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.502.0.tgz",
+			"integrity": "sha512-kCt2zQDFumz/LnJJJOSd2GW4dr8oT8YMJKgxC/pph3aRXoSHXRwhrMbFnQ8swEE9vjywxtcED8sym0b0tNhhoA==",
+			"dependencies": {
+				"@aws-crypto/crc32": "3.0.0",
+				"@aws-crypto/crc32c": "3.0.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/is-array-buffer": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/@aws-sdk/middleware-host-header": {
 			"version": "3.496.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.496.0",
 				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-location-constraint": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.502.0.tgz",
+			"integrity": "sha512-fLRwPuTZvEWQkPjys03m3D6tYN4kf7zU6+c8mJxwvEg+yfBuv2RBsbd+Vn2bTisUjXvIg1kyBzONlpHoIyFneg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+			"dependencies": {
 				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
@@ -946,6 +1577,37 @@
 			"dependencies": {
 				"@aws-sdk/types": "3.496.0",
 				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-s3": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.502.0.tgz",
+			"integrity": "sha512-GbGugrfyL5bNA/zw8iQll92yXBONfWSC8Ns00DtkOU1saPXp4/7WHtyyZGYdvPa73T1IsuZy9egpoYRBmRcd5Q==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-arn-parser": "3.495.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/signature-v4": "^2.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+			"dependencies": {
 				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
@@ -996,6 +1658,31 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/middleware-ssec": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.502.0.tgz",
+			"integrity": "sha512-1nidVTIba6/aVjjzD/WNqWdzSyTrXOHO3Ddz2MGD8S1yGSrYz4iYaq4Bm/uosfdr8B1L0Ws0pjdRXrNfzSw/DQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
 			"version": "3.496.0",
 			"license": "Apache-2.0",
@@ -1019,6 +1706,34 @@
 				"@smithy/types": "^2.9.1",
 				"@smithy/util-config-provider": "^2.2.1",
 				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.502.0.tgz",
+			"integrity": "sha512-NpOXtUXH0ZAgnyI3Y3s2fPrgwbsWoNMwdoXdFZvH0eDzzX80tim7Yuy6dzVA5zrxSzOYs1xjcOhM+4CmM0QZiw==",
+			"dependencies": {
+				"@aws-sdk/middleware-sdk-s3": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/signature-v4": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1076,6 +1791,17 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-arn-parser": {
+			"version": "3.495.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.495.0.tgz",
+			"integrity": "sha512-hwdA3XAippSEUxs7jpznwD63YYFR+LtQvlEcebPTgWR9oQgG9TfS+39PUfbnEeje1ICuOrN3lrFqFbmP9uzbMg==",
+			"dependencies": {
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1141,6 +1867,18 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.496.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.496.0.tgz",
+			"integrity": "sha512-GvEjh537IIeOw1ZkZuB37sV12u+ipS5Z1dwjEC/HAvhl5ac23ULtTr1/n+U1gLNN+BAKSWjKiQ2ksj8DiUzeyw==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -2680,6 +3418,23 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@smithy/chunked-blob-reader": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.1.1.tgz",
+			"integrity": "sha512-NjNFCKxC4jVvn+lUr3Yo4/PmUJj3tbyqH6GNHueyTGS5Q27vlEJ1MkNhUDV8QGxJI7Bodnc2pD18lU2zRfhHlQ==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/chunked-blob-reader-native": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.1.1.tgz",
+			"integrity": "sha512-zNW+43dltfNMUrBEYLMWgI8lQr0uhtTcUyxkgC9EP4j17WREzgSFMPUFVrVV6Rc2+QtWERYjb4tzZnQGa7R9fQ==",
+			"dependencies": {
+				"@smithy/util-base64": "^2.1.1",
+				"tslib": "^2.5.0"
+			}
+		},
 		"node_modules/@smithy/config-resolver": {
 			"version": "2.1.1",
 			"license": "Apache-2.0",
@@ -2735,6 +3490,57 @@
 				"tslib": "^2.5.0"
 			}
 		},
+		"node_modules/@smithy/eventstream-serde-browser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.1.1.tgz",
+			"integrity": "sha512-JvEdCmGlZUay5VtlT8/kdR6FlvqTDUiJecMjXsBb0+k1H/qc9ME5n2XKPo8q/MZwEIA1GmGgYMokKGjVvMiDow==",
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-config-resolver": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.1.1.tgz",
+			"integrity": "sha512-EqNqXYp3+dk//NmW3NAgQr9bEQ7fsu/CcxQmTiq07JlaIcne/CBWpMZETyXm9w5LXkhduBsdXdlMscfDUDn2fA==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.1.1.tgz",
+			"integrity": "sha512-LF882q/aFidFNDX7uROAGxq3H0B7rjyPkV6QDn6/KDQ+CG7AFkRccjxRf1xqajq/Pe4bMGGr+VKAaoF6lELIQw==",
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-universal": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.1.1.tgz",
+			"integrity": "sha512-LR0mMT+XIYTxk4k2fIxEA1BPtW3685QlqufUEUAX1AJcfFfxNDKEvuCRZbO8ntJb10DrIFVJR9vb0MhDCi0sAQ==",
+			"dependencies": {
+				"@smithy/eventstream-codec": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/@smithy/fetch-http-handler": {
 			"version": "2.4.1",
 			"license": "Apache-2.0",
@@ -2746,12 +3552,36 @@
 				"tslib": "^2.5.0"
 			}
 		},
+		"node_modules/@smithy/hash-blob-browser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.1.1.tgz",
+			"integrity": "sha512-jizu1+2PAUjiGIfRtlPEU8Yo6zn+d78ti/ZHDesdf1SUn2BuZW433JlPoCOLH3dBoEEvTgLvQ8tUGSoTTALA+A==",
+			"dependencies": {
+				"@smithy/chunked-blob-reader": "^2.1.1",
+				"@smithy/chunked-blob-reader-native": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			}
+		},
 		"node_modules/@smithy/hash-node": {
 			"version": "2.1.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^2.9.1",
 				"@smithy/util-buffer-from": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/hash-stream-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.1.1.tgz",
+			"integrity": "sha512-VgDaKcfCy0iHcmtAZgZ3Yw9g37Gkn2JsQiMtFQXUh8Wmo3GfNgDwLOtdhJ272pOT7DStzpe9cNr+eV5Au8KfQA==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
 				"@smithy/util-utf8": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
@@ -11518,6 +12348,7 @@
 			"name": "@guardian/transcription-service-common",
 			"version": "1.0.0",
 			"dependencies": {
+				"@aws-sdk/client-s3": "^3.496.0",
 				"@aws-sdk/client-sqs": "^3.496.0",
 				"@aws-sdk/client-ssm": "^3.496.0",
 				"zod": "3.22.4"

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -6,10 +6,12 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuAmiParameter",
       "GuCertificate",
+      "GuS3Bucket",
       "GuDistributionBucketParameter",
       "GuApiLambda",
       "GuCname",
       "GuPolicy",
+      "GuAllowPolicy",
       "GuInstanceRole",
       "GuDescribeEC2Policy",
       "GuLoggingStreamNameParameter",
@@ -125,6 +127,43 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "describe-ec2-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTranscriptionserviceworkerA8AC6615",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDeleteSourceMedia6AC3A8D5": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:DeleteObject",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDeleteSourceMedia6AC3A8D5",
         "Roles": [
           {
             "Ref": "InstanceRoleTranscriptionserviceworkerA8AC6615",
@@ -340,6 +379,50 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketName": "transcription-service-source-media-test",
+        "LifecycleConfiguration": {
+          "Rules": [
+            {
+              "ExpirationInDays": 7,
+              "Status": "Enabled",
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "transcription-service",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/transcription-service",
+          },
+          {
+            "Key": "Stack",
+            "Value": "investigations",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
     "TranscriptionWorkerASGCAE69A98": {
       "Properties": {
         "AutoScalingGroupName": "transcription-service-workers-TEST",
@@ -503,7 +586,8 @@ aws s3 cp s3://",
                     "Ref": "DistributionBucketName",
                   },
                   "/investigations/TEST/transcription-service-worker/transcription-service-worker_1.0.0_all.deb .
-dpkg -i transcription-service-worker_1.0.0_all.deb",
+dpkg -i transcription-service-worker_1.0.0_all.deb
+service transcription-service-worker start",
                 ],
               ],
             },

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -10,10 +10,10 @@ import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuVpc, SubnetType } from '@guardian/cdk/lib/constructs/ec2';
 import {
 	GuAllowPolicy,
-	GuGetS3ObjectsPolicy,
 	GuInstanceRole,
 	GuPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
+import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import { GuardianAwsAccounts } from '@guardian/private-infrastructure-config';
 import { type App, Duration } from 'aws-cdk-lib';
 import { EndpointType } from 'aws-cdk-lib/aws-apigateway';
@@ -34,7 +34,6 @@ import {
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
-import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 
 export class TranscriptionService extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -81,7 +81,7 @@ export class TranscriptionService extends GuStack {
 				'TranscriptionServiceUploadsBucket',
 				{
 					app: APP_NAME,
-					bucketName: `transcription-service-source-media-DEV`,
+					bucketName: `transcription-service-source-media-dev`,
 				},
 			);
 			sourceMediaBucketDev.addLifecycleRule({

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "@aws-sdk/client-ssm": "^3.496.0",
     "zod": "3.22.4",
-    "@aws-sdk/client-sqs": "^3.496.0"
+    "@aws-sdk/client-sqs": "^3.496.0",
+    "@aws-sdk/client-s3": "^3.496.0"
   },
   "devDependencies": {
   },

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -11,6 +11,10 @@ export interface TranscriptionConfig {
 		rootUrl: string;
 		taskQueueUrl: string;
 		stage: string;
+		sourceMediaBucket: string;
+		destinationTopicArns: {
+			transcriptionService: string;
+		};
 	};
 	aws: {
 		region: string;
@@ -90,6 +94,10 @@ export const getConfig = async (): Promise<TranscriptionConfig> => {
 			secret: appSecret,
 			taskQueueUrl,
 			stage,
+			sourceMediaBucket: 'my-bucket',
+			destinationTopicArns: {
+				transcriptionService: 'replaceme',
+			},
 		},
 		aws: {
 			region,

--- a/packages/common/src/s3.ts
+++ b/packages/common/src/s3.ts
@@ -1,0 +1,7 @@
+import { S3Client } from '@aws-sdk/client-s3';
+
+export const getClient = (region: string) => {
+	return new S3Client({
+		region,
+	});
+};

--- a/packages/common/src/sqs.ts
+++ b/packages/common/src/sqs.ts
@@ -5,7 +5,10 @@ import {
 	ReceiveMessageCommand,
 	DeleteMessageCommand,
 } from '@aws-sdk/client-sqs';
-import { TranscriptionJob } from '@guardian/transcription-service-common';
+import {
+	DestinationService,
+	TranscriptionJob,
+} from '@guardian/transcription-service-common';
 
 enum SQSStatus {
 	Success,
@@ -50,10 +53,13 @@ export const sendMessage = async (
 	queueUrl: string,
 ): Promise<SendResult> => {
 	const job: TranscriptionJob = {
-		id: 'my-first-transcription',
+		id: 'my-first-transcription', // uuid
 		s3Url: 's3://test/test',
 		retryCount: 0,
 		sentTimestamp: new Date().toISOString(),
+		userEmail: 'email',
+		transcriptDestinationService: DestinationService.TranscriptionService,
+		originalFilename: 'test.mp3',
 	};
 
 	try {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-enum DestinationService {
+export enum DestinationService {
 	TranscriptionService = 'TranscriptionService',
 }
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,10 +1,27 @@
 import { z } from 'zod';
 
+enum DestinationService {
+	TranscriptionService = 'TranscriptionService',
+}
+
 export const TranscriptionJob = z.object({
 	id: z.string(),
+	originalFilename: z.string(),
 	s3Url: z.string(),
 	retryCount: z.number(),
 	sentTimestamp: z.string(),
+	userEmail: z.string(),
+	transcriptDestinationService: z.nativeEnum(DestinationService),
 });
 
 export type TranscriptionJob = z.infer<typeof TranscriptionJob>;
+
+export const TranscriptionOutput = z.object({
+	id: z.string(),
+	transcriptionSrt: z.string(),
+	languageCode: z.string(),
+	englishTranslation: z.optional(z.string()),
+	userEmail: z.string(),
+});
+
+export type TranscriptionOutput = z.infer<typeof TranscriptionOutput>;


### PR DESCRIPTION
## What does this change?
Paired with @marjisound and @zekehuntergreen 

This PR:
 - Adds a new S3 bucket to hold source media for the transcription service
 - Adds permissions to the worker to fetch and delete from the bucket
 - Updates packages/common/src/types.ts to include all relevant fields we think will be needed to be passed between our different services

## How to test
This code doesn't actually do anything yet so I think is safe to merge if the build passes. I've deployed to CODE to check that the deploy works
