### PR TITLE
Create dead letter queue for transcription tasks

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -459,7 +459,7 @@ export class TranscriptionService extends GuStack {
 			contentBasedDeduplication: true,
 			deadLetterQueue: {
 				queue: transcriptionDeadLetterQueue,
-				maxReceiveCount: 5,
+				maxReceiveCount: 3,
 			},
 		});
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- cdk for a dead letter queue where transcription task messages are moved after 3 failed attempts
- also includes a small change to workers to log a message and exit early when sqs message receipt handle is missing

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- [x] test in CODE

