### PR TITLE
hotfix: remove worker security group

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -364,7 +364,7 @@ export class TranscriptionService extends GuStack {
 				],
 				userData,
 				role: workerRole,
-				securityGroup: workerSecurityGroup,
+				// securityGroup: workerSecurityGroup,
 			},
 		);
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
temporarily remove the worker security group - we think this is causing workers not to be able to fetch media files from s3