### PR TITLE
Block egress traffic from workers (except for AWS services)

### DIFF
--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -160,59 +160,6 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GetDeleteSourceMedia6AC3A8D5": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:GetObject",
-                "s3:DeleteObject",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "TranscriptionServiceSourceMediaBucketTranscriptionservice4981E040",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "TranscriptionServiceOutputBucketTranscriptionservice35996ED2",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "GetDeleteSourceMedia6AC3A8D5",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleTranscriptionserviceworkerA8AC6615",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "GetDistributablePolicyTranscriptionserviceworker2DFD604E": {
       "Properties": {
         "PolicyDocument": {
@@ -557,6 +504,10 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
         },
         "TableName": "transcription-service-TEST",
         "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -1017,6 +968,27 @@ service transcription-service-worker start",
       },
       "Type": "AWS::IAM::Policy",
     },
+    "WriteCloudwatch15686221": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "WriteCloudwatch15686221",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTranscriptionserviceworkerA8AC6615",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "WriteToDestinationTopic3E565788": {
       "Properties": {
         "PolicyDocument": {
@@ -1294,6 +1266,11 @@ service transcription-service-worker start",
               ],
               "Effect": "Allow",
               "Resource": "arn:aws:ssm:test-region:745349931791:parameter/TEST/investigations/transcription-service/*",
+            },
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
             },
             {
               "Action": [
@@ -1991,6 +1968,11 @@ service transcription-service-worker start",
               ],
               "Effect": "Allow",
               "Resource": "arn:aws:ssm:test-region:745349931791:parameter/TEST/investigations/transcription-service/*",
+            },
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
             },
           ],
           "Version": "2012-10-17",

--- a/packages/cdk/lib/repository.ts
+++ b/packages/cdk/lib/repository.ts
@@ -30,6 +30,20 @@ export class TranscriptionServiceRepository extends GuStack {
 					'Deploy tools account id - needed to give AMIgo access to this repository',
 			},
 		);
