### PR TITLE
Add message to task queue when file is uploaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6826,6 +6826,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
 		"node_modules/autoprefixer": {
 			"version": "10.4.17",
 			"dev": true,
@@ -7308,6 +7313,16 @@
 			},
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/axios": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+			"integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+			"dependencies": {
+				"follow-redirects": "^1.15.4",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/babel-jest": {
@@ -7963,6 +7978,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/commander": {
 			"version": "3.0.2",
 			"license": "MIT"
@@ -8145,6 +8171,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/depd": {
@@ -9091,6 +9125,25 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.5",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+			"integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/for-each": {
 			"version": "0.3.3",
 			"license": "MIT",
@@ -9122,6 +9175,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/forwarded": {
@@ -12550,6 +12616,11 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+		},
 		"node_modules/pstree.remy": {
 			"version": "1.1.8",
 			"dev": true,
@@ -14379,7 +14450,8 @@
 				"@aws-sdk/client-s3": "^3.496.0",
 				"@aws-sdk/client-sqs": "^3.496.0",
 				"@aws-sdk/client-ssm": "^3.496.0",
-				"@aws-sdk/lib-dynamodb": "^3.509.0"
+				"@aws-sdk/lib-dynamodb": "^3.509.0",
+				"axios": "^1.6.7"
 			},
 			"devDependencies": {}
 		},

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -63,7 +63,7 @@ const getApp = async () => {
 		}),
 	]);
 
