### PR TITLE
Add/remove scale in protection for worker instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -180,6 +180,477 @@
 			"version": "1.14.1",
 			"license": "0BSD"
 		},
+		"node_modules/@aws-sdk/client-auto-scaling": {
+			"version": "3.509.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-auto-scaling/-/client-auto-scaling-3.509.0.tgz",
+			"integrity": "sha512-DiN7nQgvi4ynbTa3VGOF48H9PqEvH4/3VTd4xYR3LIgHYsv8YT7iAUkZf28MuDYEokHJvzadAKWcCmcczHzRJQ==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.507.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/credential-provider-node": "3.509.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-signing": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"@smithy/util-waiter": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/client-sso": {
+			"version": "3.507.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.507.0.tgz",
+			"integrity": "sha512-pFeaKwqv4tXD6QVxWC2V4N62DUoP3bPSm/mCe2SPhaNjNsmwwA53viUHz/nwxIbs8w4vV44UQsygb0AgKm+HoQ==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.507.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.507.0.tgz",
+			"integrity": "sha512-ms5CH2ImhqqCIbo5irxayByuPOlVAmSiqDVfjZKwgIziqng2bVgNZMeKcT6t0bmrcgScEAVnZwY7j/iZTIw73g==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.507.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-signing": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.507.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/client-sts": {
+			"version": "3.507.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.507.0.tgz",
+			"integrity": "sha512-TOWBe0ApEh32QOib0R+irWGjd1F9wnhbGV5PcB9SakyRwvqwG5MKOfYxG7ocoDqLlaRwzZMidcy/PV8/OEVNKg==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.496.0",
+				"@aws-sdk/middleware-host-header": "3.502.0",
+				"@aws-sdk/middleware-logger": "3.502.0",
+				"@aws-sdk/middleware-recursion-detection": "3.502.0",
+				"@aws-sdk/middleware-user-agent": "3.502.0",
+				"@aws-sdk/region-config-resolver": "3.502.0",
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@aws-sdk/util-user-agent-browser": "3.502.0",
+				"@aws-sdk/util-user-agent-node": "3.502.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.507.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.502.0.tgz",
+			"integrity": "sha512-KIB8Ae1Z7domMU/jU4KiIgK4tmYgvuXlhR54ehwlVHxnEoFPoPuGHFZU7oFn79jhhSLUFQ1lRYMxP0cEwb7XeQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.507.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.507.0.tgz",
+			"integrity": "sha512-2CnyduoR9COgd7qH1LPYK8UggGqVs8R4ASDMB5bwGxbg9ZerlStDiHpqvJNNg1k+VlejBr++utxfmHd236XgmQ==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.507.0",
+				"@aws-sdk/credential-provider-env": "3.502.0",
+				"@aws-sdk/credential-provider-process": "3.502.0",
+				"@aws-sdk/credential-provider-sso": "3.507.0",
+				"@aws-sdk/credential-provider-web-identity": "3.507.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.509.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.509.0.tgz",
+			"integrity": "sha512-uXT8wIq1k+m0mS/pC9U1cUTIjUB7/4PgxyiYsTxYPIULtWnQXltAlcPU3QzKTJMP60sqftRYZ2jFDLAVsipQxw==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.502.0",
+				"@aws-sdk/credential-provider-http": "3.503.1",
+				"@aws-sdk/credential-provider-ini": "3.507.0",
+				"@aws-sdk/credential-provider-process": "3.502.0",
+				"@aws-sdk/credential-provider-sso": "3.507.0",
+				"@aws-sdk/credential-provider-web-identity": "3.507.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.502.0.tgz",
+			"integrity": "sha512-fJJowOjQ4infYQX0E1J3xFVlmuwEYJAFk0Mo1qwafWmEthsBJs+6BR2RiWDELHKrSK35u4Pf3fu3RkYuCtmQFw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.507.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.507.0.tgz",
+			"integrity": "sha512-6WBjou52QukFpDi4ezb19bcAx/bM8ge8qnJnRT02WVRmU6zFQ5yLD2fW1MFsbX3cwbey+wSqKd5FGE1Hukd5wQ==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.507.0",
+				"@aws-sdk/token-providers": "3.507.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.507.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.507.0.tgz",
+			"integrity": "sha512-f+aGMfazBimX7S06224JRYzGTaMh1uIhfj23tZylPJ05KxTVi5IO1RoqeI/uHLJ+bDOx+JHBC04g/oCdO4kHvw==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.507.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.502.0.tgz",
+			"integrity": "sha512-EjnG0GTYXT/wJBmm5/mTjDcAkzU8L7wQjOzd3FTXuTCNNyvAvwrszbOj5FlarEw5XJBbQiZtBs+I5u9+zy560w==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.502.0.tgz",
+			"integrity": "sha512-FDyv6K4nCoHxbjLGS2H8ex8I0KDIiu4FJgVRPs140ZJy6gE5Pwxzv6YTzZGLMrnqcIs9gh065Lf6DjwMelZqaw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.502.0.tgz",
+			"integrity": "sha512-hvbyGJbxeuezxOu8VfFmcV4ql1hKXLxHTe5FNYfEBat2KaZXVhc1Hg+4TvB06/53p+E8J99Afmumkqbxs2esUA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/middleware-signing": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.502.0.tgz",
+			"integrity": "sha512-4hF08vSzJ7L6sB+393gOFj3s2N6nLusYS0XrMW6wYNFU10IDdbf8Z3TZ7gysDJJHEGQPmTAesPEDBsasGWcMxg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/signature-v4": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.502.0.tgz",
+			"integrity": "sha512-TxbBZbRiXPH0AUxegqiNd9aM9zNSbfjtBs5MEfcBsweeT/B2O7K1EjP9+CkB8Xmk/5FLKhAKLr19b1TNoE27rw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@aws-sdk/util-endpoints": "3.502.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.502.0.tgz",
+			"integrity": "sha512-mxmsX2AGgnSM+Sah7mcQCIneOsJQNiLX0COwEttuf8eO+6cLMAZvVudH3BnWTfea4/A9nuri9DLCqBvEmPrilg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/token-providers": {
+			"version": "3.507.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.507.0.tgz",
+			"integrity": "sha512-ehOINGjoGJc6Puzon7ev4bXckkaZx18WNgMTNttYJhj3vTpj5LPSQbI/5SS927bEbpGMFz1+hJ6Ra5WGfbTcEQ==",
+			"dependencies": {
+				"@aws-sdk/client-sso-oidc": "3.507.0",
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/types": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+			"integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.502.0.tgz",
+			"integrity": "sha512-6LKFlJPp2J24r1Kpfoz5ESQn+1v5fEjDB3mtUKRdpwarhm3syu7HbKlHCF3KbcCOyahobvLvhoedT78rJFEeeg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.502.0.tgz",
+			"integrity": "sha512-v8gKyCs2obXoIkLETAeEQ3AM+QmhHhst9xbM1cJtKUGsRlVIak/XyyD+kVE6kmMm1cjfudHpHKABWk9apQcIZQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/types": "^2.9.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-auto-scaling/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.502.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.502.0.tgz",
+			"integrity": "sha512-9RjxpkGZKbTdl96tIJvAo+vZoz4P/cQh36SBUt9xfRfW0BtsaLyvSrvlR5wyUYhvRcC12Axqh/8JtnAPq//+Vw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.502.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@aws-sdk/client-s3": {
 			"version": "3.504.0",
 			"license": "Apache-2.0",
@@ -13469,6 +13940,7 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"@aws-sdk/client-auto-scaling": "^3.496.0",
 				"@aws-sdk/client-sns": "^3.496.0",
 				"@guardian/transcription-service-backend-common": "1.0.0"
 			},

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -16,6 +16,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       "GuAllowPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
+      "GuAllowPolicy",
       "GuInstanceRole",
       "GuDescribeEC2Policy",
       "GuLogShippingPolicy",
@@ -420,6 +421,27 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "SetInstanceProtection5DD5610F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "autoscaling:SetInstanceProtection",
+              "Effect": "Allow",
+              "Resource": "arn:aws:autoscaling:test-region:745349931791:autoScalingGroup:*:autoScalingGroupName/transcription-service-workers-TEST",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SetInstanceProtection5DD5610F",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTranscriptionserviceworkerA8AC6615",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "TranscriptDestinationTopic831E3125": {
       "Properties": {
         "Tags": [
@@ -539,7 +561,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
             ],
           },
         },
-        "NewInstancesProtectedFromScaleIn": false,
+        "NewInstancesProtectedFromScaleIn": true,
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -52,6 +52,7 @@ export class TranscriptionService extends GuStack {
 		const APP_NAME = 'transcription-service';
 		const apiId = `${APP_NAME}-${props.stage}`;
 		const isProd = props.stage === 'PROD';
+		const autoScalingGroupName = `transcription-service-workers-${this.stage}`;
 		if (!props.env?.region) throw new Error('region not provided in props');
 
 		const workerAmi = new GuAmiParameter(this, {
@@ -242,7 +243,7 @@ export class TranscriptionService extends GuStack {
 				new GuAllowPolicy(this, 'SetInstanceProtection', {
 					actions: ['autoscaling:SetInstanceProtection'],
 					resources: [
-						`arn:aws:autoscaling:${props.env.region}:${GuardianAwsAccounts.Investigations}:autoScalingGroup:*:autoScalingGroupName/transcription-service-workers-${this.stage}`,
+						`arn:aws:autoscaling:${props.env.region}:${GuardianAwsAccounts.Investigations}:autoScalingGroup:*:autoScalingGroupName/${autoScalingGroupName}`,
 					],
 				}),
 			],
@@ -292,7 +293,7 @@ export class TranscriptionService extends GuStack {
 			{
 				minCapacity: 0,
 				maxCapacity: isProd ? 20 : 4,
-				autoScalingGroupName: `transcription-service-workers-${this.stage}`,
+				autoScalingGroupName,
 				vpc: GuVpc.fromIdParameter(this, 'InvestigationsInternetEnabledVpc', {
 					availabilityZones: ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
 				}),

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -239,6 +239,12 @@ export class TranscriptionService extends GuStack {
 					],
 					resources: [loggingStreamArn],
 				}),
+				new GuAllowPolicy(this, 'SetInstanceProtection', {
+					actions: ['autoscaling:SetInstanceProtection'],
+					resources: [
+						`arn:aws:autoscaling:${props.env.region}:${GuardianAwsAccounts.Investigations}:autoScalingGroup:*:autoScalingGroupName/transcription-service-workers-${this.stage}`,
+					],
+				}),
 			],
 		});
 

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -298,7 +298,7 @@ export class TranscriptionService extends GuStack {
 				},
 				// we might want to set this to true once we are actually doing transcriptions to protect the instance from
 				// being terminated before it has a chance to complete a transcription job.
-				newInstancesProtectedFromScaleIn: false,
+				newInstancesProtectedFromScaleIn: true,
 				mixedInstancesPolicy: {
 					launchTemplate,
 					instancesDistribution: {

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -12,6 +12,7 @@
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
+		"@aws-sdk/client-auto-scaling": "^3.496.0",
 		"@aws-sdk/client-sns": "^3.496.0",
 		"@guardian/transcription-service-backend-common": "1.0.0"
 	},

--- a/packages/worker/src/asg.ts
+++ b/packages/worker/src/asg.ts
@@ -2,7 +2,7 @@ import {
 	AutoScalingClient,
 	SetInstanceProtectionCommand,
 } from '@aws-sdk/client-auto-scaling';
-import { readFile } from './transcribe';
+import { readFile } from './util';
 
 export const updateScaleInProtection = async (
 	region: string,
@@ -23,8 +23,8 @@ export const updateScaleInProtection = async (
 				ProtectedFromScaleIn: value,
 			};
 			const command = new SetInstanceProtectionCommand(input);
-			const response = await autoScalingClient.send(command);
-			console.log('added scale-in protection', response);
+			await autoScalingClient.send(command);
+			console.log(`added scale-in protection to instance ${instanceId}`);
 		}
 	} catch (error) {
 		console.log(`Could not remove scale-in protection`, error);

--- a/packages/worker/src/asg.ts
+++ b/packages/worker/src/asg.ts
@@ -24,7 +24,9 @@ export const updateScaleInProtection = async (
 			};
 			const command = new SetInstanceProtectionCommand(input);
 			await autoScalingClient.send(command);
-			console.log(`added scale-in protection to instance ${instanceId}`);
+			console.log(
+				`Updated scale-in protection to value ${value} for instance ${instanceId}`,
+			);
 		}
 	} catch (error) {
 		console.log(`Could not remove scale-in protection`, error);

--- a/packages/worker/src/asg.ts
+++ b/packages/worker/src/asg.ts
@@ -18,7 +18,7 @@ export const updateScaleInProtection = async (
 			console.log(`instanceId: ${instanceId}`);
 			const autoScalingClient = new AutoScalingClient(clientConfig);
 			const input = {
-				InstanceIds: [instanceId],
+				InstanceIds: [instanceId.trim()],
 				AutoScalingGroupName: `transcription-service-workers-${stage}`,
 				ProtectedFromScaleIn: value,
 			};

--- a/packages/worker/src/asg.ts
+++ b/packages/worker/src/asg.ts
@@ -1,0 +1,27 @@
+import {
+	AutoScalingClient,
+	SetInstanceProtectionCommand,
+} from '@aws-sdk/client-auto-scaling';
+import { readFile } from './transcribe';
+
+export const updateScaleInProtection = async (
+	stage: string,
+	value: boolean,
+) => {
+	try {
+		const instanceId = readFile('/var/lib/cloud/data/instance-id');
+		console.log(`instanceId: ${instanceId}`);
+		const autoScalingClient = new AutoScalingClient();
+		const input = {
+			InstanceIds: [instanceId],
+			AutoScalingGroupName: `transcription-service-workers-${stage}`,
+			ProtectedFromScaleIn: value,
+		};
+		const command = new SetInstanceProtectionCommand(input);
+		const response = await autoScalingClient.send(command);
+		console.log('added scale-in protection', response);
+	} catch (error) {
+		console.log(`Could not remove scale-in protection`, error);
+		throw error;
+	}
+};

--- a/packages/worker/src/asg.ts
+++ b/packages/worker/src/asg.ts
@@ -9,17 +9,19 @@ export const updateScaleInProtection = async (
 	value: boolean,
 ) => {
 	try {
-		const instanceId = readFile('/var/lib/cloud/data/instance-id');
-		console.log(`instanceId: ${instanceId}`);
-		const autoScalingClient = new AutoScalingClient();
-		const input = {
-			InstanceIds: [instanceId],
-			AutoScalingGroupName: `transcription-service-workers-${stage}`,
-			ProtectedFromScaleIn: value,
-		};
-		const command = new SetInstanceProtectionCommand(input);
-		const response = await autoScalingClient.send(command);
-		console.log('added scale-in protection', response);
+		if (stage !== 'DEV') {
+			const instanceId = readFile('/var/lib/cloud/data/instance-id');
+			console.log(`instanceId: ${instanceId}`);
+			const autoScalingClient = new AutoScalingClient();
+			const input = {
+				InstanceIds: [instanceId],
+				AutoScalingGroupName: `transcription-service-workers-${stage}`,
+				ProtectedFromScaleIn: value,
+			};
+			const command = new SetInstanceProtectionCommand(input);
+			const response = await autoScalingClient.send(command);
+			console.log('added scale-in protection', response);
+		}
 	} catch (error) {
 		console.log(`Could not remove scale-in protection`, error);
 		throw error;

--- a/packages/worker/src/asg.ts
+++ b/packages/worker/src/asg.ts
@@ -5,14 +5,18 @@ import {
 import { readFile } from './transcribe';
 
 export const updateScaleInProtection = async (
+	region: string,
 	stage: string,
 	value: boolean,
 ) => {
+	const clientConfig = {
+		region,
+	};
 	try {
 		if (stage !== 'DEV') {
 			const instanceId = readFile('/var/lib/cloud/data/instance-id');
 			console.log(`instanceId: ${instanceId}`);
-			const autoScalingClient = new AutoScalingClient();
+			const autoScalingClient = new AutoScalingClient(clientConfig);
 			const input = {
 				InstanceIds: [instanceId],
 				AutoScalingGroupName: `transcription-service-workers-${stage}`,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -63,8 +63,6 @@ const main = async () => {
 
 		const fileToTranscribe = await getFileFromS3(config, job.s3Key);
 
-		console.log('file is here');
-
 		// docker container to run ffmpeg and whisper on file
 		const containerId = await getOrCreateContainer(
 			path.parse(fileToTranscribe).dir,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -23,22 +23,23 @@ import { updateScaleInProtection } from './asg';
 const main = async () => {
 	const config = await getConfig();
 	const stage = config.app.stage;
+	const region = config.aws.region;
 	console.log('stage is: ', stage);
 
 	const numberOfThreads = config.app.stage === 'PROD' ? 16 : 2;
 
-	const client = getSQSClient(config.aws.region, config.aws.localstackEndpoint);
+	const client = getSQSClient(region, config.aws.localstackEndpoint);
 	const message = await getNextMessage(client, config.app.taskQueueUrl);
 
 	if (isFailure(message)) {
 		console.error(`Failed to fetch message due to ${message.errorMsg}`);
-		await updateScaleInProtection(stage, false);
+		await updateScaleInProtection(region, stage, false);
 		return;
 	}
 
 	if (!message.message) {
 		console.log('No messages available');
-		await updateScaleInProtection(stage, false);
+		await updateScaleInProtection(region, stage, false);
 		return;
 	}
 
@@ -128,7 +129,7 @@ const main = async () => {
 			);
 		}
 	} finally {
-		await updateScaleInProtection(stage, false);
+		await updateScaleInProtection(region, stage, false);
 	}
 };
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -32,11 +32,13 @@ const main = async () => {
 
 	if (isFailure(message)) {
 		console.error(`Failed to fetch message due to ${message.errorMsg}`);
+		await updateScaleInProtection(stage, false);
 		return;
 	}
 
 	if (!message.message) {
 		console.log('No messages available');
+		await updateScaleInProtection(stage, false);
 		return;
 	}
 
@@ -126,9 +128,7 @@ const main = async () => {
 			);
 		}
 	} finally {
-		if (stage !== 'DEV') {
-			await updateScaleInProtection(stage, false);
-		}
+		await updateScaleInProtection(stage, false);
 	}
 };
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -18,9 +18,12 @@ import {
 	getOrCreateContainer,
 } from './transcribe';
 import path from 'path';
+import { updateScaleInProtection } from './asg';
 
 const main = async () => {
 	const config = await getConfig();
+	const stage = config.app.stage;
+	console.log('stage is: ', stage);
 
 	const numberOfThreads = config.app.stage === 'PROD' ? 16 : 2;
 
@@ -121,6 +124,10 @@ const main = async () => {
 				message.message.ReceiptHandle,
 				0,
 			);
+		}
+	} finally {
+		if (stage !== 'DEV') {
+			await updateScaleInProtection(stage, false);
 		}
 	}
 };

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -24,7 +24,6 @@ const main = async () => {
 	const config = await getConfig();
 	const stage = config.app.stage;
 	const region = config.aws.region;
-	console.log('stage is: ', stage);
 
 	const numberOfThreads = config.app.stage === 'PROD' ? 16 : 2;
 

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process';
 import path from 'path';
-import * as fs from 'fs';
+import { readFile } from './util';
 
 interface ProcessResult {
 	code?: number;
@@ -137,11 +137,6 @@ const getDuration = (ffmpegOutput: string) => {
 	const duration = hour * 3600 + minute * 60 + seconds;
 	console.log(`File duration is ${duration} seconds`);
 	return duration;
-};
-
-export const readFile = (filePath: string): string => {
-	const file = fs.readFileSync(filePath, 'utf8');
-	return file;
 };
 
 export const getTranscriptionText = async (

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -139,7 +139,7 @@ const getDuration = (ffmpegOutput: string) => {
 	return duration;
 };
 
-const readFile = (filePath: string): string => {
+export const readFile = (filePath: string): string => {
 	const file = fs.readFileSync(filePath, 'utf8');
 	return file;
 };

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -1,0 +1,6 @@
+import * as fs from 'fs';
+
+export const readFile = (filePath: string): string => {
+	const file = fs.readFileSync(filePath, 'utf8');
+	return file;
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds scale-in polict to the worker instances and removes that when it's not needed any more. Changes are as followed:
- add a function that can update the scale-in protection of the running instance
- Updates the ASG in cdk to create the instances with scale-in protection 
- Adds new allow policy to the ASG instance role in order to allow to SetInstanceProtection from within the instance
- Removes scale-in protection when  reading a message from queue fails or when there is no message in queue
- Removes scale-in protection when the worker finishes the work
- Removes scale-in protection when the worker fails to finish the work

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This was tested locally and in PROD
