### PR TITLE
Use signed urls for transcription output

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -132,7 +132,7 @@ const getApp = async () => {
 				config,
 				`${parsedItem.data.originalFilename} transcript`,
 				exportRequest.data.oAuthTokenResponse,
-				parsedItem.data.transcript.srt,
+				parsedItem.data.transcripts.srt,
 			);
 			if (!exportResult) {
 				const msg = `Failed to create google document for item with id ${parsedItem.data.id}`;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -67,15 +67,7 @@ const getApp = async () => {
 			const userEmail = 'digital.investigations@theguardian.com';
 			const originalFilename = 'test.mp3';
 			const id = 'my-first-transcription';
-			const signedUrl = await getSignedUrl(
-				config.aws.region,
-				config.app.sourceMediaBucket,
-				userEmail,
-				originalFilename,
-				7,
-				false,
-				id,
-			);
+			const signedUrl = 'tifsample.wav';
 			const sendResult = await sendMessage(
 				id,
 				sqsClient,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -64,7 +64,12 @@ const getApp = async () => {
 	apiRouter.post('/send-message', [
 		checkAuth,
 		asyncHandler(async (req, res) => {
-			const sendResult = await sendMessage(sqsClient, config.app.taskQueueUrl);
+			const sendResult = await sendMessage(
+				sqsClient,
+				config.app.taskQueueUrl,
+				config.app.transcriptionOutputBucket,
+				config.aws.region,
+			);
 			if (isFailure(sendResult)) {
 				res.status(500).send(sendResult.errorMsg);
 				return;
@@ -147,6 +152,7 @@ const getApp = async () => {
 				config.app.sourceMediaBucket,
 				req.user?.email ?? 'not found',
 				queryParams.data.fileName,
+				60,
 			);
 
 			res.set('Cache-Control', 'no-cache');

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -64,11 +64,19 @@ const getApp = async () => {
 	apiRouter.post('/send-message', [
 		checkAuth,
 		asyncHandler(async (req, res) => {
+			const userEmail = 'digital.investigations@theguardian.com';
+			const originalFilename = 'test.mp3';
+			const id = 'my-first-transcription';
+			const signedUrl = 'tifsample.wav';
 			const sendResult = await sendMessage(
+				id,
 				sqsClient,
 				config.app.taskQueueUrl,
 				config.app.transcriptionOutputBucket,
 				config.aws.region,
+				userEmail,
+				originalFilename,
+				signedUrl,
 			);
 			if (isFailure(sendResult)) {
 				res.status(500).send(sendResult.errorMsg);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -67,7 +67,15 @@ const getApp = async () => {
 			const userEmail = 'digital.investigations@theguardian.com';
 			const originalFilename = 'test.mp3';
 			const id = 'my-first-transcription';
-			const signedUrl = 'tifsample.wav';
+			const signedUrl = await getSignedUrl(
+				config.aws.region,
+				config.app.sourceMediaBucket,
+				userEmail,
+				originalFilename,
+				7,
+				false,
+				id,
+			);
 			const sendResult = await sendMessage(
 				id,
 				sqsClient,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -161,6 +161,7 @@ const getApp = async () => {
 				req.user?.email ?? 'not found',
 				queryParams.data.fileName,
 				60,
+				true,
 			);
 
 			res.set('Cache-Control', 'no-cache');

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -13,6 +13,7 @@ export interface TranscriptionConfig {
 		stage: string;
 		emailNotificationFromAddress: string;
 		sourceMediaBucket: string;
+		transcriptionOutputBucket: string;
 		destinationTopicArns: {
 			transcriptionService: string;
 		};
@@ -105,6 +106,12 @@ export const getConfig = async (): Promise<TranscriptionConfig> => {
 
 	const tableName = findParameter(parameters, paramPath, 'app/tableName');
 
+	const transcriptionOutputBucket = findParameter(
+		parameters,
+		paramPath,
+		'app/transcriptionOutputBucket',
+	);
+
 	return {
 		auth: {
 			clientId: authClientId,
@@ -121,6 +128,7 @@ export const getConfig = async (): Promise<TranscriptionConfig> => {
 				transcriptionService: destinationTopic,
 			},
 			tableName,
+			transcriptionOutputBucket,
 		},
 		aws: {
 			region,

--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -23,18 +23,18 @@ export const getDynamoClient = (
 	return DynamoDBDocumentClient.from(client);
 };
 
-export const Transcript = z.object({
+export const Transcripts = z.object({
 	srt: z.string(),
 	text: z.string(),
 	json: z.string(),
 });
 
-export type Transcript = z.infer<typeof Transcript>;
+export type Transcripts = z.infer<typeof Transcripts>;
 
 export const TranscriptionItem = z.object({
 	id: z.string(),
 	originalFilename: z.string(),
-	transcript: Transcript,
+	transcripts: Transcripts,
 	userEmail: z.string(),
 });
 

--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -28,6 +28,9 @@ export const Transcript = z.object({
 	text: z.string(),
 	json: z.string(),
 });
+
+export type Transcript = z.infer<typeof Transcript>;
+
 export const TranscriptionItem = z.object({
 	id: z.string(),
 	originalFilename: z.string(),

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -2,3 +2,5 @@ export * from './sqs';
 export * from './s3';
 export * from './config';
 export * from './configHelpers';
+export * from './utils';
+export * from './dynamodb';

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -9,7 +9,10 @@ import { z } from 'zod';
 
 const ReadableBody = z.instanceof(Readable);
 
-export const getS3Client = (region: string, useAccelerateEndpoint: boolean) => {
+export const getS3Client = (
+	region: string,
+	useAccelerateEndpoint: boolean = false,
+) => {
 	return new S3Client({
 		region,
 		useAccelerateEndpoint,
@@ -74,4 +77,17 @@ export const getFile = async (
 		console.error(e);
 		throw e;
 	}
+};
+
+export const getFileFromS3 = async (
+	region: string,
+	destinationDirectory: string,
+	bucket: string,
+	s3Key: string,
+) => {
+	const s3Client = getS3Client(region);
+
+	const file = await getFile(s3Client, bucket, s3Key, destinationDirectory);
+
+	return file;
 };

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -21,18 +21,20 @@ export const getSignedUrl = (
 	bucket: string,
 	userEmail: string,
 	fileName: string,
+	expiresIn: number,
+	id?: string,
 ) =>
 	getSignedUrlSdk(
 		getS3Client(region),
 		new PutObjectCommand({
 			Bucket: bucket,
-			Key: uuid4(),
+			Key: id || uuid4(),
 			Metadata: {
 				'user-email': userEmail,
 				'file-name': fileName,
 			},
 		}),
-		{ expiresIn: 60 }, // override default expiration time of 15 minutes
+		{ expiresIn }, // override default expiration time of 15 minutes
 	);
 
 export const getFile = async (

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -9,10 +9,10 @@ import { z } from 'zod';
 
 const ReadableBody = z.instanceof(Readable);
 
-export const getS3Client = (region: string) => {
+export const getS3Client = (region: string, useAccelerateEndpoint: boolean) => {
 	return new S3Client({
 		region,
-		useAccelerateEndpoint: true,
+		useAccelerateEndpoint,
 	});
 };
 
@@ -22,10 +22,11 @@ export const getSignedUrl = (
 	userEmail: string,
 	fileName: string,
 	expiresIn: number,
+	useAccelerateEndpoint: boolean,
 	id?: string,
 ) =>
 	getSignedUrlSdk(
-		getS3Client(region),
+		getS3Client(region, useAccelerateEndpoint),
 		new PutObjectCommand({
 			Bucket: bucket,
 			Key: id || uuid4(),

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -218,13 +218,16 @@ const generateOutputSignedUrls = async (
 	expiresInDays: number,
 ): Promise<OutputBucketUrls> => {
 	const expiresIn = expiresInDays * 24 * 60;
+	const srtKey = `srt/${id}.srt`;
+	const jsonKey = `json/${id}.json`;
+	const textKey = `text/${id}.txt`;
 	const srtSignedS3Url = await getSignedUrl(
 		region,
 		outputBucket,
 		userEmail,
 		originalFilename,
 		expiresIn,
-		`srt/${id}.srt`,
+		srtKey,
 	);
 	const textSignedS3Url = await getSignedUrl(
 		region,
@@ -232,7 +235,7 @@ const generateOutputSignedUrls = async (
 		userEmail,
 		originalFilename,
 		expiresIn,
-		`text/${id}.txt`,
+		jsonKey,
 	);
 	const jsonSignedS3Url = await getSignedUrl(
 		region,
@@ -240,12 +243,12 @@ const generateOutputSignedUrls = async (
 		userEmail,
 		originalFilename,
 		expiresIn,
-		`json/${id}.json`,
+		textKey,
 	);
 
 	return {
-		srt: srtSignedS3Url,
-		text: textSignedS3Url,
-		json: jsonSignedS3Url,
+		srt: { url: srtSignedS3Url, key: srtKey },
+		text: { url: textSignedS3Url, key: textKey },
+		json: { url: jsonSignedS3Url, key: jsonKey },
 	};
 };

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -53,15 +53,15 @@ export const isFailure = (
 ): result is SQSFailure => result.status === SQSStatus.Failure;
 
 export const sendMessage = async (
+	id: string,
 	client: SQSClient,
 	queueUrl: string,
 	outputBucket: string,
 	region: string,
+	userEmail: string,
+	originalFilename: string,
+	inputSignedUrl: string,
 ): Promise<SendResult> => {
-	const userEmail = 'digital.investigations@theguardian.com';
-	const originalFilename = 'test.mp3';
-	const id = 'my-first-transcription';
-
 	const signedUrls = await generateOutputSignedUrls(
 		id,
 		region,
@@ -73,7 +73,7 @@ export const sendMessage = async (
 
 	const job: TranscriptionJob = {
 		id, // id of the source file
-		s3Key: 'tifsample.wav',
+		inputSignedUrl,
 		retryCount: 0,
 		sentTimestamp: new Date().toISOString(),
 		userEmail,

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -227,6 +227,7 @@ const generateOutputSignedUrls = async (
 		userEmail,
 		originalFilename,
 		expiresIn,
+		false,
 		srtKey,
 	);
 	const textSignedS3Url = await getSignedUrl(
@@ -235,6 +236,7 @@ const generateOutputSignedUrls = async (
 		userEmail,
 		originalFilename,
 		expiresIn,
+		false,
 		jsonKey,
 	);
 	const jsonSignedS3Url = await getSignedUrl(
@@ -243,6 +245,7 @@ const generateOutputSignedUrls = async (
 		userEmail,
 		originalFilename,
 		expiresIn,
+		false,
 		textKey,
 	);
 

--- a/packages/backend-common/src/utils.ts
+++ b/packages/backend-common/src/utils.ts
@@ -1,0 +1,6 @@
+import * as fs from 'fs';
+
+export const readFile = (filePath: string): string => {
+	const file = fs.readFileSync(filePath, 'utf8');
+	return file;
+};

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -18,6 +18,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       "GuAllowPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
+      "GuAllowPolicy",
       "GuInstanceRole",
       "GuDescribeEC2Policy",
       "GuLogShippingPolicy",
@@ -133,6 +134,59 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "describe-ec2-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTranscriptionserviceworkerA8AC6615",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDeleteSourceMedia6AC3A8D5": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:DeleteObject",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "TranscriptionServiceOutputBucketTranscriptionservice35996ED2",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDeleteSourceMedia6AC3A8D5",
         "Roles": [
           {
             "Ref": "InstanceRoleTranscriptionserviceworkerA8AC6615",
@@ -509,6 +563,9 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
     "TranscriptionServiceOutputBucketTranscriptionservice35996ED2": {
       "DeletionPolicy": "Retain",
       "Properties": {
+        "AccelerateConfiguration": {
+          "AccelerationStatus": "Enabled",
+        },
         "BucketName": "transcription-service-output-test",
         "LifecycleConfiguration": {
           "Rules": [

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -18,7 +18,6 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       "GuAllowPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
-      "GuAllowPolicy",
       "GuInstanceRole",
       "GuDescribeEC2Policy",
       "GuLogShippingPolicy",
@@ -134,59 +133,6 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "describe-ec2-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleTranscriptionserviceworkerA8AC6615",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "GetDeleteSourceMedia6AC3A8D5": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:GetObject",
-                "s3:DeleteObject",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "TranscriptionServiceOutputBucketTranscriptionservice35996ED2",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "GetDeleteSourceMedia6AC3A8D5",
         "Roles": [
           {
             "Ref": "InstanceRoleTranscriptionserviceworkerA8AC6615",
@@ -563,9 +509,6 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
     "TranscriptionServiceOutputBucketTranscriptionservice35996ED2": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "AccelerateConfiguration": {
-          "AccelerationStatus": "Enabled",
-        },
         "BucketName": "transcription-service-output-test",
         "LifecycleConfiguration": {
           "Rules": [

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -11,6 +11,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuApiLambda",
       "GuPolicy",
+      "GuPolicy",
       "GuCname",
       "GuLoggingStreamNameParameter",
       "GuPolicy",
@@ -360,41 +361,59 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
                 "s3:PutObject",
               ],
               "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
                   ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "TranscriptionServiceOutputBucketTranscriptionservice35996ED2",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",
         },
         "PolicyName": "LambdaMediaUploadBucketInlinePolicyD28A1181",
+        "Roles": [
+          {
+            "Ref": "transcriptionserviceapiServiceRole0EF40E0F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "LambdaOutputBucketInlinePolicyC1164987": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "TranscriptionServiceOutputBucketTranscriptionservice35996ED2",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "LambdaOutputBucketInlinePolicyC1164987",
         "Roles": [
           {
             "Ref": "transcriptionserviceapiServiceRole0EF40E0F",
@@ -544,6 +563,9 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
     "TranscriptionServiceOutputBucketTranscriptionservice35996ED2": {
       "DeletionPolicy": "Retain",
       "Properties": {
+        "AccelerateConfiguration": {
+          "AccelerationStatus": "Enabled",
+        },
         "BucketName": "transcription-service-output-test",
         "LifecycleConfiguration": {
           "Rules": [
@@ -1182,6 +1204,34 @@ service transcription-service-worker start",
                 ],
               },
             },
+            {
+              "Action": [
+                "dynamodb:BatchGetItem",
+                "dynamodb:GetRecords",
+                "dynamodb:GetShardIterator",
+                "dynamodb:Query",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:DescribeTable",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "TranscriptTableA6F8B506",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1810,6 +1860,24 @@ service transcription-service-worker start",
               ],
               "Effect": "Allow",
               "Resource": "*",
+            },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "TranscriptionServiceOutputBucketTranscriptionservice35996ED2",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
             },
             {
               "Action": [

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -7,6 +7,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       "GuAmiParameter",
       "GuCertificate",
       "GuS3Bucket",
+      "GuS3Bucket",
       "GuDistributionBucketParameter",
       "GuApiLambda",
       "GuPolicy",
@@ -150,20 +151,36 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
                 "s3:DeleteObject",
               ],
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Fn::GetAtt": [
-                        "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040",
-                        "Arn",
-                      ],
-                    },
-                    "/*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
                   ],
-                ],
-              },
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "TranscriptionServiceOutputBucketTranscriptionservice35996ED2",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",
@@ -343,20 +360,36 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
                 "s3:PutObject",
               ],
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Fn::GetAtt": [
-                        "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040",
-                        "Arn",
-                      ],
-                    },
-                    "/*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
                   ],
-                ],
-              },
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "TranscriptionServiceOutputBucketTranscriptionservice35996ED2",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",
@@ -465,6 +498,92 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
         "TopicName": "transcription-service-destination-topic-TEST",
       },
       "Type": "AWS::SNS::Topic",
+    },
+    "TranscriptTableA6F8B506": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S",
+          },
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH",
+          },
+        ],
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 1,
+          "WriteCapacityUnits": 1,
+        },
+        "TableName": "transcription-service-TEST",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/transcription-service",
+          },
+          {
+            "Key": "Stack",
+            "Value": "investigations",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "TranscriptionServiceOutputBucketTranscriptionservice35996ED2": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketName": "transcription-service-output-test",
+        "LifecycleConfiguration": {
+          "Rules": [
+            {
+              "ExpirationInDays": 7,
+              "Status": "Enabled",
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "transcription-service",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/transcription-service",
+          },
+          {
+            "Key": "Stack",
+            "Value": "investigations",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
     },
     "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040": {
       "DeletionPolicy": "Retain",
@@ -1639,6 +1758,34 @@ service transcription-service-worker start",
                   ],
                 ],
               },
+            },
+            {
+              "Action": [
+                "dynamodb:BatchGetItem",
+                "dynamodb:GetRecords",
+                "dynamodb:GetShardIterator",
+                "dynamodb:Query",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:DescribeTable",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "TranscriptTableA6F8B506",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
             },
             {
               "Action": [

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -262,13 +262,6 @@ export class TranscriptionService extends GuStack {
 				new GuPolicy(this, 'WorkerGetParameters', {
 					statements: [getParametersPolicy],
 				}),
-				new GuAllowPolicy(this, 'GetDeleteSourceMedia', {
-					actions: ['s3:GetObject', 's3:DeleteObject'],
-					resources: [
-						`${sourceMediaBucket.bucketArn}/*`,
-						`${outputBucket.bucketArn}/*`,
-					],
-				}),
 				new GuAllowPolicy(this, 'WriteToDestinationTopic', {
 					actions: ['sns:Publish'],
 					resources: [transcriptDestinationTopic.topicArn],

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -262,6 +262,13 @@ export class TranscriptionService extends GuStack {
 				new GuPolicy(this, 'WorkerGetParameters', {
 					statements: [getParametersPolicy],
 				}),
+				new GuAllowPolicy(this, 'GetDeleteSourceMedia', {
+					actions: ['s3:GetObject', 's3:DeleteObject'],
+					resources: [
+						`${sourceMediaBucket.bucketArn}/*`,
+						`${outputBucket.bucketArn}/*`,
+					],
+				}),
 				new GuAllowPolicy(this, 'WriteToDestinationTopic', {
 					actions: ['sns:Publish'],
 					resources: [transcriptDestinationTopic.topicArn],

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -99,7 +99,6 @@ export class TranscriptionService extends GuStack {
 			{
 				app: APP_NAME,
 				bucketName: `transcription-service-output-${this.stage.toLowerCase()}`,
-				transferAcceleration: true,
 			},
 		);
 
@@ -135,7 +134,6 @@ export class TranscriptionService extends GuStack {
 				{
 					app: APP_NAME,
 					bucketName: `transcription-service-output-dev`,
-					transferAcceleration: true,
 				},
 			);
 			transcriptionOutputBucketDev.addLifecycleRule({

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -99,6 +99,7 @@ export class TranscriptionService extends GuStack {
 			{
 				app: APP_NAME,
 				bucketName: `transcription-service-output-${this.stage.toLowerCase()}`,
+				transferAcceleration: true,
 			},
 		);
 
@@ -134,6 +135,7 @@ export class TranscriptionService extends GuStack {
 				{
 					app: APP_NAME,
 					bucketName: `transcription-service-output-dev`,
+					transferAcceleration: true,
 				},
 			);
 			transcriptionOutputBucketDev.addLifecycleRule({
@@ -166,10 +168,19 @@ export class TranscriptionService extends GuStack {
 					new PolicyStatement({
 						effect: Effect.ALLOW,
 						actions: ['s3:GetObject', 's3:PutObject'],
-						resources: [
-							`${sourceMediaBucket.bucketArn}/*`,
-							`${outputBucket.bucketArn}/*`,
-						],
+						resources: [`${sourceMediaBucket.bucketArn}/*`],
+					}),
+				],
+			}),
+		);
+
+		apiLambda.role?.attachInlinePolicy(
+			new GuPolicy(this, 'LambdaOutputBucketInlinePolicy', {
+				statements: [
+					new PolicyStatement({
+						effect: Effect.ALLOW,
+						actions: ['s3:PutObject'],
+						resources: [`${outputBucket.bucketArn}/*`],
 					}),
 				],
 			}),

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -93,6 +93,19 @@ export class TranscriptionService extends GuStack {
 			expiration: Duration.days(7),
 		});
 
+		const outputBucket = new GuS3Bucket(
+			this,
+			'TranscriptionServiceOutputBucket',
+			{
+				app: APP_NAME,
+				bucketName: `transcription-service-output-${this.stage.toLowerCase()}`,
+			},
+		);
+
+		outputBucket.addLifecycleRule({
+			expiration: Duration.days(7),
+		});
+
 		// we only want one dev bucket so only create on CODE
 		if (props.stage === 'CODE') {
 			const domainNameDev = 'transcribe.local.dev-gutools.co.uk';
@@ -113,6 +126,18 @@ export class TranscriptionService extends GuStack {
 			);
 			sourceMediaBucketDev.addLifecycleRule({
 				expiration: Duration.days(1),
+			});
+
+			const transcriptionOutputBucketDev = new GuS3Bucket(
+				this,
+				'TranscriptionServiceOutputsBucket',
+				{
+					app: APP_NAME,
+					bucketName: `transcription-service-output-dev`,
+				},
+			);
+			transcriptionOutputBucketDev.addLifecycleRule({
+				expiration: Duration.days(7),
 			});
 		}
 
@@ -141,7 +166,10 @@ export class TranscriptionService extends GuStack {
 					new PolicyStatement({
 						effect: Effect.ALLOW,
 						actions: ['s3:GetObject', 's3:PutObject'],
-						resources: [`${sourceMediaBucket.bucketArn}/*`],
+						resources: [
+							`${sourceMediaBucket.bucketArn}/*`,
+							`${outputBucket.bucketArn}/*`,
+						],
 					}),
 				],
 			}),
@@ -227,7 +255,10 @@ export class TranscriptionService extends GuStack {
 				}),
 				new GuAllowPolicy(this, 'GetDeleteSourceMedia', {
 					actions: ['s3:GetObject', 's3:DeleteObject'],
-					resources: [`${sourceMediaBucket.bucketArn}/*`],
+					resources: [
+						`${sourceMediaBucket.bucketArn}/*`,
+						`${outputBucket.bucketArn}/*`,
+					],
 				}),
 				new GuAllowPolicy(this, 'WriteToDestinationTopic', {
 					actions: ['sns:Publish'],

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -436,6 +436,14 @@ export class TranscriptionService extends GuStack {
 			}),
 		);
 
+		outputHandlerLambda.addToRolePolicy(
+			new PolicyStatement({
+				effect: Effect.ALLOW,
+				actions: ['s3:GetObject'],
+				resources: [`${outputBucket.bucketArn}/*`],
+			}),
+		);
+
 		outputHandlerLambda.addToRolePolicy(getParametersPolicy);
 	}
 }

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -47,9 +47,9 @@ export const UploadForm = () => {
 			return;
 		}
 
-		const uploadSuccess = await uploadToS3(body.data.presignedS3Url, blob);
-		setStatus(uploadSuccess);
-		if (uploadSuccess) {
+		const uploadStatus = await uploadToS3(body.data.presignedS3Url, blob);
+		setStatus(uploadStatus.isSuccess);
+		if (uploadStatus.isSuccess) {
 			maybeFileInput.value = '';
 		}
 	};

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -1,21 +1,10 @@
 import { authFetch } from '@/helpers';
 import { useContext, useState } from 'react';
-import { SignedUrlResponseBody } from '@guardian/transcription-service-common';
+import {
+	SignedUrlResponseBody,
+	uploadToS3,
+} from '@guardian/transcription-service-common';
 import { AuthContext } from '@/app/template';
-
-const uploadToS3 = async (url: string, blob: Blob) => {
-	try {
-		const response = await fetch(url, {
-			method: 'PUT',
-			body: blob,
-		});
-		const status = response.status;
-		return status === 200;
-	} catch (error) {
-		console.error('upload error:', error);
-		return false;
-	}
-};
 
 export const UploadForm = () => {
 	const [status, setStatus] = useState<boolean | undefined>(undefined);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './utils';

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -4,13 +4,28 @@ export enum DestinationService {
 	TranscriptionService = 'TranscriptionService',
 }
 
+const OutputSignedUrl = z.object({
+	url: z.string(),
+	key: z.string(),
+});
+
+export type OutputSignedUrl = z.infer<typeof OutputSignedUrl>;
+
 const OutputBucketUrls = z.object({
+	srt: OutputSignedUrl,
+	text: OutputSignedUrl,
+	json: OutputSignedUrl,
+});
+
+export type OutputBucketUrls = z.infer<typeof OutputBucketUrls>;
+
+const OutputBucketKeys = z.object({
 	srt: z.string(),
 	text: z.string(),
 	json: z.string(),
 });
 
-export type OutputBucketUrls = z.infer<typeof OutputBucketUrls>;
+export type OutputBucketKeys = z.infer<typeof OutputBucketKeys>;
 
 export const TranscriptionJob = z.object({
 	id: z.string(),
@@ -31,7 +46,7 @@ export const TranscriptionOutput = z.object({
 	languageCode: z.string(),
 	// englishTranslation: z.optional(z.string()),
 	userEmail: z.string(),
-	outputBucketUrls: OutputBucketUrls,
+	outputBucketKeys: OutputBucketKeys,
 });
 
 export type TranscriptionOutput = z.infer<typeof TranscriptionOutput>;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -4,6 +4,14 @@ export enum DestinationService {
 	TranscriptionService = 'TranscriptionService',
 }
 
+const OutputBucketUrls = z.object({
+	srt: z.string(),
+	text: z.string(),
+	json: z.string(),
+});
+
+export type OutputBucketUrls = z.infer<typeof OutputBucketUrls>;
+
 export const TranscriptionJob = z.object({
 	id: z.string(),
 	originalFilename: z.string(),
@@ -12,6 +20,7 @@ export const TranscriptionJob = z.object({
 	sentTimestamp: z.string(),
 	userEmail: z.string(),
 	transcriptDestinationService: z.nativeEnum(DestinationService),
+	outputBucketUrls: OutputBucketUrls,
 });
 
 export type TranscriptionJob = z.infer<typeof TranscriptionJob>;
@@ -19,10 +28,10 @@ export type TranscriptionJob = z.infer<typeof TranscriptionJob>;
 export const TranscriptionOutput = z.object({
 	id: z.string(),
 	originalFilename: z.string(),
-	transcriptionSrt: z.string(),
 	languageCode: z.string(),
-	englishTranslation: z.optional(z.string()),
+	// englishTranslation: z.optional(z.string()),
 	userEmail: z.string(),
+	outputBucketUrls: OutputBucketUrls,
 });
 
 export type TranscriptionOutput = z.infer<typeof TranscriptionOutput>;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -30,7 +30,7 @@ export type OutputBucketKeys = z.infer<typeof OutputBucketKeys>;
 export const TranscriptionJob = z.object({
 	id: z.string(),
 	originalFilename: z.string(),
-	s3Key: z.string(),
+	inputSignedUrl: z.string(),
 	retryCount: z.number(),
 	sentTimestamp: z.string(),
 	userEmail: z.string(),

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -4,17 +4,17 @@ export enum DestinationService {
 	TranscriptionService = 'TranscriptionService',
 }
 
-const OutputSignedUrl = z.object({
+const SignedUrl = z.object({
 	url: z.string(),
 	key: z.string(),
 });
 
-export type OutputSignedUrl = z.infer<typeof OutputSignedUrl>;
+export type SignedUrl = z.infer<typeof SignedUrl>;
 
 const OutputBucketUrls = z.object({
-	srt: OutputSignedUrl,
-	text: OutputSignedUrl,
-	json: OutputSignedUrl,
+	srt: SignedUrl,
+	text: SignedUrl,
+	json: SignedUrl,
 });
 
 export type OutputBucketUrls = z.infer<typeof OutputBucketUrls>;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -44,7 +44,6 @@ export const TranscriptionOutput = z.object({
 	id: z.string(),
 	originalFilename: z.string(),
 	languageCode: z.string(),
-	// englishTranslation: z.optional(z.string()),
 	userEmail: z.string(),
 	outputBucketKeys: OutputBucketKeys,
 });

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,0 +1,13 @@
+export const uploadToS3 = async (url: string, blob: Blob) => {
+	try {
+		const response = await fetch(url, {
+			method: 'PUT',
+			body: blob,
+		});
+		const status = response.status;
+		return status === 200;
+	} catch (error) {
+		console.error('upload error:', error);
+		return false;
+	}
+};

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -36,9 +36,11 @@ export const uploadToS3 = async (
 			isSuccess: true,
 		};
 	} catch (error) {
-		console.error('upload error:', error);
+		const errorMsg = `S3 upload failed: ${error}`;
+		console.error(errorMsg, error);
 		return {
 			isSuccess: false,
+			errorMsg,
 		};
 	}
 };

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -5,7 +5,14 @@ export const uploadToS3 = async (url: string, blob: Blob) => {
 			body: blob,
 		});
 		const status = response.status;
-		return status === 200;
+		const isSuccess = status === 200;
+		if (!isSuccess) {
+			console.log(`S3 upload status is ${status} - ${response.statusText}`);
+			const responseText = await response.text();
+			console.log('responseText: ', responseText);
+		}
+
+		return isSuccess;
 	} catch (error) {
 		console.error('upload error:', error);
 		return false;

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -1,13 +1,20 @@
 import { Handler } from 'aws-lambda';
 import { sendEmail, getSESClient } from './ses';
 import { IncomingSQSEvent } from './sqs-event-types';
-import { getConfig } from '@guardian/transcription-service-backend-common';
+import {
+	TranscriptionConfig,
+	getConfig,
+	getFile,
+	getS3Client,
+} from '@guardian/transcription-service-backend-common';
 import {
 	getDynamoClient,
 	TranscriptionItem,
 	writeTranscriptionItem,
 } from '@guardian/transcription-service-backend-common/src/dynamodb';
+import type { Transcript } from '@guardian/transcription-service-backend-common/src/dynamodb';
 import { testMessage } from '../test/testMessage';
+import { type OutputBucketKeys } from '@guardian/transcription-service-common';
 
 const messageBody = (
 	transcriptId: string,
@@ -19,6 +26,35 @@ const messageBody = (
 		<h1>Transcript for ${originalFilename} ready</h1>
 		<p>Click <a href="${exportUrl}">here</a> to export to a google doc.</p>
 	`;
+};
+
+export const getFileFromS3 = async (
+	config: TranscriptionConfig,
+	s3Key: string,
+) => {
+	const s3Client = getS3Client(config.aws.region);
+
+	const file = await getFile(
+		s3Client,
+		config.app.transcriptionOutputBucket,
+		s3Key,
+		config.app.stage === 'DEV' ? `${__dirname}/sample` : '/tmp',
+	);
+
+	return file;
+};
+
+export const getTranscriptsText = async (
+	config: TranscriptionConfig,
+	outputBucketKeys: OutputBucketKeys,
+): Promise<Transcript> => {
+	const srt = await getFileFromS3(config, outputBucketKeys.srt);
+	const json = await getFileFromS3(config, outputBucketKeys.json);
+	const text = await getFileFromS3(config, outputBucketKeys.text);
+
+	const result: Transcript = { srt, json, text };
+
+	return result;
 };
 
 const processMessage = async (event: unknown) => {
@@ -34,13 +70,18 @@ const processMessage = async (event: unknown) => {
 	for (const record of parsedEvent.data.Records) {
 		const transcriptionOutput = record.body.Message;
 
+		const transcripts = await getTranscriptsText(
+			config,
+			transcriptionOutput.outputBucketKeys,
+		);
+
 		const dynamoItem: TranscriptionItem = {
 			id: transcriptionOutput.id,
 			originalFilename: transcriptionOutput.originalFilename,
 			transcript: {
-				srt: transcriptionOutput.transcriptionSrt,
-				text: '',
-				json: '',
+				srt: transcripts.srt,
+				text: transcripts.text,
+				json: transcripts.json,
 			},
 			userEmail: transcriptionOutput.userEmail,
 		};

--- a/packages/output-handler/test/testMessage.ts
+++ b/packages/output-handler/test/testMessage.ts
@@ -2,7 +2,7 @@ export const testMessage = {
 	Records: [
 		{
 			messageId: 'abc123',
-			body: '{\n  "Type" : "Notification",\n  "MessageId" : "message-id",\n  "TopicArn" : "mytopicarn",\n  "Message" : "{\\"id\\":\\"my-first-transcription\\",\\"transcriptionSrt\\":\\"1\\\\n00:00:00,000 --> 00:00:01,300\\\\n This is The Guardian.\\\\n\\\\n2\\\\n00:00:01,300 --> 00:00:06,300\\\\n [Music]\\\\n\\\\n\\",\\"languageCode\\":\\"en\\",\\"userEmail\\":\\"test@test.com\\",\\"originalFilename\\":\\"test.mp3\\"}",\n  "Timestamp" : "2024-02-08T11:10:11.014Z"\n}',
+			body: '{\n  "Type" : "Notification",\n  "MessageId" : "message-id",\n  "TopicArn" : "mytopicarn",\n  "Message" : "{\\"id\\":\\"my-first-transcription\\",\\"outputBucketKeys\\":{\\"srt\\":\\"srt/my-first-transcription.srt\\", \\"json\\":\\"json/my-first-transcription.json\\", \\"text\\":\\"text/my-first-transcription.txt\\"},\\"languageCode\\":\\"en\\",\\"userEmail\\":\\"test@test.com\\",\\"originalFilename\\":\\"test.mp3\\"}",\n  "Timestamp" : "2024-02-08T11:10:11.014Z"\n}',
 		},
 	],
 };

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "esbuild --bundle --platform=node --target=node20 --outfile=dist/index.js src/index.ts",
 		"package": "docker run --rm -v $PWD:/worker $(docker build -q deb-build/) fpm",
-		"start": "STAGE=DEV nodemon src/index.ts"
+		"start": "STAGE=DEV nodemon --ignore src/sample src/index.ts"
 	},
 	"keywords": [],
 	"author": "",

--- a/packages/worker/src/asg.ts
+++ b/packages/worker/src/asg.ts
@@ -2,7 +2,7 @@ import {
 	AutoScalingClient,
 	SetInstanceProtectionCommand,
 } from '@aws-sdk/client-auto-scaling';
-import { readFile } from './util';
+import { readFile } from '@guardian/transcription-service-backend-common';
 
 export const updateScaleInProtection = async (
 	region: string,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -7,7 +7,10 @@ import {
 	deleteMessage,
 	changeMessageVisibility,
 } from '@guardian/transcription-service-backend-common';
-import { type TranscriptionOutput } from '@guardian/transcription-service-common';
+import {
+	OutputBucketKeys,
+	type TranscriptionOutput,
+} from '@guardian/transcription-service-common';
 import { getSNSClient, publishTranscriptionOutput } from './sns';
 import {
 	getTranscriptionText,
@@ -95,12 +98,18 @@ const main = async () => {
 
 		await uploadAllTranscriptsToS3(outputBucketUrls, transcripts);
 
+		const outputBucketKeys: OutputBucketKeys = {
+			srt: outputBucketUrls.srt.key,
+			json: outputBucketUrls.json.key,
+			text: outputBucketUrls.text.key,
+		};
+
 		const transcriptionOutput: TranscriptionOutput = {
 			id: job.id,
 			languageCode: 'en',
 			userEmail: job.userEmail,
 			originalFilename: job.originalFilename,
-			outputBucketUrls,
+			outputBucketKeys,
 		};
 
 		await publishTranscriptionOutput(

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -64,7 +64,7 @@ const main = async () => {
 			loggableJob,
 		);
 
-		const fileToTranscribe = await getFileFromS3(config, job.s3Key);
+		const fileToTranscribe = await getFileFromS3(config, job.inputSignedUrl);
 
 		// docker container to run ffmpeg and whisper on file
 		const containerId = await getOrCreateContainer(

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -5,24 +5,19 @@ import {
 	parseTranscriptJobMessage,
 	isFailure,
 	deleteMessage,
-	getFile,
-	getS3Client,
 	changeMessageVisibility,
-	TranscriptionConfig,
 } from '@guardian/transcription-service-backend-common';
-import type {
-	OutputBucketUrls,
-	TranscriptionOutput,
-} from '@guardian/transcription-service-common';
+import { type TranscriptionOutput } from '@guardian/transcription-service-common';
 import { getSNSClient, publishTranscriptionOutput } from './sns';
 import {
 	getTranscriptionText,
 	convertToWav,
 	getOrCreateContainer,
-	Transcripts,
 } from './transcribe';
 import path from 'path';
+
 import { updateScaleInProtection } from './asg';
+import { getFileFromS3, uploadAllTranscriptsToS3 } from './util';
 
 const main = async () => {
 	const config = await getConfig();
@@ -136,59 +131,6 @@ const main = async () => {
 		}
 	} finally {
 		await updateScaleInProtection(region, stage, false);
-	}
-};
-
-const getFileFromS3 = async (config: TranscriptionConfig, s3Key: string) => {
-	const s3Client = getS3Client(config.aws.region);
-
-	const file = await getFile(
-		s3Client,
-		config.app.sourceMediaBucket,
-		s3Key,
-		config.app.stage === 'DEV' ? `${__dirname}/sample` : '/tmp',
-	);
-
-	return file;
-};
-
-export const uploadAllTranscriptsToS3 = async (
-	destinationBucketUrls: OutputBucketUrls,
-	files: Transcripts,
-) => {
-	const getBlob = (file: string) => new Blob([file as BlobPart]);
-	const getFileName = (file: string) => path.basename(file);
-	const blobs: [string, string, Blob][] = [
-		[getFileName(files.srt), destinationBucketUrls.srt, getBlob(files.srt)],
-		[getFileName(files.json), destinationBucketUrls.json, getBlob(files.json)],
-		[getFileName(files.text), destinationBucketUrls.text, getBlob(files.text)],
-	];
-
-	try {
-		for (const blobDetail of blobs) {
-			const [fileName, url, blob] = blobDetail;
-			const response = await uploadToS3(url, blob);
-			if (!response) {
-				throw new Error(`Could not upload ${fileName} to S3`);
-			}
-			console.log(`Successfully uploaded ${fileName} to S3`);
-		}
-	} catch (error) {
-		console.error('failed to upload transcript to S3', error);
-	}
-};
-
-const uploadToS3 = async (url: string, blob: Blob) => {
-	try {
-		const response = await fetch(url, {
-			method: 'PUT',
-			body: blob,
-		});
-		const status = response.status;
-		return status === 200;
-	} catch (error) {
-		console.error('upload error:', error);
-		return false;
 	}
 };
 

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -1,6 +1,5 @@
 import { spawn } from 'child_process';
 import path from 'path';
-// import { readFile } from './util';
 
 interface ProcessResult {
 	code?: number;

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process';
 import path from 'path';
+import { readFile } from '@guardian/transcription-service-backend-common';
 
 interface ProcessResult {
 	code?: number;
@@ -153,25 +154,29 @@ export const getTranscriptionText = async (
 	numberOfThreads: number,
 	model: WhisperModel,
 ): Promise<Transcripts> => {
-	console.log(`my original file: ${file}`);
-	const resultFile = await transcribe(
-		containerId,
-		wavPath,
-		numberOfThreads,
-		model,
-	);
-	console.log(`result file: ${path.resolve(path.parse(file).dir, resultFile)}`);
+	try {
+		const resultFile = await transcribe(
+			containerId,
+			wavPath,
+			numberOfThreads,
+			model,
+		);
 
-	const res = {
-		srt: path.resolve(path.parse(file).dir, `${resultFile}.srt`),
-		text: path.resolve(path.parse(file).dir, `${resultFile}.txt`),
-		json: path.resolve(path.parse(file).dir, `${resultFile}.json`),
-	};
+		const srtPath = path.resolve(path.parse(file).dir, `${resultFile}.srt`);
+		const textPath = path.resolve(path.parse(file).dir, `${resultFile}.txt`);
+		const jsonPath = path.resolve(path.parse(file).dir, `${resultFile}.json`);
 
-	console.log('transcribe all files: ');
-	console.log(res);
+		const res = {
+			srt: readFile(srtPath),
+			text: readFile(textPath),
+			json: readFile(jsonPath),
+		};
 
-	return res;
+		return res;
+	} catch (error) {
+		console.log(`Could not read the transcripts result`);
+		throw error;
+	}
 };
 
 export const transcribe = async (

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -162,9 +162,6 @@ export const getTranscriptionText = async (
 		model,
 	);
 	console.log(`result file: ${path.resolve(path.parse(file).dir, resultFile)}`);
-	// const transcriptText = readFile(
-	// 	path.resolve(path.parse(file).dir, resultFile),
-	// );
 
 	const res = {
 		srt: path.resolve(path.parse(file).dir, `${resultFile}.srt`),

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -33,8 +33,10 @@ export const uploadAllTranscriptsToS3 = async (
 	for (const blobDetail of blobs) {
 		const [fileName, url, blob] = blobDetail;
 		const response = await uploadToS3(url, blob);
-		if (!response) {
-			throw new Error(`Could not upload file: ${fileName} to S3`);
+		if (!response.isSuccess) {
+			throw new Error(
+				`Could not upload file: ${fileName} to S3! ${response.errorMsg}`,
+			);
 		}
 		console.log(`Successfully uploaded ${fileName} to S3`);
 	}

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -23,16 +23,24 @@ export const uploadAllTranscriptsToS3 = async (
 	const getBlob = (file: string) => new Blob([file as BlobPart]);
 	const getFileName = (file: string) => path.basename(file);
 	const blobs: [string, string, Blob][] = [
-		[getFileName(files.srt), destinationBucketUrls.srt, getBlob(files.srt)],
-		[getFileName(files.json), destinationBucketUrls.json, getBlob(files.json)],
-		[getFileName(files.text), destinationBucketUrls.text, getBlob(files.text)],
+		[getFileName(files.srt), destinationBucketUrls.srt.url, getBlob(files.srt)],
+		[
+			getFileName(files.json),
+			destinationBucketUrls.json.url,
+			getBlob(files.json),
+		],
+		[
+			getFileName(files.text),
+			destinationBucketUrls.text.url,
+			getBlob(files.text),
+		],
 	];
 
 	for (const blobDetail of blobs) {
 		const [fileName, url, blob] = blobDetail;
 		const response = await uploadToS3(url, blob);
 		if (!response) {
-			throw new Error(`Could not upload ${fileName} to S3`);
+			throw new Error(`Could not upload file: ${fileName} to S3`);
 		}
 		console.log(`Successfully uploaded ${fileName} to S3`);
 	}

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -3,11 +3,6 @@ import {
 	uploadToS3,
 	type OutputBucketUrls,
 } from '@guardian/transcription-service-common';
-import {
-	getFile,
-	getS3Client,
-	TranscriptionConfig,
-} from '@guardian/transcription-service-backend-common';
 import path from 'path';
 
 export const uploadAllTranscriptsToS3 = async (
@@ -40,20 +35,4 @@ export const uploadAllTranscriptsToS3 = async (
 		}
 		console.log(`Successfully uploaded ${fileName} to S3`);
 	}
-};
-
-export const getFileFromS3 = async (
-	config: TranscriptionConfig,
-	s3Key: string,
-) => {
-	const s3Client = getS3Client(config.aws.region);
-
-	const file = await getFile(
-		s3Client,
-		config.app.sourceMediaBucket,
-		s3Key,
-		config.app.stage === 'DEV' ? `${__dirname}/sample` : '/tmp',
-	);
-
-	return file;
 };

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import { Transcripts } from './transcribe';
 import {
 	uploadToS3,
@@ -10,11 +9,6 @@ import {
 	TranscriptionConfig,
 } from '@guardian/transcription-service-backend-common';
 import path from 'path';
-
-export const readFile = (filePath: string): string => {
-	const file = fs.readFileSync(filePath, 'utf8');
-	return file;
-};
 
 export const uploadAllTranscriptsToS3 = async (
 	destinationBucketUrls: OutputBucketUrls,

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -1,6 +1,55 @@
 import * as fs from 'fs';
+import { Transcripts } from './transcribe';
+import {
+	uploadToS3,
+	type OutputBucketUrls,
+} from '@guardian/transcription-service-common';
+import {
+	getFile,
+	getS3Client,
+	TranscriptionConfig,
+} from '@guardian/transcription-service-backend-common';
+import path from 'path';
 
 export const readFile = (filePath: string): string => {
 	const file = fs.readFileSync(filePath, 'utf8');
+	return file;
+};
+
+export const uploadAllTranscriptsToS3 = async (
+	destinationBucketUrls: OutputBucketUrls,
+	files: Transcripts,
+) => {
+	const getBlob = (file: string) => new Blob([file as BlobPart]);
+	const getFileName = (file: string) => path.basename(file);
+	const blobs: [string, string, Blob][] = [
+		[getFileName(files.srt), destinationBucketUrls.srt, getBlob(files.srt)],
+		[getFileName(files.json), destinationBucketUrls.json, getBlob(files.json)],
+		[getFileName(files.text), destinationBucketUrls.text, getBlob(files.text)],
+	];
+
+	for (const blobDetail of blobs) {
+		const [fileName, url, blob] = blobDetail;
+		const response = await uploadToS3(url, blob);
+		if (!response) {
+			throw new Error(`Could not upload ${fileName} to S3`);
+		}
+		console.log(`Successfully uploaded ${fileName} to S3`);
+	}
+};
+
+export const getFileFromS3 = async (
+	config: TranscriptionConfig,
+	s3Key: string,
+) => {
+	const s3Client = getS3Client(config.aws.region);
+
+	const file = await getFile(
+		s3Client,
+		config.app.sourceMediaBucket,
+		s3Key,
+		config.app.stage === 'DEV' ? `${__dirname}/sample` : '/tmp',
+	);
+
 	return file;
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR does the following:
- CDK - Creates a bucket for storing the transcripts output (srt, json & text)
- CDK - gives `s3:PutObject` permission on the bucket to the api lambda
- CDK - gives `s3:GetObject` permission on the bucket to the outputHandler lambda
- API - Creates S3 upload signed urls for the transcript output before sending the message to SQS
- API - Adds the signed urls to the SQS message
- Worker - Uploads the transcripts to the relevant S3 bucket using the signed urls
- Worker - Adds the S3 keys of the uploaded output files to the SNS message
- Output Handler - Downloads the transcripts from the output bucket using the keys provided by the SQS message
- Output Handler - Reads the transcripts files and adds their text to the object that goes to dynamo db

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Tested in code by doing the following:
- made an api call to `api/send-message` endpoint which is using hardcoded values for the message
- Waited for the instance to scale up
- Checked the logs in the instance and make sure it's all working fine 
- Waited for the email notification
- Checked dynamo db to make sure the record was added

## TODO:
For Prod release we need to add the new config parameter to parameter store