### PR TITLE
Support export to google doc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5192,6 +5192,126 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/@next/swc-darwin-x64": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.0.tgz",
+			"integrity": "sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-arm64-gnu": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.0.tgz",
+			"integrity": "sha512-RHo7Tcj+jllXUbK7xk2NyIDod3YcCPDZxj1WLIYxd709BQ7WuRYl3OWUNG+WUfqeQBds6kvZYlc42NJJTNi4tQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-arm64-musl": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.0.tgz",
+			"integrity": "sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-x64-gnu": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.0.tgz",
+			"integrity": "sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-x64-musl": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.0.tgz",
+			"integrity": "sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-win32-arm64-msvc": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.0.tgz",
+			"integrity": "sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-win32-ia32-msvc": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.0.tgz",
+			"integrity": "sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-win32-x64-msvc": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.0.tgz",
+			"integrity": "sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6036,6 +6036,12 @@
 				"@types/send": "*"
 			}
 		},
+		"node_modules/@types/google.accounts": {
+			"version": "0.0.14",
+			"resolved": "https://registry.npmjs.org/@types/google.accounts/-/google.accounts-0.0.14.tgz",
+			"integrity": "sha512-HqIVkVzpiLWhlajhQQd4rIV7czanFvXblJI2J1fSrL+VKQuQwwZ63m35D/mI0flsqKE6p/hNrAG0Yn4FD6JvNA==",
+			"dev": true
+		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.9",
 			"dev": true,
@@ -6462,6 +6468,17 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+			"integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/ajv": {
@@ -7312,6 +7329,14 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/bignumber.js": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+			"integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"dev": true,
@@ -7924,7 +7949,6 @@
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.1.2"
@@ -8764,6 +8788,11 @@
 			"version": "2.0.0",
 			"license": "MIT"
 		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"dev": true,
@@ -9063,6 +9092,32 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/gaxios": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.2.0.tgz",
+			"integrity": "sha512-H6+bHeoEAU5D6XNc6mPKeN5dLZqEDs9Gpk6I+SZBEzK5So58JVrHPmevNi35fRl1J9Y5TaeLW0kYx3pCJ1U2mQ==",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"is-stream": "^2.0.0",
+				"node-fetch": "^2.6.9"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+			"integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+			"dependencies": {
+				"gaxios": "^6.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"dev": true,
@@ -9266,6 +9321,81 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/google-auth-library": {
+			"version": "9.6.3",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.6.3.tgz",
+			"integrity": "sha512-4CacM29MLC2eT9Cey5GDVK4Q8t+MMp8+OEdOaqD9MG6b0dOyLORaaeJMPQ7EESVgm/+z5EKYyFLxgzBJlJgyHQ==",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^6.1.1",
+				"gcp-metadata": "^6.1.0",
+				"gtoken": "^7.0.0",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/google-auth-library/node_modules/jwa": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+			"dependencies": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/google-auth-library/node_modules/jws": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+			"integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+			"dependencies": {
+				"jwa": "^2.0.0",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/googleapis": {
+			"version": "133.0.0",
+			"resolved": "https://registry.npmjs.org/googleapis/-/googleapis-133.0.0.tgz",
+			"integrity": "sha512-6xyc49j+x7N4smawJs/q1i7mbSkt6SYUWWd9RbsmmDW7gRv+mhwZ4xT+XkPihZcNyo/diF//543WZq4szdS74w==",
+			"dependencies": {
+				"google-auth-library": "^9.0.0",
+				"googleapis-common": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/googleapis-common": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.0.1.tgz",
+			"integrity": "sha512-mgt5zsd7zj5t5QXvDanjWguMdHAcJmmDrF9RkInCecNsyV7S7YtGqm5v2IWONNID88osb7zmx5FtrAP12JfD0w==",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"gaxios": "^6.0.3",
+				"google-auth-library": "^9.0.0",
+				"qs": "^6.7.0",
+				"url-template": "^2.0.8",
+				"uuid": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/googleapis-common/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/gopd": {
 			"version": "1.0.1",
 			"license": "MIT",
@@ -9284,6 +9414,37 @@
 			"version": "1.4.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/gtoken": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+			"integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+			"dependencies": {
+				"gaxios": "^6.0.0",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/gtoken/node_modules/jwa": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+			"dependencies": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/gtoken/node_modules/jws": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+			"integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+			"dependencies": {
+				"jwa": "^2.0.0",
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"node_modules/has-bigints": {
 			"version": "1.0.2",
@@ -9383,6 +9544,18 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.3.tgz",
+			"integrity": "sha512-kCnwztfX0KZJSLOBrcL0emLeFako55NWMovvyPP2AjsghNk9RB1yjSI+jVumPHYZsNXegNoqupSW9IY3afSH8w==",
+			"dependencies": {
+				"agent-base": "^7.0.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/human-signals": {
@@ -9767,7 +9940,6 @@
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -10527,6 +10699,14 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
 			}
 		},
 		"node_modules/json-buffer": {
@@ -11414,6 +11594,25 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/node-int64": {
@@ -13349,6 +13548,11 @@
 				"nodetouch": "bin/nodetouch.js"
 			}
 		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+		},
 		"node_modules/ts-api-utils": {
 			"version": "1.0.3",
 			"dev": true,
@@ -13685,6 +13889,11 @@
 				"querystring": "0.2.0"
 			}
 		},
+		"node_modules/url-template": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+			"integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
+		},
 		"node_modules/url/node_modules/punycode": {
 			"version": "1.3.2",
 			"license": "MIT"
@@ -13779,6 +13988,20 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -13998,6 +14221,7 @@
 				"aws-lambda": "^1.0.7",
 				"express": "^4.18.2",
 				"express-async-handler": "^1.2.0",
+				"googleapis": "^133.0.0",
 				"jwt-decode": "^4.0.0",
 				"passport": "^0.7.0",
 				"passport-google-oauth2": "^0.2.0",
@@ -14291,6 +14515,7 @@
 				"react-dom": "^18"
 			},
 			"devDependencies": {
+				"@types/google.accounts": "0.0.14",
 				"@types/node": "^20",
 				"@types/react": "^18",
 				"@types/react-dom": "^18",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,6 +19,7 @@
 		"aws-lambda": "^1.0.7",
 		"express": "^4.18.2",
 		"express-async-handler": "^1.2.0",
+		"googleapis": "^133.0.0",
 		"jwt-decode": "^4.0.0",
 		"passport": "^0.7.0",
 		"passport-google-oauth2": "^0.2.0",

--- a/packages/api/src/index.html
+++ b/packages/api/src/index.html
@@ -22,7 +22,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 		<title>Transcribe</title>
-		<script src="https://accounts.google.com/gsi/client" async></script>
 	</head>
 	<body>
 		<noscript>You need to enable JavaScript to run this app.</noscript>

--- a/packages/api/src/index.html
+++ b/packages/api/src/index.html
@@ -1,21 +1,18 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <!-- <link rel="icon" href="%PUBLIC_URL%/favicon.ico" /> -->
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Guardian Transcription Service"
-    />
-    <!-- <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> -->
-    <!--
+	<head>
+		<meta charset="utf-8" />
+		<!-- <link rel="icon" href="%PUBLIC_URL%/favicon.ico" /> -->
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#000000" />
+		<meta name="description" content="Guardian Transcription Service" />
+		<!-- <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> -->
+		<!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <!-- <link rel="manifest" href="%PUBLIC_URL%/manifest.json" /> -->
-    <!--
+		<!-- <link rel="manifest" href="%PUBLIC_URL%/manifest.json" /> -->
+		<!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -24,15 +21,15 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Transcribe</title>
-    <!-- <script src="https://accounts.google.com/gsi/client" async></script> -->
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root">
-        <p>Hello world</p>
-    </div>
-    <!--
+		<title>Transcribe</title>
+		<script src="https://accounts.google.com/gsi/client" async></script>
+	</head>
+	<body>
+		<noscript>You need to enable JavaScript to run this app.</noscript>
+		<div id="root">
+			<p>Hello world</p>
+		</div>
+		<!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -42,5 +39,5 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+	</body>
 </html>

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -100,14 +100,12 @@ const getApp = async () => {
 				);
 				const parsedItem = TranscriptionItem.safeParse(item);
 				if (parsedItem.success) {
-					console.log('parsed item', parsedItem.data);
 					const exportResult = await createTranscriptDocument(
 						config,
 						`${parsedItem.data.originalFilename} transcript`,
 						exportRequest.data.oAuthTokenResponse,
 						parsedItem.data.transcript.srt,
 					);
-					console.log('Export result', exportResult);
 					res.send({
 						documentId: exportResult,
 					});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -147,10 +147,20 @@ const getApp = async () => {
 
 	app.use('/api', apiRouter);
 
+	const clientPages = ['export'];
+
 	if (runningOnAws) {
 		app.use(express.static('client'));
-		app.get('/*', (req, res) => {
-			res.sendFile(path.resolve(__dirname, 'client', 'index.html'));
+		app.get('/:page', (req, res) => {
+			if (req.params.page && !clientPages.includes(req.params.page)) {
+				res
+					.status(404)
+					.send(
+						`Endpoint not supported. Valid endpoints: /, /${clientPages.join(', /')}`,
+					);
+			}
+			const page = req.params.page ? `${req.params.page}.html` : 'index.html';
+			res.sendFile(path.resolve(__dirname, 'client', page));
 		});
 	} else {
 		if (emulateProductionLocally) {
@@ -159,7 +169,8 @@ const getApp = async () => {
 					path.resolve(__dirname, '..', '..', '..', 'packages/client/out'),
 				),
 			);
-			app.get('/*', (req: Request, res: Response) => {
+			app.get('/:page', (req: Request, res: Response) => {
+				const page = req.params.page ? `${req.params.page}.html` : 'index.html';
 				res.sendFile(
 					path.resolve(
 						__dirname,
@@ -167,7 +178,7 @@ const getApp = async () => {
 						'..',
 						'..',
 						'packages/client/out',
-						'index.html',
+						page,
 					),
 				);
 			});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -98,6 +98,12 @@ const getApp = async () => {
 					config.app.tableName,
 					exportRequest.data.id,
 				);
+				if (!item) {
+					const msg = `Failed to fetch item with id ${exportRequest.data.id} from database.`;
+					console.error(msg);
+					res.status(500).send(msg);
+					return;
+				}
 				const parsedItem = TranscriptionItem.safeParse(item);
 				if (parsedItem.success) {
 					const exportResult = await createTranscriptDocument(

--- a/packages/api/src/services/googleDrive.ts
+++ b/packages/api/src/services/googleDrive.ts
@@ -14,7 +14,7 @@ export const getOrCreateTranscriptFolder = async (
 	try {
 		// first see if there is already a folder matching folderName
 		const existingFolders = await drive.files.list({
-			q: `mimeType='application/vnd.google-apps.folder' and name ='${folderName}' and trashed=false`,
+			q: `mimeType='${fileMetadata.mimeType}' and name ='${folderName}' and trashed=false`,
 			spaces: 'drive',
 		});
 		// there could be multiple folders with this name, let's upload to the first one
@@ -111,7 +111,7 @@ export const createTranscriptDocument = async (
 	);
 	if (!folderId) {
 		console.error('Failed to get or create folder');
-		return null;
+		return undefined;
 	}
 	const docId = await uploadToGoogleDocs(
 		drive,

--- a/packages/api/src/services/googleDrive.ts
+++ b/packages/api/src/services/googleDrive.ts
@@ -1,0 +1,125 @@
+import { OAuth2Client } from 'google-auth-library/build/src/auth/oauth2client';
+import { google, drive_v3, docs_v1 } from 'googleapis';
+import { TranscriptionConfig } from '@guardian/transcription-service-backend-common';
+import { ZTokenResponse } from '@guardian/transcription-service-common';
+
+export const createTranscriptFolder = async (
+	drive: drive_v3.Drive,
+	folderName: string,
+) => {
+	const fileMetadata = {
+		name: folderName,
+		mimeType: 'application/vnd.google-apps.folder',
+	};
+	try {
+		const file = await drive.files.create({
+			requestBody: fileMetadata,
+			fields: 'id',
+		});
+		console.log('Folder Id:', file.data.id);
+		return file.data.id;
+	} catch (err) {
+		console.error('Failed to create folder', err);
+		throw err;
+	}
+};
+
+export const uploadToGoogleDocs = async (
+	drive: drive_v3.Drive,
+	docs: docs_v1.Docs,
+	folderId: string,
+	fileName: string,
+	text: string,
+): Promise<string> => {
+	console.log(fileName, text);
+	// Create using the Drive API
+	const createResponse = await drive.files.create({
+		supportsAllDrives: true,
+		requestBody: {
+			mimeType: 'application/vnd.google-apps.document',
+			name: fileName,
+			parents: [folderId],
+		},
+	});
+
+	if (createResponse.data.id) {
+		await docs.documents.batchUpdate({
+			documentId: createResponse.data.id,
+			requestBody: {
+				requests: [
+					{
+						insertText: {
+							text: fileName,
+							location: {
+								index: 1,
+							},
+						},
+					},
+					{
+						insertText: {
+							text: '\n' + text,
+							endOfSegmentLocation: {
+								segmentId: null,
+							},
+						},
+					},
+					{
+						updateParagraphStyle: {
+							paragraphStyle: {
+								namedStyleType: 'HEADING_1',
+							},
+							fields: 'namedStyleType',
+							range: {
+								startIndex: 1,
+								endIndex: fileName.length,
+							},
+						},
+					},
+					// {
+					//     updateParagraphStyle: {
+					//         paragraphStyle: {
+					//             namedStyleType: "NORMAL_TEXT"
+					//         },
+					//         fields: "namedStyleType",
+					//         range: {
+					//             startIndex: fileName.length,
+					//             endIndex: text.length+1
+					//         }
+					//     }
+					// },
+				],
+			},
+		});
+		return createResponse.data.id;
+	}
+	throw new Error('Failed to create document');
+};
+
+export const createTranscriptDocument = async (
+	config: TranscriptionConfig,
+	fileName: string,
+	oAuthTokenResponse: ZTokenResponse,
+	transcriptText: string,
+) => {
+	const oAuth2Client: OAuth2Client = new google.auth.OAuth2(config.auth);
+	oAuth2Client.setCredentials(oAuthTokenResponse);
+
+	const drive = google.drive({ version: 'v3', auth: oAuth2Client });
+	const docs = google.docs({ version: 'v1', auth: oAuth2Client });
+
+	const folderId = await createTranscriptFolder(
+		drive,
+		'Guardian Transcribe Tool',
+	);
+	if (folderId) {
+		const docId = await uploadToGoogleDocs(
+			drive,
+			docs,
+			folderId,
+			fileName,
+			transcriptText,
+		);
+		return docId;
+	}
+	return null;
+};

--- a/packages/backend-common/src/configHelpers.ts
+++ b/packages/backend-common/src/configHelpers.ts
@@ -21,7 +21,6 @@ export const getParameters = async (
 					NextToken: nextToken,
 				});
 			if (data.Parameters) {
-				console.log('Paramaters have been fetched');
 				parameters = parameters.concat(data.Parameters);
 			}
 			nextToken = data.NextToken;

--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -72,6 +72,6 @@ export const getTranscriptionItem = async (
 		return result.Item;
 	} catch (error) {
 		console.error(`Failed to get item ${itemId} from dynamodb`, error);
-		throw error;
+		return null;
 	}
 };

--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -72,6 +72,6 @@ export const getTranscriptionItem = async (
 		return result.Item;
 	} catch (error) {
 		console.error(`Failed to get item ${itemId} from dynamodb`, error);
-		return null;
+		return undefined;
 	}
 };

--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -1,5 +1,9 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { PutCommand, DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+	PutCommand,
+	DynamoDBDocumentClient,
+	GetCommand,
+} from '@aws-sdk/lib-dynamodb';
 
 import { z } from 'zod';
 
@@ -48,6 +52,26 @@ export const writeTranscriptionItem = async (
 		console.log(`saved to db item ${item.id}`);
 	} catch (error) {
 		console.error('error writing to db', error);
+		throw error;
+	}
+};
+
+export const getTranscriptionItem = async (
+	client: DynamoDBDocumentClient,
+	tableName: string,
+	itemId: string,
+) => {
+	const command = new GetCommand({
+		TableName: tableName,
+		Key: {
+			id: itemId,
+		},
+	});
+	try {
+		const result = await client.send(command);
+		return result.Item;
+	} catch (error) {
+		console.error(`Failed to get item ${itemId} from dynamodb`, error);
 		throw error;
 	}
 };

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -379,6 +379,7 @@ export class TranscriptionService extends GuStack {
 		);
 
 		transcriptTable.grantReadWriteData(outputHandlerLambda);
+		transcriptTable.grantReadWriteData(apiLambda);
 
 		const transcriptionOutputQueue = new Queue(
 			this,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -20,6 +20,7 @@
 		"@types/node": "^20",
 		"@types/react": "^18",
 		"@types/react-dom": "^18",
+		"@types/google.accounts": "0.0.14",
 		"autoprefixer": "^10.0.1",
 		"postcss": "^8",
 		"tailwindcss": "^3.3.0",

--- a/packages/client/src/app/about/page.tsx
+++ b/packages/client/src/app/about/page.tsx
@@ -1,9 +1,0 @@
-import React from "react";
-
-const About = () => {
-    return (
-        <div>About page</div>
-    )
-}
-
-export default About;

--- a/packages/client/src/app/export/page.tsx
+++ b/packages/client/src/app/export/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+import React from 'react';
+import ExportButton from '@/components/ExportButton';
+
+const Export = () => {
+	return (
+		<div>
+			<h2>Export transcript</h2>
+			<ExportButton />
+		</div>
+	);
+};
+
+export default Export;

--- a/packages/client/src/app/page.tsx
+++ b/packages/client/src/app/page.tsx
@@ -8,7 +8,7 @@ const Home = () => {
 	const auth = useContext(AuthContext);
 	return (
 		<div>
-			<h2>This is home page</h2>
+			<h2>Upload file for transcribing</h2>
 			<UploadForm auth={auth}></UploadForm>
 		</div>
 	);

--- a/packages/client/src/app/page.tsx
+++ b/packages/client/src/app/page.tsx
@@ -1,15 +1,11 @@
 'use client';
 import React from 'react';
 import { UploadForm } from '../components/UploadForm';
-import { useContext } from 'react';
-import { AuthContext } from './template';
-
 const Home = () => {
-	const auth = useContext(AuthContext);
 	return (
 		<div>
 			<h2>Upload file for transcribing</h2>
-			<UploadForm auth={auth}></UploadForm>
+			<UploadForm></UploadForm>
 		</div>
 	);
 };

--- a/packages/client/src/app/template.tsx
+++ b/packages/client/src/app/template.tsx
@@ -7,7 +7,7 @@ import { AuthState } from '@/types';
 import { createContext } from 'react';
 
 export const authExpiryCheckPeriodInSeconds = 30;
-export const AuthContext = createContext({});
+export const AuthContext: React.Context<AuthState> = createContext({});
 
 export default function Template({ children }: { children: React.ReactNode }) {
 	const [auth, setAuth] = useState<AuthState>(initialState);

--- a/packages/client/src/components/ExportButton.tsx
+++ b/packages/client/src/components/ExportButton.tsx
@@ -9,7 +9,7 @@ import { AuthContext } from '@/app/template';
 import Script from 'next/script';
 import { useSearchParams } from 'next/navigation';
 
-const getClientConfig = async (authToken?: string): Promise<ClientConfig> => {
+const getClientConfig = async (authToken: string): Promise<ClientConfig> => {
 	const configResp = await authFetch('/api/client-config', authToken);
 	if (!configResp) {
 		throw new Error('Failed to fetch client config');
@@ -51,7 +51,7 @@ const promiseInitTokenClient = (
 };
 
 const exportTranscript = async (
-	authToken: string | undefined,
+	authToken: string,
 	transcriptId: string,
 ): Promise<Response | null> => {
 	const config = await getClientConfig(authToken);
@@ -89,8 +89,9 @@ const ExportButton = () => {
 	const searchParams = useSearchParams();
 	const [docId, setDocId] = useState<string | undefined>(undefined);
 	const [loading, setLoading] = useState(false);
-	if (!auth.token) {
-		return <p>Cannot export -missing auth token</p>;
+	const token = auth.token;
+	if (!token) {
+		return <p>Cannot export - missing auth token</p>;
 	}
 	const transcriptId = searchParams.get('transcriptId');
 	if (!transcriptId) {
@@ -112,7 +113,7 @@ const ExportButton = () => {
 			<button
 				onClick={async () => {
 					setLoading(true);
-					const response = await exportTranscript(auth.token, transcriptId);
+					const response = await exportTranscript(token, transcriptId);
 					setLoading(false);
 					const parsedResponse = ExportResponse.safeParse(response);
 					if (parsedResponse.success) {

--- a/packages/client/src/components/ExportButton.tsx
+++ b/packages/client/src/components/ExportButton.tsx
@@ -1,0 +1,132 @@
+import React, { useContext, useState } from 'react';
+import { authFetch } from '@/helpers';
+import {
+	ClientConfig,
+	ExportResponse,
+	TranscriptExportRequest,
+} from '@guardian/transcription-service-common';
+import { AuthContext } from '@/app/template';
+import Script from 'next/script';
+import { useSearchParams } from 'next/navigation';
+
+const getClientConfig = async (authToken?: string): Promise<ClientConfig> => {
+	const configResp = await authFetch('/api/client-config', authToken);
+	if (!configResp) {
+		throw new Error('Failed to fetch client config');
+	}
+	const configJson = await configResp.json();
+	const parseResult = ClientConfig.safeParse(configJson);
+	if (!parseResult.success) {
+		throw new Error(
+			`Failed to parse client config, ${parseResult.error.message}`,
+		);
+	}
+	return parseResult.data;
+};
+const promiseInitTokenClient = (
+	clientId: string,
+	scope: string,
+): Promise<google.accounts.oauth2.TokenResponse> => {
+	return new Promise((resolve, reject) => {
+		const client = google.accounts.oauth2.initTokenClient({
+			client_id: clientId,
+			scope,
+			callback: (tokenResponse: google.accounts.oauth2.TokenResponse) => {
+				if (!google.accounts.oauth2.hasGrantedAllScopes(tokenResponse, scope)) {
+					const msg = "User didn't grant drive permissions.";
+					console.error(msg);
+					return reject(msg);
+				}
+				resolve(tokenResponse);
+			},
+			error_callback: (error: google.accounts.oauth2.ClientConfigError) => {
+				const msg = `Error fetching google auth token: ${error.message}`;
+				console.error(msg);
+				return reject(msg);
+			},
+		});
+		// we have to actually call this otherwise the above promise will never resolve
+		client.requestAccessToken();
+	});
+};
+
+const exportTranscript = async (
+	authToken: string | undefined,
+	transcriptId: string,
+): Promise<Response | null> => {
+	const config = await getClientConfig(authToken);
+	if (config === null) {
+		throw Error('Client config unavailable. Cannot authenticate with Google');
+	}
+
+	const driveFileScope = 'https://www.googleapis.com/auth/drive.file';
+
+	const tokenResponse = await promiseInitTokenClient(
+		config.googleClientId,
+		driveFileScope,
+	);
+
+	// the return type from google doesn't actually respect the TokenResponse interface. Our zod type is more accurate, so
+	// we have to ts-ignore here
+	const exportRequest: TranscriptExportRequest = {
+		id: transcriptId,
+		// @ts-ignore
+		oAuthTokenResponse: tokenResponse,
+	};
+
+	const exportResponse = await authFetch('/api/export', authToken, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify(exportRequest),
+	});
+	if (exportResponse) {
+		return exportResponse.json();
+	}
+	return null;
+};
+const ExportButton = () => {
+	const auth = useContext(AuthContext);
+	const searchParams = useSearchParams();
+	const [docId, setDocId] = useState<string | undefined>(undefined);
+	const [loading, setLoading] = useState(false);
+	if (!auth.token) {
+		return <p>Cannot export -missing auth token</p>;
+	}
+	const transcriptId = searchParams.get('transcriptId');
+	if (!transcriptId) {
+		return <p>Cannot export -missing transcript id</p>;
+	}
+	if (loading) {
+		return 'exporting....';
+	}
+	if (docId) {
+		return (
+			<a href={`https://docs.google.com/document/d/${docId}`} target={'_blank'}>
+				View transcript
+			</a>
+		);
+	}
+	return (
+		<>
+			<Script src="https://accounts.google.com/gsi/client" async></Script>
+			<button
+				onClick={async () => {
+					setLoading(true);
+					const response = await exportTranscript(auth.token, transcriptId);
+					setLoading(false);
+					const parsedResponse = ExportResponse.safeParse(response);
+					if (parsedResponse.success) {
+						console.log('setting doc id');
+						setDocId(parsedResponse.data.documentId);
+					}
+				}}
+			>
+				export
+			</button>
+		</>
+	);
+};
+
+export default ExportButton;

--- a/packages/client/src/components/ExportButton.tsx
+++ b/packages/client/src/components/ExportButton.tsx
@@ -70,7 +70,7 @@ const exportTranscript = async (
 	// we have to ts-ignore here
 	const exportRequest: TranscriptExportRequest = {
 		id: transcriptId,
-		// @ts-ignore
+		// @ts-expect-error
 		oAuthTokenResponse: tokenResponse,
 	};
 

--- a/packages/client/src/components/ExportButton.tsx
+++ b/packages/client/src/components/ExportButton.tsx
@@ -66,11 +66,9 @@ const exportTranscript = async (
 		driveFileScope,
 	);
 
-	// the return type from google doesn't actually respect the TokenResponse interface. Our zod type is more accurate, so
-	// we have to ts-ignore here
 	const exportRequest: TranscriptExportRequest = {
 		id: transcriptId,
-		// @ts-expect-error
+		// @ts-expect-error (return object from google isn't actually a TokenResponse, our zod type is more accurate)
 		oAuthTokenResponse: tokenResponse,
 	};
 

--- a/packages/client/src/components/ExportButton.tsx
+++ b/packages/client/src/components/ExportButton.tsx
@@ -1,95 +1,17 @@
 import React, { useContext, useState } from 'react';
-import { authFetch } from '@/helpers';
-import {
-	ClientConfig,
-	ExportResponse,
-	TranscriptExportRequest,
-} from '@guardian/transcription-service-common';
+import { ExportResponse } from '@guardian/transcription-service-common';
 import { AuthContext } from '@/app/template';
 import Script from 'next/script';
 import { useSearchParams } from 'next/navigation';
+import { exportTranscript } from '@/services/export';
 
-const getClientConfig = async (authToken: string): Promise<ClientConfig> => {
-	const configResp = await authFetch('/api/client-config', authToken);
-	if (!configResp) {
-		throw new Error('Failed to fetch client config');
-	}
-	const configJson = await configResp.json();
-	const parseResult = ClientConfig.safeParse(configJson);
-	if (!parseResult.success) {
-		throw new Error(
-			`Failed to parse client config, ${parseResult.error.message}`,
-		);
-	}
-	return parseResult.data;
-};
-const promiseInitTokenClient = (
-	clientId: string,
-	scope: string,
-): Promise<google.accounts.oauth2.TokenResponse> => {
-	return new Promise((resolve, reject) => {
-		const client = google.accounts.oauth2.initTokenClient({
-			client_id: clientId,
-			scope,
-			callback: (tokenResponse: google.accounts.oauth2.TokenResponse) => {
-				if (!google.accounts.oauth2.hasGrantedAllScopes(tokenResponse, scope)) {
-					const msg = "User didn't grant drive permissions.";
-					console.error(msg);
-					return reject(msg);
-				}
-				resolve(tokenResponse);
-			},
-			error_callback: (error: google.accounts.oauth2.ClientConfigError) => {
-				const msg = `Error fetching google auth token: ${error.message}`;
-				console.error(msg);
-				return reject(msg);
-			},
-		});
-		// we have to actually call this otherwise the above promise will never resolve
-		client.requestAccessToken();
-	});
-};
-
-const exportTranscript = async (
-	authToken: string,
-	transcriptId: string,
-): Promise<Response | null> => {
-	const config = await getClientConfig(authToken);
-	if (config === null) {
-		throw Error('Client config unavailable. Cannot authenticate with Google');
-	}
-
-	const driveFileScope = 'https://www.googleapis.com/auth/drive.file';
-
-	const tokenResponse = await promiseInitTokenClient(
-		config.googleClientId,
-		driveFileScope,
-	);
-
-	const exportRequest: TranscriptExportRequest = {
-		id: transcriptId,
-		// @ts-expect-error (return object from google isn't actually a TokenResponse, our zod type is more accurate)
-		oAuthTokenResponse: tokenResponse,
-	};
-
-	const exportResponse = await authFetch('/api/export', authToken, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify(exportRequest),
-	});
-	if (exportResponse) {
-		return exportResponse.json();
-	}
-	return null;
-};
 const ExportButton = () => {
 	const auth = useContext(AuthContext);
 	const searchParams = useSearchParams();
 	const [docId, setDocId] = useState<string | undefined>(undefined);
 	const [loading, setLoading] = useState(false);
 	const token = auth.token;
+	// TODO: once we have some CSS/component library, tidy up this messy error handling
 	if (!token) {
 		return <p>Cannot export - missing auth token</p>;
 	}
@@ -117,7 +39,6 @@ const ExportButton = () => {
 					setLoading(false);
 					const parsedResponse = ExportResponse.safeParse(response);
 					if (parsedResponse.success) {
-						console.log('setting doc id');
 						setDocId(parsedResponse.data.documentId);
 					}
 				}}

--- a/packages/client/src/components/ExportButton.tsx
+++ b/packages/client/src/components/ExportButton.tsx
@@ -8,11 +8,9 @@ import { exportTranscript } from '@/services/export';
 const ExportButton = () => {
 	const auth = useContext(AuthContext);
 	const searchParams = useSearchParams();
-	const [docId, setDocId] = useState<string | undefined>(undefined);
+	const [docId, setDocId] = useState<string | undefined>();
 	const [loading, setLoading] = useState(false);
-	const [exportFailed, setExportFailed] = useState<string | undefined>(
-		undefined,
-	);
+	const [exportFailed, setExportFailed] = useState<string | undefined>();
 	const token = auth.token;
 	// TODO: once we have some CSS/component library, tidy up this messy error handling
 	if (!token) {

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -20,6 +20,10 @@ const uploadToS3 = async (url: string, blob: Blob) => {
 export const UploadForm = ({ auth }: { auth: AuthState }) => {
 	const [status, setStatus] = useState<boolean | undefined>(undefined);
 
+	if (!auth.token) {
+		return 'Missing auth token';
+	}
+
 	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 
@@ -41,6 +45,10 @@ export const UploadForm = ({ auth }: { auth: AuthState }) => {
 			`/signedUrl?${urlParams.toString()}`,
 			auth.token,
 		);
+		if (!response) {
+			console.error('Failed to fetch signed url');
+			return;
+		}
 
 		const body = SignedUrlResponseBody.safeParse(await response.json());
 		if (!body.success) {

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -1,7 +1,7 @@
 import { authFetch } from '@/helpers';
-import { AuthState } from '@/types';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { SignedUrlResponseBody } from '@guardian/transcription-service-common';
+import { AuthContext } from '@/app/template';
 
 const uploadToS3 = async (url: string, blob: Blob) => {
 	try {
@@ -17,11 +17,13 @@ const uploadToS3 = async (url: string, blob: Blob) => {
 	}
 };
 
-export const UploadForm = ({ auth }: { auth: AuthState }) => {
+export const UploadForm = () => {
 	const [status, setStatus] = useState<boolean | undefined>(undefined);
+	const auth = useContext(AuthContext);
+	const token = auth.token;
 
-	if (!auth.token) {
-		return 'Missing auth token';
+	if (!token) {
+		return <p>Cannot upload - missing auth token</p>;
 	}
 
 	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -43,7 +45,7 @@ export const UploadForm = ({ auth }: { auth: AuthState }) => {
 		const urlParams = new URLSearchParams({ fileName: file.name });
 		const response = await authFetch(
 			`/signedUrl?${urlParams.toString()}`,
-			auth.token,
+			token,
 		);
 		if (!response) {
 			console.error('Failed to fetch signed url');

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -44,7 +44,7 @@ export const UploadForm = () => {
 
 		const urlParams = new URLSearchParams({ fileName: file.name });
 		const response = await authFetch(
-			`/signedUrl?${urlParams.toString()}`,
+			`/api/signedUrl?${urlParams.toString()}`,
 			token,
 		);
 		if (!response) {

--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -1,12 +1,8 @@
 export const authFetch = async (
 	url: string,
-	token?: string,
+	token: string,
 	init?: RequestInit,
-): Promise<Response | null> => {
-	if (!token) {
-		console.error('Missing auth token');
-		return null;
-	}
+): Promise<Response> => {
 	const request = new Request(url, init);
 
 	request.headers.set('Authorization', `Bearer ${token}`);
@@ -15,6 +11,5 @@ export const authFetch = async (
 		headers: request.headers,
 	});
 
-	const res = await fetch(authRequest);
-	return res;
+	return await fetch(authRequest);
 };

--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -1,7 +1,29 @@
-export const authFetch = async (url: string, token?: string) => {
-	return await fetch(`api/${url}`, {
-		headers: {
-			Authorization: `Bearer ${token}`,
-		},
+// export const authFetch = async (url: string, token?: string) => {
+// 	return await fetch(`api/${url}`, {
+// 		headers: {
+// 			Authorization: `Bearer ${token}`,
+// 		},
+// 	});
+// };
+
+export const authFetch = async (
+	url: string,
+	token?: string,
+	init?: RequestInit,
+): Promise<Response | null> => {
+	console.log('lets go');
+	if (!token) {
+		console.error('Missing auth token');
+		return null;
+	}
+	const request = new Request(url, init);
+
+	request.headers.set('Authorization', `Bearer ${token}`);
+
+	const authRequest = new Request(request, {
+		headers: request.headers,
 	});
+
+	const res = await fetch(authRequest);
+	return res;
 };

--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -4,12 +4,7 @@ export const authFetch = async (
 	init?: RequestInit,
 ): Promise<Response> => {
 	const request = new Request(url, init);
-
 	request.headers.set('Authorization', `Bearer ${token}`);
 
-	const authRequest = new Request(request, {
-		headers: request.headers,
-	});
-
-	return await fetch(authRequest);
+	return await fetch(request);
 };

--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -1,17 +1,8 @@
-// export const authFetch = async (url: string, token?: string) => {
-// 	return await fetch(`api/${url}`, {
-// 		headers: {
-// 			Authorization: `Bearer ${token}`,
-// 		},
-// 	});
-// };
-
 export const authFetch = async (
 	url: string,
 	token?: string,
 	init?: RequestInit,
 ): Promise<Response | null> => {
-	console.log('lets go');
 	if (!token) {
 		console.error('Missing auth token');
 		return null;

--- a/packages/client/src/services/export.ts
+++ b/packages/client/src/services/export.ts
@@ -60,6 +60,7 @@ export const exportTranscript = async (
 
 	const exportRequest: TranscriptExportRequest = {
 		id: transcriptId,
+		// @ts-expect-error (return object from google isn't actually a TokenResponse, our zod type is more accurate)
 		oAuthTokenResponse: tokenResponse,
 	};
 

--- a/packages/client/src/services/export.ts
+++ b/packages/client/src/services/export.ts
@@ -48,11 +48,8 @@ const promiseInitTokenClient = (
 export const exportTranscript = async (
 	authToken: string,
 	transcriptId: string,
-): Promise<Response | null> => {
+): Promise<Response> => {
 	const config = await getClientConfig(authToken);
-	if (config === null) {
-		throw Error('Client config unavailable. Cannot authenticate with Google');
-	}
 
 	const driveFileScope = 'https://www.googleapis.com/auth/drive.file';
 
@@ -63,7 +60,6 @@ export const exportTranscript = async (
 
 	const exportRequest: TranscriptExportRequest = {
 		id: transcriptId,
-		// @ts-expect-error (return object from google isn't actually a TokenResponse, our zod type is more accurate)
 		oAuthTokenResponse: tokenResponse,
 	};
 
@@ -74,8 +70,5 @@ export const exportTranscript = async (
 		},
 		body: JSON.stringify(exportRequest),
 	});
-	if (exportResponse) {
-		return exportResponse.json();
-	}
-	return null;
+	return exportResponse;
 };

--- a/packages/client/src/services/export.ts
+++ b/packages/client/src/services/export.ts
@@ -1,0 +1,81 @@
+import {
+	ClientConfig,
+	TranscriptExportRequest,
+} from '@guardian/transcription-service-common';
+import { authFetch } from '@/helpers';
+
+const getClientConfig = async (authToken: string): Promise<ClientConfig> => {
+	const configResp = await authFetch('/api/client-config', authToken);
+	if (!configResp) {
+		throw new Error('Failed to fetch client config');
+	}
+	const configJson = await configResp.json();
+	const parseResult = ClientConfig.safeParse(configJson);
+	if (!parseResult.success) {
+		throw new Error(
+			`Failed to parse client config, ${parseResult.error.message}`,
+		);
+	}
+	return parseResult.data;
+};
+const promiseInitTokenClient = (
+	clientId: string,
+	scope: string,
+): Promise<google.accounts.oauth2.TokenResponse> => {
+	return new Promise((resolve, reject) => {
+		const client = google.accounts.oauth2.initTokenClient({
+			client_id: clientId,
+			scope,
+			callback: (tokenResponse: google.accounts.oauth2.TokenResponse) => {
+				if (!google.accounts.oauth2.hasGrantedAllScopes(tokenResponse, scope)) {
+					const msg = "User didn't grant drive permissions.";
+					console.error(msg);
+					return reject(msg);
+				}
+				resolve(tokenResponse);
+			},
+			error_callback: (error: google.accounts.oauth2.ClientConfigError) => {
+				const msg = `Error fetching google auth token: ${error.message}`;
+				console.error(msg);
+				return reject(msg);
+			},
+		});
+		// we have to actually call this otherwise the above promise will never resolve
+		client.requestAccessToken();
+	});
+};
+
+export const exportTranscript = async (
+	authToken: string,
+	transcriptId: string,
+): Promise<Response | null> => {
+	const config = await getClientConfig(authToken);
+	if (config === null) {
+		throw Error('Client config unavailable. Cannot authenticate with Google');
+	}
+
+	const driveFileScope = 'https://www.googleapis.com/auth/drive.file';
+
+	const tokenResponse = await promiseInitTokenClient(
+		config.googleClientId,
+		driveFileScope,
+	);
+
+	const exportRequest: TranscriptExportRequest = {
+		id: transcriptId,
+		// @ts-expect-error (return object from google isn't actually a TokenResponse, our zod type is more accurate)
+		oAuthTokenResponse: tokenResponse,
+	};
+
+	const exportResponse = await authFetch('/api/export', authToken, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify(exportRequest),
+	});
+	if (exportResponse) {
+		return exportResponse.json();
+	}
+	return null;
+};

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -33,3 +33,42 @@ export const SignedUrlResponseBody = z.object({
 	presignedS3Url: z.string(),
 });
 export type SignedUrlResponseBody = z.infer<typeof SignedUrlResponseBody>;
+
+export const ClientConfig = z.object({
+	googleClientId: z.string(),
+});
+
+export type ClientConfig = z.infer<typeof ClientConfig>;
+
+// this type is Zod version of the TokenResponse interface in the google oauth2 library - to understand what the
+// different properties mean check that library. We duplicate it here just to get nice zod parsing
+// I was hoping we could at least get the typechecker to tell us if we missed a property or use the wrong type for
+// a property of TokenResponse by setting the type as z.ZodType<google.accounts.oauth2.TokenResponse> - but it looks like
+// the returned TokenResponse doesn't actually respect the TokenResponse type
+export const ZTokenResponse = z.object({
+	access_token: z.string(),
+	expires_in: z.number(),
+	hd: z.string(),
+	prompt: z.string(),
+	token_type: z.string(),
+	scope: z.string(),
+	state: z.optional(z.string()),
+	error: z.optional(z.string()),
+	error_description: z.optional(z.string()),
+	error_uri: z.optional(z.string()),
+});
+
+export type ZTokenResponse = z.infer<typeof ZTokenResponse>;
+
+export const TranscriptExportRequest = z.object({
+	id: z.string(),
+	oAuthTokenResponse: ZTokenResponse,
+});
+
+export type TranscriptExportRequest = z.infer<typeof TranscriptExportRequest>;
+
+export const ExportResponse = z.object({
+	documentId: z.string(),
+});
+
+export type ExportResponse = z.infer<typeof ExportResponse>;

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -11,7 +11,6 @@ import { testMessage } from '../test/testMessage';
 
 const messageBody = (
 	transcriptId: string,
-	transcript: string,
 	originalFilename: string,
 	rootUrl: string,
 ): string => {
@@ -19,11 +18,6 @@ const messageBody = (
 	return `
 		<h1>Transcript for ${originalFilename} ready</h1>
 		<p>Click <a href="${exportUrl}">here</a> to export to a google doc.</p>
-		<h2>Transcript</h2>
-		${transcript
-			.split('\n')
-			.map((line) => `<p>${line}</p>`)
-			.join('')}
 	`;
 };
 
@@ -64,7 +58,6 @@ const processMessage = async (event: unknown) => {
 			transcriptionOutput.originalFilename,
 			messageBody(
 				transcriptionOutput.id,
-				transcriptionOutput.transcriptionSrt,
 				transcriptionOutput.originalFilename,
 				config.app.rootUrl,
 			),

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -15,7 +15,7 @@ const messageBody = (
 	originalFilename: string,
 	rootUrl: string,
 ): string => {
-	const exportUrl = `${rootUrl}/export/${transcriptId}`;
+	const exportUrl = `${rootUrl}/export?transcriptId=${transcriptId}`;
 	return `
 		<h1>Transcript for ${originalFilename} ready</h1>
 		<p>Click <a href="${exportUrl}">here</a> to export to a google doc.</p>


### PR DESCRIPTION
## What does this change?
The main aim here is to allow users to export a transcript to a google doc. This involves the following features:
Client:
 - A new 'Export' page. This is the first React page that we have that is not just index.html. The way Next.js works is that it creates a separate page.html file for each page. As such I have had to update the production handler for client side pages -previously we always just returned index.html
 - A new 'ExportButton' component to handle export, waiting for an export, and linking to the generated google doc
 - `export.ts` service on the client which handles authentication with google to get permsissions to write to google drive
 - I've refactored `authFetch` to allow the entire request object to be overridden

Server:
 - A new /export endpoint to trigger the export and handle all the various error cases by returning an error with an appropriate status code
 - `googleDrive.ts` - this takes the authentication token shared by the client and uses it to actually create files in google drive
 - A new 'getTranscriptionItem' function to read values from dynamodb
 - Modification to how we serve the client side app - as discussed in the first point above

## How to test
You should be able to deploy to CODE/PROD and then use the test event on the output handler lambda (change the userEmail field) to get an email sent to you with a working export link.

Alternatively locally, you can run `npm run output-handler::start` to get a dummy item into your dynamodb table which you can then use to test the export on https://transcribe.local.dev-gutools.co.uk/export?transcriptId=my-first-transcription


![export](https://freeagent-res.cloudinary.com/image/upload/c_limit,w_1200/dpr_auto,f_auto/website-images/netlify/blog__export-data__export-data-og.gif)