### PR TITLE
Add initial SNS CDK, localstack configuration and test message 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
-      - SERVICES=sqs,s3
+      - SERVICES=sqs,sns
       - PERSISTENCE=1
     volumes:
       - '${LOCALSTACK_VOLUME_DIR:-./localstack}:/var/lib/localstack'

--- a/package-lock.json
+++ b/package-lock.json
@@ -646,6 +646,476 @@
 				}
 			}
 		},
+		"node_modules/@aws-sdk/client-sns": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.504.0.tgz",
+			"integrity": "sha512-ePa/VX3IGNOw3a76GN5gaXnPNHG4kQrtvyYCbHTWftBA9WF6hYujRL7p+ZIW5w2Uk52UmynNaEPO4BzI7OUCtg==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.504.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/credential-provider-node": "3.504.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-signing": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.502.0.tgz",
+			"integrity": "sha512-OZAYal1+PQgUUtWiHhRayDtX0OD+XpXHKAhjYgEIPbyhQaCMp3/Bq1xDX151piWXvXqXLJHFKb8DUEqzwGO9QA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.504.0.tgz",
+			"integrity": "sha512-ODA33/nm2srhV08EW0KZAP577UgV0qjyr7Xp2yEo8MXWL4ZqQZprk1c+QKBhjr4Djesrm0VPmSD/np0mtYP68A==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.504.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-signing": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.504.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sts": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.504.0.tgz",
+			"integrity": "sha512-IESs8FkL7B/uY+ml4wgoRkrr6xYo4PizcNw6JX17eveq1gRBCPKeGMjE6HTDOcIYZZ8rqz/UeuH3JD4UhrMOnA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.504.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.502.0.tgz",
+			"integrity": "sha512-KIB8Ae1Z7domMU/jU4KiIgK4tmYgvuXlhR54ehwlVHxnEoFPoPuGHFZU7oFn79jhhSLUFQ1lRYMxP0cEwb7XeQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.504.0.tgz",
+			"integrity": "sha512-ODICLXfr8xTUd3wweprH32Ge41yuBa+u3j0JUcLdTUO1N9ldczSMdo8zOPlP0z4doqD3xbnqMkjNQWgN/Q+5oQ==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.504.0",
+				"@aws-sdk/credential-provider-env": "3.502.0",
+				"@aws-sdk/credential-provider-process": "3.502.0",
+				"@aws-sdk/credential-provider-sso": "3.504.0",
+				"@aws-sdk/credential-provider-web-identity": "3.504.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.504.0.tgz",
+			"integrity": "sha512-6+V5hIh+tILmUjf2ZQWQINR3atxQVgH/bFrGdSR/sHSp/tEgw3m0xWL3IRslWU1e4/GtXrfg1iYnMknXy68Ikw==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.502.0",
+				"@aws-sdk/credential-provider-http": "3.503.1",
+				"@aws-sdk/credential-provider-ini": "3.504.0",
+				"@aws-sdk/credential-provider-process": "3.502.0",
+				"@aws-sdk/credential-provider-sso": "3.504.0",
+				"@aws-sdk/credential-provider-web-identity": "3.504.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.502.0.tgz",
+			"integrity": "sha512-fJJowOjQ4infYQX0E1J3xFVlmuwEYJAFk0Mo1qwafWmEthsBJs+6BR2RiWDELHKrSK35u4Pf3fu3RkYuCtmQFw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.504.0.tgz",
+			"integrity": "sha512-4MgH2or2SjPzaxM08DCW+BjaX4DSsEGJlicHKmz6fh+w9JmLh750oXcTnbvgUeVz075jcs6qTKjvUcsdGM/t8Q==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.502.0",
+				"@aws-sdk/token-providers": "3.504.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.504.0.tgz",
+			"integrity": "sha512-L1ljCvGpIEFdJk087ijf2ohg7HBclOeB1UgBxUBBzf4iPRZTQzd2chGaKj0hm2VVaXz7nglswJeURH5PFcS5oA==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.504.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.502.0.tgz",
+			"integrity": "sha512-EjnG0GTYXT/wJBmm5/mTjDcAkzU8L7wQjOzd3FTXuTCNNyvAvwrszbOj5FlarEw5XJBbQiZtBs+I5u9+zy560w==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.502.0.tgz",
+			"integrity": "sha512-FDyv6K4nCoHxbjLGS2H8ex8I0KDIiu4FJgVRPs140ZJy6gE5Pwxzv6YTzZGLMrnqcIs9gh065Lf6DjwMelZqaw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.502.0.tgz",
+			"integrity": "sha512-hvbyGJbxeuezxOu8VfFmcV4ql1hKXLxHTe5FNYfEBat2KaZXVhc1Hg+4TvB06/53p+E8J99Afmumkqbxs2esUA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-signing": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.502.0.tgz",
+			"integrity": "sha512-4hF08vSzJ7L6sB+393gOFj3s2N6nLusYS0XrMW6wYNFU10IDdbf8Z3TZ7gysDJJHEGQPmTAesPEDBsasGWcMxg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/signature-v4": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.502.0.tgz",
+			"integrity": "sha512-TxbBZbRiXPH0AUxegqiNd9aM9zNSbfjtBs5MEfcBsweeT/B2O7K1EjP9+CkB8Xmk/5FLKhAKLr19b1TNoE27rw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.502.0.tgz",
+			"integrity": "sha512-mxmsX2AGgnSM+Sah7mcQCIneOsJQNiLX0COwEttuf8eO+6cLMAZvVudH3BnWTfea4/A9nuri9DLCqBvEmPrilg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/token-providers": {
+			"version": "3.504.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.504.0.tgz",
+			"integrity": "sha512-YIJWWsZi2ClUiILS1uh5L6VjmCUSTI6KKMuL9DkGjYqJ0aI6M8bd8fT9Wm7QmXCyjcArTgr/Atkhia4T7oKvzQ==",
+			"dependencies": {
+				"@aws-sdk/client-sso-oidc": "3.504.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/types": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.502.0.tgz",
+			"integrity": "sha512-6LKFlJPp2J24r1Kpfoz5ESQn+1v5fEjDB3mtUKRdpwarhm3syu7HbKlHCF3KbcCOyahobvLvhoedT78rJFEeeg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.502.0.tgz",
+			"integrity": "sha512-v8gKyCs2obXoIkLETAeEQ3AM+QmhHhst9xbM1cJtKUGsRlVIak/XyyD+kVE6kmMm1cjfudHpHKABWk9apQcIZQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/types": "^2.9.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.502.0.tgz",
+			"integrity": "sha512-9RjxpkGZKbTdl96tIJvAo+vZoz4P/cQh36SBUt9xfRfW0BtsaLyvSrvlR5wyUYhvRcC12Axqh/8JtnAPq//+Vw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@aws-sdk/client-sqs": {
 			"version": "3.504.0",
 			"license": "Apache-2.0",
@@ -12283,6 +12753,7 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"@aws-sdk/client-sns": "^3.496.0",
 				"@guardian/transcription-service-common": "1.0.0"
 			},
 			"devDependencies": {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -46,7 +46,7 @@ const getApp = async () => {
 	]);
 
 	apiRouter.post('/send-message', [
-		// checkAuth,
+		checkAuth,
 		asyncHandler(async (req, res) => {
 			const sendResult = await sendMessage(sqsClient, config.app.taskQueueUrl);
 			if (isFailure(sendResult)) {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -46,7 +46,7 @@ const getApp = async () => {
 	]);
 
 	apiRouter.post('/send-message', [
-		checkAuth,
+		// checkAuth,
 		asyncHandler(async (req, res) => {
 			const sendResult = await sendMessage(sqsClient, config.app.taskQueueUrl);
 			if (isFailure(sendResult)) {

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -67,6 +67,11 @@ export const getConfig = async (): Promise<TranscriptionConfig> => {
 
 	console.log(`Parameters fetched: ${parameterNames.join(', ')}`);
 	const taskQueueUrl = findParameter(parameters, paramPath, 'taskQueueUrl');
+	const destinationTopic = findParameter(
+		parameters,
+		paramPath,
+		'destinationTopicArns/transcriptionService',
+	);
 	// AWS clients take an optional 'endpoint' property that is only needed by localstack - on code/prod you don't need
 	// to set it. Here we inder the endpoint (http://localhost:4566) from the sqs url
 	const localstackEndpoint =
@@ -96,7 +101,7 @@ export const getConfig = async (): Promise<TranscriptionConfig> => {
 			stage,
 			sourceMediaBucket: 'my-bucket',
 			destinationTopicArns: {
-				transcriptionService: 'replaceme',
+				transcriptionService: destinationTopic,
 			},
 		},
 		aws: {

--- a/packages/common/src/sqs.ts
+++ b/packages/common/src/sqs.ts
@@ -38,6 +38,7 @@ export const getClient = (region: string, localstackEndpoint?: string) => {
 	const clientBaseConfig = {
 		region,
 	};
+	console.log(localstackEndpoint);
 	const clientConfig = localstackEndpoint
 		? { ...clientBaseConfig, endpoint: localstackEndpoint }
 		: clientBaseConfig;
@@ -53,7 +54,7 @@ export const sendMessage = async (
 	queueUrl: string,
 ): Promise<SendResult> => {
 	const job: TranscriptionJob = {
-		id: 'my-first-transcription', // uuid
+		id: new Date().toISOString(), // uuid
 		s3Url: 's3://test/test',
 		retryCount: 0,
 		sentTimestamp: new Date().toISOString(),
@@ -61,6 +62,7 @@ export const sendMessage = async (
 		transcriptDestinationService: DestinationService.TranscriptionService,
 		originalFilename: 'test.mp3',
 	};
+	console.log(queueUrl);
 
 	try {
 		const result = await client.send(

--- a/packages/common/src/sqs.ts
+++ b/packages/common/src/sqs.ts
@@ -38,7 +38,7 @@ export const getClient = (region: string, localstackEndpoint?: string) => {
 	const clientBaseConfig = {
 		region,
 	};
-	console.log(localstackEndpoint);
+
 	const clientConfig = localstackEndpoint
 		? { ...clientBaseConfig, endpoint: localstackEndpoint }
 		: clientBaseConfig;
@@ -54,7 +54,7 @@ export const sendMessage = async (
 	queueUrl: string,
 ): Promise<SendResult> => {
 	const job: TranscriptionJob = {
-		id: new Date().toISOString(), // uuid
+		id: 'my-first-transcription', // uuid
 		s3Url: 's3://test/test',
 		retryCount: 0,
 		sentTimestamp: new Date().toISOString(),
@@ -62,7 +62,6 @@ export const sendMessage = async (
 		transcriptDestinationService: DestinationService.TranscriptionService,
 		originalFilename: 'test.mp3',
 	};
-	console.log(queueUrl);
 
 	try {
 		const result = await client.send(

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,21 +1,22 @@
 {
-  "name": "worker",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "build": "esbuild --bundle --platform=node --target=node20 --outfile=dist/index.js src/index.ts",
-    "package": "docker run --rm -v $PWD:/worker $(docker build -q deb-build/) fpm",
-    "start": "STAGE=DEV nodemon src/index.ts"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "dependencies": {
-    "@guardian/transcription-service-common" : "1.0.0"
-  },
-  "devDependencies": {
-    "@types/node": "^20.11.5",
-    "typescript": "^5.3.3"
-  }
+	"name": "worker",
+	"version": "1.0.0",
+	"description": "",
+	"main": "index.js",
+	"scripts": {
+		"build": "esbuild --bundle --platform=node --target=node20 --outfile=dist/index.js src/index.ts",
+		"package": "docker run --rm -v $PWD:/worker $(docker build -q deb-build/) fpm",
+		"start": "STAGE=DEV nodemon src/index.ts"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"dependencies": {
+		"@guardian/transcription-service-common": "1.0.0",
+		"@aws-sdk/client-sns": "^3.496.0"
+	},
+	"devDependencies": {
+		"@types/node": "^20.11.5",
+		"typescript": "^5.3.3"
+	}
 }

--- a/packages/worker/src/sns.ts
+++ b/packages/worker/src/sns.ts
@@ -1,0 +1,38 @@
+import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
+import { TranscriptionOutput } from '@guardian/transcription-service-common';
+
+export const getSNSClient = (region: string, localstackEndpoint?: string) => {
+	const clientBaseConfig = {
+		region,
+	};
+	const clientConfig = localstackEndpoint
+		? { ...clientBaseConfig, endpoint: localstackEndpoint }
+		: clientBaseConfig;
+
+	return new SNSClient(clientConfig);
+};
+
+const publishMessage = async (
+	client: SNSClient,
+	topicArn: string,
+	message: string,
+): Promise<string | undefined> => {
+	try {
+		const resp = await client.send(
+			new PublishCommand({ TopicArn: topicArn, Message: message }),
+		);
+		console.log('message sent', resp);
+		return resp.MessageId;
+	} catch (e) {
+		console.error('Error publishing message', e);
+		throw e;
+	}
+};
+
+export const publishTranscriptionOutput = async (
+	client: SNSClient,
+	topicArn: string,
+	output: TranscriptionOutput,
+) => {
+	await publishMessage(client, topicArn, JSON.stringify(output));
+};

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -28,3 +28,7 @@ QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-na
 QUEUE_URL_LOCALHOST=${QUEUE_URL/sqs.eu-west-1.localhost.localstack.cloud/localhost}
 
 echo "Created queue in localstack, url: ${QUEUE_URL_LOCALHOST}"
+
+TOPIC_ARN=$(aws --endpoint-url=http://localhost:4566 sns create-topic --name transcription-service-destination-topic-DEV | jq .TopicArn)
+
+echo "Created topic in localstack, arn: ${TOPIC_ARN}"


### PR DESCRIPTION
## What does this change?
This PR:
 - Adds CDK to create an SNS topic
 - Removes s3 from our localstack container (following advice from @twrichards that localstack S3 can be challenging to work with due to differences in API implementations) -  note we weren't actually using localstack for S3 yet anyway
 - Adds SNS to localstack, updates setup.sh script to create a topic
 - Adds a new sns.ts client file in the worker project
 - Adds some code to send a dummy event to the SNS topic on app startup

## How to test
I've tested this by deploying to AWS and then starting a worker and verifying that a message gets sent to SNS
