### PR TITLE
Setup log shipping to central ELK

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -292,6 +292,8 @@ export class TranscriptionService extends GuStack {
 			{ applyToLaunchedInstances: true },
 		);
 
+		Tags.of(transcriptionWorkerASG).add('SystemdUnit', workerApp);
+
 		// SQS queue for transcription tasks from API lambda to worker EC2 instances
 		const transcriptionTaskQueue = new Queue(this, `${APP_NAME}-task-queue`, {
 			fifo: true,

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -292,7 +292,9 @@ export class TranscriptionService extends GuStack {
 			{ applyToLaunchedInstances: true },
 		);
 
-		Tags.of(transcriptionWorkerASG).add('SystemdUnit', `${workerApp}.service`);
+		Tags.of(transcriptionWorkerASG).add('SystemdUnit', `${workerApp}.service`, {
+			applyToLaunchedInstances: true,
+		});
 
 		// SQS queue for transcription tasks from API lambda to worker EC2 instances
 		const transcriptionTaskQueue = new Queue(this, `${APP_NAME}-task-queue`, {

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -292,7 +292,7 @@ export class TranscriptionService extends GuStack {
 			{ applyToLaunchedInstances: true },
 		);
 
-		Tags.of(transcriptionWorkerASG).add('SystemdUnit', workerApp);
+		Tags.of(transcriptionWorkerASG).add('SystemdUnit', `${workerApp}.service`);
 
 		// SQS queue for transcription tasks from API lambda to worker EC2 instances
 		const transcriptionTaskQueue = new Queue(this, `${APP_NAME}-task-queue`, {


### PR DESCRIPTION
## What does this change?

Adds tags to ASG and role permissions to write to log kinesis stream so logs (including application logs) go to central ELK. 

## How to test

Tested on [CODE](https://logs.gutools.co.uk/s/investigations/goto/f525deb0-c5e0-11ee-a363-830c35c1ec3b) - logs are there.
