### PR TITLE
Use debian bookworm-slim for worker container

### DIFF
--- a/packages/worker/deb-build/Dockerfile
+++ b/packages/worker/deb-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 WORKDIR /worker
 
 #suppress installation prompts

--- a/whisper_container/Dockerfile
+++ b/whisper_container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM debian:bookworm-slim
 WORKDIR /opt
 LABEL com.theguardian.transcription-service.whisper-container="Whisper.cpp container with models downloaded, including ffmpeg"
 


### PR DESCRIPTION
## What does this change?
We have 2 containers in this project at the moment - one used for building a .deb package for the worker package, another containing ffmpeg and whisper.cpp.

This PR gets them both to use the same debian bookworm 'slim' image (bookworm is the latest version of debian). This isn't a significant improvement - both ubuntu and bookworm-slim containers are a similar size, but it's good to be consistent - and there may be some security benefits from using a 'minimal' image versus ubuntu.

If we really wanted to optimise our containers we could use alpine linux, but given that we're including giant whisper models in our main container, I'm not sure it's worth the hassle

Some background here https://www.chainguard.dev/unchained/minimal-container-images-towards-a-more-secure-future

## How to test
The worker build appears to still be working, so changes to that Dockerfile seem to be ok.

We update our 'latest' worker container every time the Dockerfile changes - so I tested this new container by running a transcription on a worker instance