### PR TITLE
Worker polls for transcription tasks every 30 seconds

### DIFF
--- a/packages/worker/src/asg.ts
+++ b/packages/worker/src/asg.ts
@@ -29,7 +29,7 @@ export const updateScaleInProtection = async (
 			);
 		}
 	} catch (error) {
-		console.log(`Could not remove scale-in protection`, error);
+		console.error(`Could not set scale-in protection`, error);
 		throw error;
 	}
 };

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -68,6 +68,14 @@ const releaseSemaphoreAndRemoveScaleInProtection = async (
 	await updateScaleInProtection(region, stage, false);
 };
 
+const takeSemaphoreAndEnableScaleInProtection = async (
+	region: string,
+	stage: string,
+) => {
+	transcriptionTaskSemaphoreTaken = true;
+	await updateScaleInProtection(region, stage, true);
+};
+
 const pollTranscriptionQueue = async (
 	pollCount: number,
 	sqsClient: SQSClient,
@@ -86,6 +94,8 @@ const pollTranscriptionQueue = async (
 	console.log(
 		`worker polling for transcription task. Poll count = ${pollCount}`,
 	);
+
+	await takeSemaphoreAndEnableScaleInProtection(region, stage);
 
 	const message = await getNextMessage(sqsClient, config.app.taskQueueUrl);
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- changes transcriptions workers so that they poll the task queue every 30 seconds, rather than only polling once, when they're started up.
- this should help to stop workers from getting into a state where they are doing no work but preventing other workers from taking their place

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- [x] test on code
