### PR TITLE
Add failure metric to worker and output-handler services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 **.js
 localstack/
 **/package-lock.json
+**.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -686,6 +686,513 @@
 				}
 			}
 		},
+		"node_modules/@aws-sdk/client-cloudwatch": {
+			"version": "3.512.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.512.0.tgz",
+			"integrity": "sha512-GW3xxLHGF4WIMBzeRR0F1+JDjtAdRxQc6DFO4PCRTsKqBB6D7SQ4pMnNbvPxZX+XZrFngMsRVt357jPgKyujoQ==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.511.0",
+				"@aws-sdk/core": "3.511.0",
+				"@aws-sdk/credential-provider-node": "3.511.0",
+				"@aws-sdk/middleware-host-header": "3.511.0",
+				"@aws-sdk/middleware-logger": "3.511.0",
+				"@aws-sdk/middleware-recursion-detection": "3.511.0",
+				"@aws-sdk/middleware-signing": "3.511.0",
+				"@aws-sdk/middleware-user-agent": "3.511.0",
+				"@aws-sdk/region-config-resolver": "3.511.0",
+				"@aws-sdk/types": "3.511.0",
+				"@aws-sdk/util-endpoints": "3.511.0",
+				"@aws-sdk/util-user-agent-browser": "3.511.0",
+				"@aws-sdk/util-user-agent-node": "3.511.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-compression": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"@smithy/util-waiter": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/client-sso": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.511.0.tgz",
+			"integrity": "sha512-v1f5ZbuZWpad+fgTOpgFyIZT3A37wdqoSPh0hl+cKRu5kPsz96xCe9+UvLx+HdN2yJ/mV0UZcMq6ysj4xAGIEg==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.511.0",
+				"@aws-sdk/middleware-host-header": "3.511.0",
+				"@aws-sdk/middleware-logger": "3.511.0",
+				"@aws-sdk/middleware-recursion-detection": "3.511.0",
+				"@aws-sdk/middleware-user-agent": "3.511.0",
+				"@aws-sdk/region-config-resolver": "3.511.0",
+				"@aws-sdk/types": "3.511.0",
+				"@aws-sdk/util-endpoints": "3.511.0",
+				"@aws-sdk/util-user-agent-browser": "3.511.0",
+				"@aws-sdk/util-user-agent-node": "3.511.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.511.0.tgz",
+			"integrity": "sha512-cITRRq54eTrq7ll9li+yYnLbNHKXG2P+ovdZSDiQ6LjCYBdcD4ela30qbs87Yye9YsopdslDzBhHHtrf5oiuMw==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.511.0",
+				"@aws-sdk/core": "3.511.0",
+				"@aws-sdk/middleware-host-header": "3.511.0",
+				"@aws-sdk/middleware-logger": "3.511.0",
+				"@aws-sdk/middleware-recursion-detection": "3.511.0",
+				"@aws-sdk/middleware-signing": "3.511.0",
+				"@aws-sdk/middleware-user-agent": "3.511.0",
+				"@aws-sdk/region-config-resolver": "3.511.0",
+				"@aws-sdk/types": "3.511.0",
+				"@aws-sdk/util-endpoints": "3.511.0",
+				"@aws-sdk/util-user-agent-browser": "3.511.0",
+				"@aws-sdk/util-user-agent-node": "3.511.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.511.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/client-sts": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.511.0.tgz",
+			"integrity": "sha512-lwVEEXK+1auEwmBuTv35m2GvbxPthi8SjNUpU4pRetZPVbGhnhCN6H7JqeMDP6GLf81Io2eySXRsmLMt7l/fjg==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.511.0",
+				"@aws-sdk/middleware-host-header": "3.511.0",
+				"@aws-sdk/middleware-logger": "3.511.0",
+				"@aws-sdk/middleware-recursion-detection": "3.511.0",
+				"@aws-sdk/middleware-user-agent": "3.511.0",
+				"@aws-sdk/region-config-resolver": "3.511.0",
+				"@aws-sdk/types": "3.511.0",
+				"@aws-sdk/util-endpoints": "3.511.0",
+				"@aws-sdk/util-user-agent-browser": "3.511.0",
+				"@aws-sdk/util-user-agent-node": "3.511.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.1",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.1.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.511.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/core": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.511.0.tgz",
+			"integrity": "sha512-0gbDvQhToyLxPyr/7KP6uavrBYKh7exld2lju1Lp65U61XgEjTVP/thJmHTvH4BAKGSqeIz/rrwJ0KrC8nwBtw==",
+			"dependencies": {
+				"@smithy/core": "^1.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/signature-v4": "^2.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.511.0.tgz",
+			"integrity": "sha512-4VUsnLRox8YzxnZwnFrfZM4bL5KKLhsjjjX7oiuLyzFkhauI4HFYt7rTB8YNGphpqAg/Wzw5DBZfO3Bw1iR1HA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.511.0.tgz",
+			"integrity": "sha512-y83Gt8GPpgMe/lMFxIq+0G2rbzLTC6lhrDocHUzqcApLD6wet8Esy2iYckSRlJgYY+qsVAzpLrSMtt85DwRPTw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-stream": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.511.0.tgz",
+			"integrity": "sha512-AgIOCtYzm61jbTQCY/2Vf/yu7DeLG0TLZa05a3VVRN9XE4ERtEnMn7TdbxM+hS24MTX8xI0HbMcWxCBkXRIg9w==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.511.0",
+				"@aws-sdk/credential-provider-env": "3.511.0",
+				"@aws-sdk/credential-provider-process": "3.511.0",
+				"@aws-sdk/credential-provider-sso": "3.511.0",
+				"@aws-sdk/credential-provider-web-identity": "3.511.0",
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.511.0.tgz",
+			"integrity": "sha512-5JDZXsSluliJmxOF+lYYFgJdSKQfVLQyic5NxScHULTERGoEwEHMgucFGwJ9MV9FoINjNTQLfAiWlJL/kGkCEQ==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.511.0",
+				"@aws-sdk/credential-provider-http": "3.511.0",
+				"@aws-sdk/credential-provider-ini": "3.511.0",
+				"@aws-sdk/credential-provider-process": "3.511.0",
+				"@aws-sdk/credential-provider-sso": "3.511.0",
+				"@aws-sdk/credential-provider-web-identity": "3.511.0",
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.511.0.tgz",
+			"integrity": "sha512-88hLUPqcTwjSubPS+34ZfmglnKeLny8GbmZsyllk96l26PmDTAqo5RScSA8BWxL0l5pRRWGtcrFyts+oibHIuQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.511.0.tgz",
+			"integrity": "sha512-aEei9UdXYEE2e0Htf28/IcuHcWk3VkUkpcg3KDR/AyzXA3i/kxmixtAgRmHOForC5CMqoJjzVPFUITNkAscyag==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.511.0",
+				"@aws-sdk/token-providers": "3.511.0",
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.511.0.tgz",
+			"integrity": "sha512-/3XMyN7YYefAsES/sMMY5zZGRmZ5QJisJw798DdMYmYMsb1dt0Qy8kZTu+59ZzOiVIcznsjSTCEB81QmGtDKcA==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.511.0",
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.511.0.tgz",
+			"integrity": "sha512-DbBzQP/6woSHR/+g9dHN3YiYaLIqFw9u8lQFMxi3rT3hqITFVYLzzXtEaHjDD6/is56pNT84CIKbyJ6/gY5d1Q==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.511.0.tgz",
+			"integrity": "sha512-EYU9dBlJXvQcCsM2Tfgi0NQoXrqovfDv/fDy8oGJgZFrgNuHDti8tdVVxeJTUJNEAF67xlDl5o+rWEkKthkYGQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.511.0.tgz",
+			"integrity": "sha512-PlNPCV/6zpDVdNx1K69xDTh/wPNU4WyP4qa6hUo2/+4/PNG5HI9xbCWtpb4RjhdTRw6qDtkBNcPICHbtWx5aHg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-signing": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.511.0.tgz",
+			"integrity": "sha512-IMijFLfm+QQHD6NNDX9k3op9dpBSlWKnqjcMU38Tytl2nbqV4gktkarOK1exHAmH7CdoYR5BufVtBzbASNSF/A==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/signature-v4": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.511.0.tgz",
+			"integrity": "sha512-eLs+CxP2QCXh3tCGYCdAml3oyWj8MSIwKbH+8rKw0k/5vmY1YJDBy526whOxx61ivhz2e0muuijN4X5EZZ2Pnw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@aws-sdk/util-endpoints": "3.511.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.511.0.tgz",
+			"integrity": "sha512-RzBLSNaRd4iEkQyEGfiSNvSnWU/x23rsiFgA9tqYFA0Vqx7YmzSWC8QBUxpwybB8HkbbL9wNVKQqTbhI3mYneQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/token-providers": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.511.0.tgz",
+			"integrity": "sha512-92dXjMHBJcRoUkJHc0Bvtsz7Sal8t6VASRJ5vfs5c2ZpTVgLpVnM4dBmwUgGUdnvHov0cZTXbbadTJ/qOWx5Zw==",
+			"dependencies": {
+				"@aws-sdk/client-sso-oidc": "3.511.0",
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/types": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.511.0.tgz",
+			"integrity": "sha512-P03ufufxmkvd7nO46oOeEqYIMPJ8qMCKxAsfJk1JBVPQ1XctVntbail4/UFnrnzij8DTl4Mk/D62uGo7+RolXA==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.511.0.tgz",
+			"integrity": "sha512-J/5hsscJkg2pAOdLx1YKlyMCk5lFRxRxEtup9xipzOxVBlqOIE72Tuu31fbxSlF8XzO/AuCJcZL4m1v098K9oA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.511.0.tgz",
+			"integrity": "sha512-5LuESdwtIcA10aHcX7pde7aCIijcyTPBXFuXmFlDTgm/naAayQxelQDpvgbzuzGLgePf8eTyyhDKhzwPZ2EqiQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/types": "^2.9.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.511.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.511.0.tgz",
+			"integrity": "sha512-UopdlRvYY5mxlS4wwFv+QAWL6/T302wmoQj7i+RY+c/D3Ej3PKBb/mW3r2wEOgZLJmPpeeM1SYMk+rVmsW1rqw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.511.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@aws-sdk/client-dynamodb": {
 			"version": "3.509.0",
 			"license": "Apache-2.0",
@@ -5647,6 +6154,25 @@
 				"tslib": "^2.5.0"
 			}
 		},
+		"node_modules/@smithy/middleware-compression": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-2.1.1.tgz",
+			"integrity": "sha512-eLgIs2Y3YBk/xQPTyzTazhyXdnDlI0+xCBcSHbUNfpE/S0Ofd8pv/952szlJpc5soOvY00+sY3y3ROinLrhpkw==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"fflate": "0.8.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/@smithy/middleware-content-length": {
 			"version": "2.1.1",
 			"license": "Apache-2.0",
@@ -8989,6 +9515,11 @@
 			"dependencies": {
 				"bser": "2.1.1"
 			}
+		},
+		"node_modules/fflate": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
+			"integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ=="
 		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
@@ -14375,6 +14906,7 @@
 			"name": "@guardian/transcription-service-backend-common",
 			"version": "1.0.0",
 			"dependencies": {
+				"@aws-sdk/client-cloudwatch": "^3.496.0",
 				"@aws-sdk/client-dynamodb": "^3.509.0",
 				"@aws-sdk/client-s3": "^3.496.0",
 				"@aws-sdk/client-sqs": "^3.496.0",

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -6,7 +6,8 @@
 		"@aws-sdk/client-sqs": "^3.496.0",
 		"@aws-sdk/client-s3": "^3.496.0",
 		"@aws-sdk/client-dynamodb": "^3.509.0",
-		"@aws-sdk/lib-dynamodb": "^3.509.0"
+		"@aws-sdk/lib-dynamodb": "^3.509.0",
+		"@aws-sdk/client-cloudwatch": "^3.496.0"
 	},
 	"devDependencies": {},
 	"private": true,

--- a/packages/backend-common/src/cloudwatch.ts
+++ b/packages/backend-common/src/cloudwatch.ts
@@ -1,0 +1,21 @@
+import {
+	CloudWatchClient,
+	PutMetricDataCommand,
+	PutMetricDataInput,
+} from '@aws-sdk/client-cloudwatch';
+
+export const getCloudwatchClient = (region: string) => {
+	return new CloudWatchClient({ region });
+};
+
+export const putMetricData = async (
+	client: CloudWatchClient,
+	metricData: PutMetricDataInput,
+) => {
+	try {
+		await client.send(new PutMetricDataCommand(metricData));
+	} catch (error) {
+		console.error('Error writing to cloudwatch', error);
+		throw error;
+	}
+};

--- a/packages/backend-common/src/metrics.ts
+++ b/packages/backend-common/src/metrics.ts
@@ -5,8 +5,8 @@ type Metric = {
 	name: string;
 	unit: 'Count';
 };
-export const TranscriptionFailureMetric: Metric = {
-	name: 'TranscriptionFailure',
+export const FailureMetric: Metric = {
+	name: 'Failure',
 	unit: 'Count',
 };
 

--- a/packages/backend-common/src/metrics.ts
+++ b/packages/backend-common/src/metrics.ts
@@ -1,4 +1,7 @@
-import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import {
+	CloudWatchClient,
+	PutMetricDataInput,
+} from '@aws-sdk/client-cloudwatch';
 import { getCloudwatchClient, putMetricData } from './cloudwatch';
 
 type Metric = {
@@ -22,20 +25,20 @@ export class MetricsService {
 	}
 
 	async putMetric(metric: Metric) {
-		const metricData = {
+		const metricData: PutMetricDataInput = {
 			Namespace: `TranscriptionService`,
-			Dimensions: [
-				{
-					Name: 'Stage',
-					Value: this.stage,
-				},
-				{
-					Name: 'App',
-					Value: this.app,
-				},
-			],
 			MetricData: [
 				{
+					Dimensions: [
+						{
+							Name: 'Stage',
+							Value: this.stage,
+						},
+						{
+							Name: 'App',
+							Value: this.app,
+						},
+					],
 					MetricName: metric.name,
 					Value: 1,
 					Timestamp: new Date(),

--- a/packages/backend-common/src/metrics.ts
+++ b/packages/backend-common/src/metrics.ts
@@ -1,0 +1,47 @@
+import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import { getCloudwatchClient, putMetricData } from './cloudwatch';
+
+type Metric = {
+	name: string;
+	unit: 'Count';
+};
+export const TranscriptionFailureMetric: Metric = {
+	name: 'TranscriptionFailure',
+	unit: 'Count',
+};
+
+export class MetricsService {
+	private readonly cloudwatchClient: CloudWatchClient;
+	private readonly stage: string;
+	private readonly app: string;
+
+	constructor(stage: string, region: string, app: string) {
+		this.cloudwatchClient = getCloudwatchClient(region);
+		this.stage = stage;
+		this.app = app;
+	}
+
+	async putMetric(metric: Metric) {
+		const metricData = {
+			Namespace: `TranscriptionService`,
+			Dimensions: [
+				{
+					Name: 'Stage',
+					Value: this.stage,
+				},
+				{
+					Name: 'App',
+					Value: this.app,
+				},
+			],
+			MetricData: [
+				{
+					MetricName: metric.name,
+					Value: 1,
+					Timestamp: new Date(),
+				},
+			],
+		};
+		await putMetricData(this.cloudwatchClient, metricData);
+	}
+}

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -5,6 +5,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuAmiParameter",
+      "GuStringParameter",
       "GuCertificate",
       "GuS3Bucket",
       "GuS3Bucket",
@@ -25,12 +26,24 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       "GuGetDistributablePolicy",
       "GuParameterStoreReadPolicy",
       "GuVpcParameter",
+      "GuSecurityGroup",
       "GuSubnetListParameter",
       "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
   "Outputs": {
+    "WorkerRoleArn": {
+      "Export": {
+        "Name": "WorkerRoleArn",
+      },
+      "Value": {
+        "Fn::GetAtt": [
+          "InstanceRoleTranscriptionserviceworkerA8AC6615",
+          "Arn",
+        ],
+      },
+    },
     "transcriptionserviceapitranscriptionserviceTESTEndpointA34D5917": {
       "Value": {
         "Fn::Join": [
@@ -67,6 +80,11 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
     "LoggingStreamName": {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "S3PrefixListIdParameter": {
+      "Default": "/TEST/investigations/transcription-service/s3PrefixListId",
+      "Description": "ID of the managed prefix list for the S3 service. See https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-create-vpc.html",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "VpcId": {
@@ -563,9 +581,6 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
     "TranscriptionServiceOutputBucketTranscriptionservice35996ED2": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "AccelerateConfiguration": {
-          "AccelerationStatus": "Enabled",
-        },
         "BucketName": "transcription-service-output-test",
         "LifecycleConfiguration": {
           "Rules": [
@@ -665,6 +680,88 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
+    },
+    "TranscriptionServiceWorkerSGTranscriptionserviceworker6EE23C91": {
+      "Properties": {
+        "GroupDescription": "TranscriptionService/TranscriptionServiceWorkerSGTranscriptionserviceworker",
+        "SecurityGroupEgress": [
+          {
+            "Description": {
+              "Fn::Join": [
+                "",
+                [
+                  "from ",
+                  {
+                    "Fn::ImportValue": "internet-enabled-vpc-AWSEndpointSecurityGroup",
+                  },
+                  ":443",
+                ],
+              ],
+            },
+            "DestinationSecurityGroupId": {
+              "Fn::ImportValue": "internet-enabled-vpc-AWSEndpointSecurityGroup",
+            },
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "transcription-service-worker",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/transcription-service",
+          },
+          {
+            "Key": "Stack",
+            "Value": "investigations",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "TranscriptionServiceWorkerSGTranscriptionserviceworkertoIndirectPeer44380412F57": {
+      "Properties": {
+        "Description": {
+          "Fn::Join": [
+            "",
+            [
+              "to ",
+              {
+                "Ref": "S3PrefixListIdParameter",
+              },
+              ":443",
+            ],
+          ],
+        },
+        "DestinationPrefixListId": {
+          "Ref": "S3PrefixListIdParameter",
+        },
+        "FromPort": 443,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "TranscriptionServiceWorkerSGTranscriptionserviceworker6EE23C91",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 443,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "TranscriptionWorkerASGCAE69A98": {
       "Properties": {
@@ -776,6 +873,14 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
           "MetadataOptions": {
             "InstanceMetadataTags": "enabled",
           },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "TranscriptionServiceWorkerSGTranscriptionserviceworker6EE23C91",
+                "GroupId",
+              ],
+            },
+          ],
           "TagSpecifications": [
             {
               "ResourceType": "instance",

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -190,7 +190,14 @@ export class TranscriptionService extends GuStack {
 			resources: [`${ssmPrefix}/${ssmPath}/*`],
 		});
 
+		const putMetricDataPolicy = new PolicyStatement({
+			effect: Effect.ALLOW,
+			actions: ['cloudwatch:PutMetricData'],
+			resources: ['*'],
+		});
+
 		apiLambda.addToRolePolicy(getParametersPolicy);
+		apiLambda.addToRolePolicy(putMetricDataPolicy);
 
 		// The custom domain name mapped to this API
 		const apiDomain = apiLambda.api.domainName;
@@ -286,6 +293,10 @@ export class TranscriptionService extends GuStack {
 					resources: [
 						`arn:aws:autoscaling:${props.env.region}:${GuardianAwsAccounts.Investigations}:autoScalingGroup:*:autoScalingGroupName/${autoScalingGroupName}`,
 					],
+				}),
+				new GuAllowPolicy(this, 'WriteCloudwatch', {
+					actions: ['cloudwatch:PutMetricData'],
+					resources: ['*'],
 				}),
 			],
 		});
@@ -454,5 +465,6 @@ export class TranscriptionService extends GuStack {
 		);
 
 		outputHandlerLambda.addToRolePolicy(getParametersPolicy);
+		outputHandlerLambda.addToRolePolicy(putMetricDataPolicy);
 	}
 }

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -17,7 +17,7 @@ import { testMessage } from '../test/testMessage';
 import { type OutputBucketKeys } from '@guardian/transcription-service-common';
 import {
 	MetricsService,
-	TranscriptionFailureMetric,
+	FailureMetric,
 } from '@guardian/transcription-service-backend-common/src/metrics';
 
 const messageBody = (
@@ -132,7 +132,7 @@ const processMessage = async (event: unknown) => {
 				'Failed to process sqs message - transcription data may be missing from dynamo or email failed to send',
 				error,
 			);
-			await metrics.putMetric(TranscriptionFailureMetric);
+			await metrics.putMetric(FailureMetric);
 		}
 	}
 };

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -113,13 +113,10 @@ const processMessage = async (event: unknown) => {
 				dynamoItem,
 			);
 
-		await sendEmail(
-			sesClient,
-			config.app.emailNotificationFromAddress,
-			transcriptionOutput.userEmail,
-			transcriptionOutput.originalFilename,
-			messageBody(
-				transcriptionOutput.id,
+			await sendEmail(
+				sesClient,
+				config.app.emailNotificationFromAddress,
+				transcriptionOutput.userEmail,
 				transcriptionOutput.originalFilename,
 				messageBody(
 					transcriptionOutput.id,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -22,11 +22,21 @@ import path from 'path';
 
 import { updateScaleInProtection } from './asg';
 import { uploadAllTranscriptsToS3 } from './util';
+import {
+	MetricsService,
+	TranscriptionFailureMetric,
+} from '@guardian/transcription-service-backend-common/src/metrics';
 
 const main = async () => {
 	const config = await getConfig();
 	const stage = config.app.stage;
 	const region = config.aws.region;
+
+	const metrics = new MetricsService(
+		config.app.stage,
+		config.aws.region,
+		'worker',
+	);
 
 	const numberOfThreads = config.app.stage === 'PROD' ? 16 : 2;
 
@@ -54,6 +64,7 @@ const main = async () => {
 		const job = parseTranscriptJobMessage(message.message);
 
 		if (!job) {
+			await metrics.putMetric(TranscriptionFailureMetric);
 			console.error('Failed to parse job message', message);
 			return;
 		}
@@ -138,6 +149,7 @@ const main = async () => {
 	} catch (error) {
 		const msg = 'Worker failed to complete';
 		console.error(msg, error);
+		await metrics.putMetric(TranscriptionFailureMetric);
 		if (message.message?.ReceiptHandle) {
 			// Terminate the message visibility timeout
 			await changeMessageVisibility(

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -24,7 +24,7 @@ import { updateScaleInProtection } from './asg';
 import { uploadAllTranscriptsToS3 } from './util';
 import {
 	MetricsService,
-	TranscriptionFailureMetric,
+	FailureMetric,
 } from '@guardian/transcription-service-backend-common/src/metrics';
 
 const main = async () => {
@@ -64,7 +64,7 @@ const main = async () => {
 		const job = parseTranscriptJobMessage(message.message);
 
 		if (!job) {
-			await metrics.putMetric(TranscriptionFailureMetric);
+			await metrics.putMetric(FailureMetric);
 			console.error('Failed to parse job message', message);
 			return;
 		}
@@ -149,7 +149,7 @@ const main = async () => {
 	} catch (error) {
 		const msg = 'Worker failed to complete';
 		console.error(msg, error);
-		await metrics.putMetric(TranscriptionFailureMetric);
+		await metrics.putMetric(FailureMetric);
 		if (message.message?.ReceiptHandle) {
 			// Terminate the message visibility timeout
 			await changeMessageVisibility(


### PR DESCRIPTION
## What does this change?
This change adds the capability to post metrics to cloudwatch from our transcription service.

Initially, I have created one new metric called `Failure` to record failures during the transcription process. At the moment this metric will be updated in the following situations:
 - If the worker fails to parse an incoming SQS message
 - If the FFMPEG conversion or whisper transcription fails 
 - If the output-handler fails to either write to dynamo or send a notification email.

I wasn't sure whether to make the different failure scenarios different metrics or not (e.g. counting transcription failures in a different metric to 'notification failed' failures). I decided to put everything together with the idea that all we want to know is that something failed - we should then be able to go and look at the logs to work out exactly what failed.

The intention with this metric is that it should only ever be updated once per transcription job - so I'm only updating it in the top level handler functions.

At the moment there are no alarms attached to these metrics - I decided to hold off on that until PROD is stable so we don't get bored of alarms straight away.

## How to test
I tested this by deploying the branch and then kicking off a transcription, then logging onto the worker server running the transcription and calling `docker stop <container id>` to break the transcription process. I then verified that a the metric existed and the value had been updated - see `https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2?graph=~(metrics~(~(~'TranscriptionService~'Failure))~view~'timeSeries~stacked~false~region~'eu-west-1~start~'-PT1H~end~'P0D~stat~'Maximum~period~300)&namespace=~'TranscriptionService`

## How can we measure success?
In future, we should have good visibility of transcription failures. 

![failure](https://media1.giphy.com/media/26ybwvTX4DTkwst6U/200w.gif?cid=6c09b952zxwl7zqktluyezddtupx8fumbrakx9gbrg0kius0&ep=v1_gifs_search&rid=200w.gif&ct=g)