### PR TITLE
Adding devX managed nightly backups

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -418,6 +418,9 @@ export class TranscriptionService extends GuStack {
 			writeCapacity: 1,
 		});
 
+		// Enable nightly backups (via https://github.com/guardian/aws-backup)
+		Tags.of(transcriptTable).add('devx-backup-enabled', 'true');
+
 		const outputHandlerLambda = new GuLambdaFunction(
 			this,
 			'transcription-service-output-handler',


### PR DESCRIPTION
## What does this change?

Adds `devx-backup-enabled` tag to enable nightly backups

## How to test

Deployed to CODE, tag is present.