-	apiRouter.post('/send-message', [
+	apiRouter.post('/transcribe-file', [
 		checkAuth,
 		asyncHandler(async (req, res) => {
 			const userEmail = req.user?.email;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,15 +9,14 @@ import passport from 'passport';
 import { Request, Response } from 'express';
 import {
 	getConfig,
-	getSignedUrl,
+	getSignedUploadUrl,
 	getSQSClient,
 	sendMessage,
 	isFailure,
-	getDownloadSignedUrl,
+	getSignedDownloadUrl,
 } from '@guardian/transcription-service-backend-common';
 import {
 	ClientConfig,
-	SignedUrlQueryParams,
 	TranscriptExportRequest,
 	sendMessageRequestBody,
 } from '@guardian/transcription-service-common';
@@ -77,7 +76,7 @@ const getApp = async () => {
 			}
 
 			const s3Key = body.data.s3Key;
-			const signedUrl = await getDownloadSignedUrl(
+			const signedUrl = await getSignedDownloadUrl(
 				config.aws.region,
 				config.app.sourceMediaBucket,
 				s3Key,
@@ -162,20 +161,14 @@ const getApp = async () => {
 		}),
 	]);
 
-	apiRouter.get('/signedUrl', [
+	apiRouter.get('/signed-url', [
 		checkAuth,
 		asyncHandler(async (req, res) => {
-			const queryParams = SignedUrlQueryParams.safeParse(req.query);
-			if (!queryParams.success) {
-				res.status(422).send('missing query parameters');
-				return;
-			}
 			const s3Key = uuid4();
-			const presignedS3Url = await getSignedUrl(
+			const presignedS3Url = await getSignedUploadUrl(
 				config.aws.region,
 				config.app.sourceMediaBucket,
 				req.user?.email ?? 'not found',
-				queryParams.data.fileName,
 				60,
 				true,
 				s3Key,

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -2,13 +2,13 @@
 	"name": "@guardian/transcription-service-backend-common",
 	"version": "1.0.0",
 	"dependencies": {
-		"@aws-sdk/client-ssm": "^3.496.0",
-		"@aws-sdk/client-sqs": "^3.496.0",
-		"@aws-sdk/client-s3": "^3.496.0",
 		"@aws-sdk/client-dynamodb": "^3.509.0",
-		"@aws-sdk/lib-dynamodb": "^3.509.0"
+		"@aws-sdk/client-s3": "^3.496.0",
+		"@aws-sdk/client-sqs": "^3.496.0",
+		"@aws-sdk/client-ssm": "^3.496.0",
+		"@aws-sdk/lib-dynamodb": "^3.509.0",
+		"axios": "^1.6.7"
 	},
-	"devDependencies": {},
 	"private": true,
 	"main": "src/index.ts",
 	"files": [

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -101,9 +101,7 @@ const downloadS3Data = async (
 	destinationPath: string,
 	key: string,
 ) => {
-	const body = ReadableBody.parse(data);
-
-	const stream = body.pipe(createWriteStream(destinationPath));
+	const stream = data.pipe(createWriteStream(destinationPath));
 
 	await new Promise<void>((resolve, reject) => {
 		stream

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -1,7 +1,6 @@
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl as getSignedUrlSdk } from '@aws-sdk/s3-request-presigner';
-import { v4 as uuid4 } from 'uuid';
 import { createWriteStream } from 'fs';
 import path from 'path';
 import { Readable } from 'stream';
@@ -32,11 +31,26 @@ export const getSignedUrl = (
 		getS3Client(region, useAccelerateEndpoint),
 		new PutObjectCommand({
 			Bucket: bucket,
-			Key: id || uuid4(),
+			Key: id,
 			Metadata: {
 				'user-email': userEmail,
 				'file-name': fileName,
 			},
+		}),
+		{ expiresIn }, // override default expiration time of 15 minutes
+	);
+
+export const getDownloadSignedUrl = async (
+	region: string,
+	bucket: string,
+	key: string,
+	expiresIn: number,
+) =>
+	await getSignedUrlSdk(
+		getS3Client(region),
+		new GetObjectCommand({
+			Bucket: bucket,
+			Key: key,
 		}),
 		{ expiresIn }, // override default expiration time of 15 minutes
 	);

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -1,4 +1,8 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+	GetObjectCommand,
+	HeadObjectCommand,
+	S3Client,
+} from '@aws-sdk/client-s3';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl as getSignedUrlSdk } from '@aws-sdk/s3-request-presigner';
 import { ReadStream, createWriteStream } from 'fs';
@@ -127,4 +131,23 @@ export const getFileFromS3 = async (
 	const file = await getFile(s3Client, bucket, s3Key, destinationDirectory);
 
 	return file;
+};
+
+export const getObjectMetadata = async (
+	region: string,
+	bucket: string,
+	key: string,
+) => {
+	try {
+		const client = getS3Client(region);
+		const data = await client.send(
+			new HeadObjectCommand({
+				Bucket: bucket,
+				Key: key,
+			}),
+		);
+		return data.Metadata;
+	} catch (e) {
+		return;
+	}
 };

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -19,11 +19,10 @@ export const getS3Client = (
 	});
 };
 
-export const getSignedUrl = (
+export const getSignedUploadUrl = (
 	region: string,
 	bucket: string,
 	userEmail: string,
-	fileName: string,
 	expiresIn: number,
 	useAccelerateEndpoint: boolean,
 	id?: string,
@@ -35,13 +34,12 @@ export const getSignedUrl = (
 			Key: id,
 			Metadata: {
 				'user-email': userEmail,
-				'file-name': fileName,
 			},
 		}),
 		{ expiresIn }, // override default expiration time of 15 minutes
 	);
 
-export const getDownloadSignedUrl = async (
+export const getSignedDownloadUrl = async (
 	region: string,
 	bucket: string,
 	key: string,

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -11,7 +11,7 @@ import {
 	DestinationService,
 	TranscriptionJob,
 } from '@guardian/transcription-service-common';
-import { getSignedUrl } from '@guardian/transcription-service-backend-common';
+import { getSignedUploadUrl } from '@guardian/transcription-service-backend-common';
 
 enum SQSStatus {
 	Success,
@@ -221,29 +221,26 @@ const generateOutputSignedUrls = async (
 	const srtKey = `srt/${id}.srt`;
 	const jsonKey = `json/${id}.json`;
 	const textKey = `text/${id}.txt`;
-	const srtSignedS3Url = await getSignedUrl(
+	const srtSignedS3Url = await getSignedUploadUrl(
 		region,
 		outputBucket,
 		userEmail,
-		originalFilename,
 		expiresIn,
 		false,
 		srtKey,
 	);
-	const textSignedS3Url = await getSignedUrl(
+	const textSignedS3Url = await getSignedUploadUrl(
 		region,
 		outputBucket,
 		userEmail,
-		originalFilename,
 		expiresIn,
 		false,
 		jsonKey,
 	);
-	const jsonSignedS3Url = await getSignedUrl(
+	const jsonSignedS3Url = await getSignedUploadUrl(
 		region,
 		outputBucket,
 		userEmail,
-		originalFilename,
 		expiresIn,
 		false,
 		textKey,

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -262,13 +262,6 @@ export class TranscriptionService extends GuStack {
 				new GuPolicy(this, 'WorkerGetParameters', {
 					statements: [getParametersPolicy],
 				}),
-				new GuAllowPolicy(this, 'GetDeleteSourceMedia', {
-					actions: ['s3:GetObject', 's3:DeleteObject'],
-					resources: [
-						`${sourceMediaBucket.bucketArn}/*`,
-						`${outputBucket.bucketArn}/*`,
-					],
-				}),
 				new GuAllowPolicy(this, 'WriteToDestinationTopic', {
 					actions: ['sns:Publish'],
 					resources: [transcriptDestinationTopic.topicArn],

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -31,11 +31,7 @@ export const UploadForm = () => {
 		const file = files[0];
 		const blob = new Blob([file as BlobPart]);
 
-		const urlParams = new URLSearchParams({ fileName: file.name });
-		const response = await authFetch(
-			`/api/signedUrl?${urlParams.toString()}`,
-			token,
-		);
+		const response = await authFetch(`/api/signed-url`, token);
 		if (!response) {
 			console.error('Failed to fetch signed url');
 			return;

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -46,7 +46,7 @@ export const UploadForm = () => {
 		const uploadStatus = await uploadToS3(body.data.presignedS3Url, blob);
 		setStatus(uploadStatus.isSuccess);
 
-		const sendMessageResponse = await authFetch('/api/send-message', token, {
+		const sendMessageResponse = await authFetch('/api/transcribe-file', token, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -58,7 +58,7 @@ export const UploadForm = () => {
 		});
 		const sendMessageSuccess = sendMessageResponse.status !== 200;
 		if (!sendMessageSuccess) {
-			console.error('Failed to call send-message');
+			console.error('Failed to call transcribe-file');
 			return;
 		}
 

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -49,6 +49,23 @@ export const UploadForm = () => {
 
 		const uploadStatus = await uploadToS3(body.data.presignedS3Url, blob);
 		setStatus(uploadStatus.isSuccess);
+
+		const sendMessageResponse = await authFetch('/api/send-message', token, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				s3Key: body.data.s3Key,
+				fileName: file.name,
+			}),
+		});
+		const sendMessageSuccess = sendMessageResponse.status !== 200;
+		if (!sendMessageSuccess) {
+			console.error('Failed to call send-message');
+			return;
+		}
+
 		if (uploadStatus.isSuccess) {
 			maybeFileInput.value = '';
 		}

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -54,6 +54,7 @@ export const SignedUrlQueryParams = z.object({ fileName: z.string() });
 
 export const SignedUrlResponseBody = z.object({
 	presignedS3Url: z.string(),
+	s3Key: z.string(),
 });
 export type SignedUrlResponseBody = z.infer<typeof SignedUrlResponseBody>;
 
@@ -95,3 +96,9 @@ export const ExportResponse = z.object({
 });
 
 export type ExportResponse = z.infer<typeof ExportResponse>;
+
+export const sendMessageRequestBody = z.object({
+	s3Key: z.string(),
+	fileName: z.string(),
+});
+export type SendMessageRequestBody = z.infer<typeof sendMessageRequestBody>;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -100,3 +100,10 @@ export const sendMessageRequestBody = z.object({
 	fileName: z.string(),
 });
 export type SendMessageRequestBody = z.infer<typeof sendMessageRequestBody>;
+
+export const inputBucketObjectMetadata = z.object({
+	'user-email': z.string(),
+});
+export type InputBucketObjectMetadata = z.infer<
+	typeof inputBucketObjectMetadata
+>;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -50,8 +50,6 @@ export const TranscriptionOutput = z.object({
 
 export type TranscriptionOutput = z.infer<typeof TranscriptionOutput>;
 
-export const SignedUrlQueryParams = z.object({ fileName: z.string() });
-
 export const SignedUrlResponseBody = z.object({
 	presignedS3Url: z.string(),
 	s3Key: z.string(),

--- a/packages/worker/.gitignore
+++ b/packages/worker/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 dist/
 target/
 *.js
+
+sample/

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,12 +1,12 @@
 import {
 	getConfig,
-	getFileFromS3,
 	getSQSClient,
 	getNextMessage,
 	parseTranscriptJobMessage,
 	isFailure,
 	deleteMessage,
 	changeMessageVisibility,
+	getObjectWithPresignedUrl,
 } from '@guardian/transcription-service-backend-common';
 import {
 	OutputBucketKeys,
@@ -68,11 +68,10 @@ const main = async () => {
 		const destinationDirectory =
 			config.app.stage === 'DEV' ? `${__dirname}/sample` : '/tmp';
 
-		const fileToTranscribe = await getFileFromS3(
-			config.aws.region,
-			destinationDirectory,
-			config.app.sourceMediaBucket,
+		const fileToTranscribe = await getObjectWithPresignedUrl(
 			job.inputSignedUrl,
+			job.id,
+			destinationDirectory,
 		);
 
 		// docker container to run ffmpeg and whisper on file


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- updates the `transcribe-file` api endpoint (renamed from `send-message`) so that it 
  - takes an  `s3Key` parameter 
  - creates a presigned url to download the file with the given key in the uploads bucket
  - adds a message to the task queue (with non-test data) including this url so that the worker can use it to get the file
- change to client so that when the user submits the form, after the file is uploaded to s3, `transcribe-file` is called.
- change to worker so that it uses this presigned url rather than having access to the entire bucket. This change is important because it will allow third parties to integrate with the transcription service without our having to change any of the worker permissions. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- can be tested locally by starting api, client, worker
- testing in CODE

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
