### PR TITLE
Set security group on worker instances but allow all outbound.

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -324,7 +324,7 @@ export class TranscriptionService extends GuStack {
 			{
 				app: workerApp,
 				vpc,
-				allowAllOutbound: false,
+				allowAllOutbound: true,
 			},
 		);
 
@@ -364,7 +364,7 @@ export class TranscriptionService extends GuStack {
 				],
 				userData,
 				role: workerRole,
-				// securityGroup: workerSecurityGroup,
+				securityGroup: workerSecurityGroup,
 			},
 		);
 


### PR DESCRIPTION
I'm currently in the process of updating the default security groups in our AWS account so that by default they block all traffic. We are currently facing some problems with the VPC endpoints that allow transcription workers to interact with AWS services - whilst we debug that we want to allow all outbound traffic. 

With that in mind this PR makes sure a SG is explicitly applied to the worker launch template so that instances don't fall back to using the default security group, which will soon block outbound traffic.

A variation on https://github.com/guardian/transcription-service/pull/42 