### PR TITLE
Fix target-tracking ASG scaling policy

### DIFF
--- a/packages/cdk/target_tracking_scaling_policy/config.json
+++ b/packages/cdk/target_tracking_scaling_policy/config.json
@@ -58,7 +58,7 @@
 			{
 				"Label": "Calculate the backlog per instance",
 				"Id": "e1",
-				"Expression": "(m1 + m2) / m3",
+				"Expression": "(m1 + m2) / IF(m3 == 0, 0.99, m3)",
 				"ReturnData": true
 			}
 		]


### PR DESCRIPTION
## What does this change

Fixes scaling policy introduced in #11 
At the moment, when there are 0 worker instances, `e1` evaluates to `NaN`. This means that the scaling policy cloudwatch alarms always have insufficient data and we'll never scale out the ASG.
This fix coalesces the number of instances to .99 (just under our target backlog per instance of 1) to avoid division by 0.

## Alternate approach
I tried using [`FILL`](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) to convert missing `GroupInServiceInstances` values to 0 but this didn't seem to work. 
`(FILL(m1, 0) + FILL(m2, 0)) / FILL(m3, .99)` evaluated to undefined regardless of number of instances or messages in the queue


