### PR TITLE
Include Stage in worker Arn output parameter

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -511,7 +511,7 @@ export class TranscriptionService extends GuStack {
 		outputHandlerLambda.addToRolePolicy(putMetricDataPolicy);
 
 		new CfnOutput(this, 'WorkerRoleArn', {
-			exportName: 'WorkerRoleArn',
+			exportName: `WorkerRoleArn-${props.stage}`,
 			value: workerRole.roleArn,
 		});
 	}


### PR DESCRIPTION
## What does this change?
The changes in https://github.com/guardian/transcription-service/pull/34 broke our cloudformation deploys because cloudformation stack export names must be unique - they can't be the same for CODE and PROD. This change adds the stage to ensure this.