+		const transcriptionWorkerRoleArnCODE = new GuStringParameter(
+			this,
+			'TranscriptionWorkerRoleArnCODE',
+			{
+				description: 'IAM role for the CODE transcription worker instances',
+			},
+		);
+		const transcriptionWorkerRoleArnPROD = new GuStringParameter(
+			this,
+			'TranscriptionWorkerRoleArnPROD',
+			{
+				description: 'IAM role for the PROD transcription worker instances',
+			},
+		);
 		const repository = new Repository(this, 'TranscriptionServiceRepository', {
 			repositoryName: `transcription-service`,
 			lifecycleRules: [
@@ -43,7 +57,11 @@ export class TranscriptionServiceRepository extends GuStack {
 		});
 		repository.addToResourcePolicy(
 			new PolicyStatement({
-				principals: [new ArnPrincipal(githubActionsIAMRoleArn.valueAsString)],
+				principals: [
+					new ArnPrincipal(githubActionsIAMRoleArn.valueAsString),
+					new ArnPrincipal(transcriptionWorkerRoleArnCODE.valueAsString),
+					new ArnPrincipal(transcriptionWorkerRoleArnPROD.valueAsString),
+				],
 				actions: [
 					'ecr:GetAuthorizationToken',
 					'ecr:BatchCheckLayerAvailability',

--- a/packages/cdk/lib/repository.ts
+++ b/packages/cdk/lib/repository.ts
@@ -1,7 +1,7 @@
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
-import { CfnOutput, RemovalPolicy } from 'aws-cdk-lib';
+import { CfnOutput, Fn, RemovalPolicy } from 'aws-cdk-lib';
 import { Repository, TagMutability } from 'aws-cdk-lib/aws-ecr';
 import {
 	AccountPrincipal,
@@ -30,20 +30,6 @@ export class TranscriptionServiceRepository extends GuStack {
 					'Deploy tools account id - needed to give AMIgo access to this repository',
 			},
 		);
-		const transcriptionWorkerRoleArnCODE = new GuStringParameter(
-			this,
-			'TranscriptionWorkerRoleArnCODE',
-			{
-				description: 'IAM role for the CODE transcription worker instances',
-			},
-		);
-		const transcriptionWorkerRoleArnPROD = new GuStringParameter(
-			this,
-			'TranscriptionWorkerRoleArnPROD',
-			{
-				description: 'IAM role for the PROD transcription worker instances',
-			},
-		);
 		const repository = new Repository(this, 'TranscriptionServiceRepository', {
 			repositoryName: `transcription-service`,
 			lifecycleRules: [
@@ -55,13 +41,33 @@ export class TranscriptionServiceRepository extends GuStack {
 			removalPolicy: RemovalPolicy.DESTROY,
 			imageScanOnPush: true,
 		});
+		// allow transcription workers read access to the repo
 		repository.addToResourcePolicy(
 			new PolicyStatement({
 				principals: [
-					new ArnPrincipal(githubActionsIAMRoleArn.valueAsString),
-					new ArnPrincipal(transcriptionWorkerRoleArnCODE.valueAsString),
-					new ArnPrincipal(transcriptionWorkerRoleArnPROD.valueAsString),
+					new ArnPrincipal(
+						Fn.importValue(`transcription-service-CODE-WorkerRoleArn`),
+					),
+					new ArnPrincipal(
+						Fn.importValue(`transcription-service-PROD-WorkerRoleArn`),
+					),
 				],
+				actions: [
+					'ecr:GetAuthorizationToken',
+					'ecr:BatchCheckLayerAvailability',
+					'ecr:GetDownloadUrlForLayer',
+					'ecr:GetRepositoryPolicy',
+					'ecr:ListImages',
+					'ecr:DescribeImages',
+					'ecr:BatchGetImage',
+				],
+				effect: Effect.ALLOW,
+			}),
+		);
+		// allow github actions read/write access to the repo
+		repository.addToResourcePolicy(
+			new PolicyStatement({
+				principals: [new ArnPrincipal(githubActionsIAMRoleArn.valueAsString)],
 				actions: [
 					'ecr:GetAuthorizationToken',
 					'ecr:BatchCheckLayerAvailability',

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -67,6 +67,17 @@ export class TranscriptionService extends GuStack {
 			description: 'AMI to use for the worker instances',
 		});
 
+		const s3PrefixListId = new GuStringParameter(
+			this,
+			'S3PrefixListIdParameter',
+			{
+				fromSSM: true,
+				default: `/${this.stage}/${this.stack}/${APP_NAME}/s3PrefixListId`,
+				description:
+					'ID of the managed prefix list for the S3 service. See https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-create-vpc.html',
+			},
+		);
+
 		const ssmPrefix = `arn:aws:ssm:${props.env.region}:${GuardianAwsAccounts.Investigations}:parameter`;
 		const ssmPath = `${this.stage}/${this.stack}/${APP_NAME}`;
 		const domainName =
@@ -323,6 +334,11 @@ export class TranscriptionService extends GuStack {
 
 		workerSecurityGroup.addEgressRule(
 			Peer.securityGroupId(privateEndpointSecurityGroup),
+			Port.tcp(443),
+		);
+
+		workerSecurityGroup.addEgressRule(
+			Peer.prefixList(s3PrefixListId.valueAsString),
 			Port.tcp(443),
 		);
 

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -22,7 +22,7 @@ import {
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import { GuardianAwsAccounts } from '@guardian/private-infrastructure-config';
-import { type App, CfnOutput, Duration, Tags } from 'aws-cdk-lib';
+import { type App, CfnOutput, Duration, Fn, Tags } from 'aws-cdk-lib';
 import { EndpointType } from 'aws-cdk-lib/aws-apigateway';
 import {
 	AutoScalingGroup,
@@ -37,6 +37,8 @@ import {
 	InstanceType,
 	LaunchTemplate,
 	MachineImage,
+	Peer,
+	Port,
 	UserData,
 } from 'aws-cdk-lib/aws-ec2';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
@@ -313,6 +315,15 @@ export class TranscriptionService extends GuStack {
 				vpc,
 				allowAllOutbound: false,
 			},
+		);
+
+		const privateEndpointSecurityGroup = Fn.importValue(
+			`internet-enabled-vpc-AWSEndpointSecurityGroup`,
+		);
+
+		workerSecurityGroup.addEgressRule(
+			Peer.securityGroupId(privateEndpointSecurityGroup),
+			Port.tcp(443),
 		);
 
 		const launchTemplate = new LaunchTemplate(

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -22,7 +22,7 @@ import {
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import { GuardianAwsAccounts } from '@guardian/private-infrastructure-config';
-import { type App, Duration, Tags } from 'aws-cdk-lib';
+import { type App, CfnOutput, Duration, Tags } from 'aws-cdk-lib';
 import { EndpointType } from 'aws-cdk-lib/aws-apigateway';
 import {
 	AutoScalingGroup,
@@ -267,7 +267,7 @@ export class TranscriptionService extends GuStack {
 			resourceName: loggingStreamName,
 		});
 
-		const role = new GuInstanceRole(this, {
+		const workerRole = new GuInstanceRole(this, {
 			app: workerApp,
 			additionalPolicies: [
 				new GuPolicy(this, 'WorkerGetParameters', {
@@ -336,7 +336,7 @@ export class TranscriptionService extends GuStack {
 					},
 				],
 				userData,
-				role: role,
+				role: workerRole,
 				securityGroup: workerSecurityGroup,
 			},
 		);
@@ -482,5 +482,10 @@ export class TranscriptionService extends GuStack {
 
 		outputHandlerLambda.addToRolePolicy(getParametersPolicy);
 		outputHandlerLambda.addToRolePolicy(putMetricDataPolicy);
+
+		new CfnOutput(this, 'WorkerRoleArn', {
+			exportName: 'WorkerRoleArn',
+			value: workerRole.roleArn,
+		});
 	}
 }


### PR DESCRIPTION
## What does this change?
Prior to this PR we hadn't configured a security group for our transcription worker autoscaling group. As a result AWS applied the fallback default security group, which allows all outbound traffic.

For security reasons we'd like to block outbound traffic. Key considerations are:
 - Reassurance that transcript/audio data is not getting sent to some third party. Locking down egress traffic ensures this
 - If a users uploads some malware rather than some audio to transcribe, we want to limit the potential impact

This PR locks down egress traffic from the worker instances by applying a security group. However, in order to operate the worker does need access to some AWS services:
 - S3 - to download the worker deb package and transcript files
 - SQS - to fetch new transcript jobs
 - Autoscaling - to set e.g. scale-in protection
 - SNS - to post finished transcripts
 - Parameter store

This is achieved through the use of AWS Private Link/VPC endpoints which I've added here https://github.com/guardian/investigations-platform/pull/471. The S3 endpoint supports locking down to specific buckets/keys which we might want to consider at some point (otherwise in theory a malicious bit of code could upload to a random S3 bucket) but for now there's no restriction applied

This PR includes:
 - A new worker security group with egress rules for the new endpoints created in ttps://github.com/guardian/investigations-platform/pull/471. There are 2 rules - one that allows access to 'interface' vpc endpoints which is just a security group. For S3 we have to allow access to the 'managed prefix list' which appears to be global for our account - I've added as a parameter store parameter
 - I've updated the repository stack so that it allows the worker instances access to published containers **Note right now this isn't used as the containers are baked into the AMI** I thought this was a good idea because, following this change, the worker instances will no longer be able to access github packages to fetch the latest image.

## How to test
I've tested this on CODE - you can just deploy the branch and then check that transcription is still working.


![gandalf being an egress rule](https://media1.tenor.com/m/Rv-IfOOXPSIAAAAC/you-shall-not-pass-lotr.gif)
