### PR TITLE
Move task to dead letter queue when conversion to wav fails

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -11,7 +11,7 @@ import {
 	getConfig,
 	getSignedUploadUrl,
 	getSQSClient,
-	sendMessage,
+	generateOutputSignedUrlAndSendMessage,
 	isFailure,
 	getSignedDownloadUrl,
 	getObjectMetadata,
@@ -109,7 +109,7 @@ const getApp = async () => {
 				s3Key,
 				3600,
 			);
-			const sendResult = await sendMessage(
+			const sendResult = await generateOutputSignedUrlAndSendMessage(
 				s3Key,
 				sqsClient,
 				config.app.taskQueueUrl,

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -10,6 +10,7 @@ export interface TranscriptionConfig {
 		secret: string;
 		rootUrl: string;
 		taskQueueUrl: string;
+		deadLetterQueueUrl: string;
 		stage: string;
 		emailNotificationFromAddress: string;
 		sourceMediaBucket: string;
@@ -70,6 +71,11 @@ export const getConfig = async (): Promise<TranscriptionConfig> => {
 
 	console.log(`Parameters fetched: ${parameterNames.join(', ')}`);
 	const taskQueueUrl = findParameter(parameters, paramPath, 'taskQueueUrl');
+	const deadLetterQueueUrl = findParameter(
+		parameters,
+		paramPath,
+		'deadLetterQueueUrl',
+	);
 	const destinationTopic = findParameter(
 		parameters,
 		paramPath,
@@ -121,6 +127,7 @@ export const getConfig = async (): Promise<TranscriptionConfig> => {
 			rootUrl: appRootUrl,
 			secret: appSecret,
 			taskQueueUrl,
+			deadLetterQueueUrl,
 			stage,
 			sourceMediaBucket,
 			emailNotificationFromAddress,

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -10,7 +10,7 @@ export interface TranscriptionConfig {
 		secret: string;
 		rootUrl: string;
 		taskQueueUrl: string;
-		deadLetterQueueUrl: string;
+		deadLetterQueueUrl?: string;
 		stage: string;
 		emailNotificationFromAddress: string;
 		sourceMediaBucket: string;
@@ -71,11 +71,10 @@ export const getConfig = async (): Promise<TranscriptionConfig> => {
 
 	console.log(`Parameters fetched: ${parameterNames.join(', ')}`);
 	const taskQueueUrl = findParameter(parameters, paramPath, 'taskQueueUrl');
-	const deadLetterQueueUrl = findParameter(
-		parameters,
-		paramPath,
-		'deadLetterQueueUrl',
-	);
+	const deadLetterQueueUrl =
+		stage === 'DEV'
+			? undefined
+			: findParameter(parameters, paramPath, 'deadLetterQueueUrl');
 	const destinationTopic = findParameter(
 		parameters,
 		paramPath,

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -114,7 +114,7 @@ const sendMessage = async (
 			errorMsg: 'Missing message ID',
 		};
 	} catch (e) {
-		const msg = `Failed to send job ${messageBody}`;
+		const msg = `Failed to send message ${messageBody}`;
 		console.error(msg, e);
 		return {
 			status: SQSStatus.Failure,
@@ -225,10 +225,8 @@ export const moveMessageToDeadLetterQueue = async (
 	// succeeds but the delete from the task queue fails
 	const sendResult = await sendMessage(client, deadLetterQueueUrl, messageBody);
 	if (sendResult.status == SQSStatus.Failure) {
-		const errorMessage = 'Failed to send message to dead letter queue.';
-		console.error(errorMessage, sendResult.error, sendResult.errorMsg);
 		// rethrow exception, let another worker retry
-		throw Error(errorMessage);
+		throw Error('Failed to send message to dead letter queue');
 	}
 	// if the delete command throws an exception, it will be caught by
 	// deleteMessage and logged. Another worker will reprocess the message in

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -28,6 +28,10 @@ interface ReceiveSuccess {
 	message?: Message;
 }
 
+interface DeleteSuccess {
+	status: SQSStatus.Success;
+}
+
 interface SQSFailure {
 	status: SQSStatus.Failure;
 	error?: unknown;
@@ -36,6 +40,7 @@ interface SQSFailure {
 
 type SendResult = SendSuccess | SQSFailure;
 type ReceiveResult = ReceiveSuccess | SQSFailure;
+type DeleteResult = DeleteSuccess | SQSFailure;
 
 export const getSQSClient = (region: string, localstackEndpoint?: string) => {
 	const clientBaseConfig = {
@@ -52,7 +57,7 @@ export const isFailure = (
 	result: SendResult | ReceiveResult,
 ): result is SQSFailure => result.status === SQSStatus.Failure;
 
-export const sendMessage = async (
+export const generateOutputSignedUrlAndSendMessage = async (
 	id: string,
 	client: SQSClient,
 	queueUrl: string,
@@ -81,12 +86,19 @@ export const sendMessage = async (
 		originalFilename,
 		outputBucketUrls: signedUrls,
 	};
+	return await sendMessage(client, queueUrl, JSON.stringify(job));
+};
 
+const sendMessage = async (
+	client: SQSClient,
+	queueUrl: string,
+	messageBody: string,
+): Promise<SendResult> => {
 	try {
 		const result = await client.send(
 			new SendMessageCommand({
 				QueueUrl: queueUrl,
-				MessageBody: JSON.stringify(job),
+				MessageBody: messageBody,
 				MessageGroupId: 'api-transcribe-request',
 			}),
 		);
@@ -102,7 +114,7 @@ export const sendMessage = async (
 			errorMsg: 'Missing message ID',
 		};
 	} catch (e) {
-		const msg = `Failed to send job ${JSON.stringify(job, null, 2)}`;
+		const msg = `Failed to send job ${messageBody}`;
 		console.error(msg, e);
 		return {
 			status: SQSStatus.Failure,
@@ -179,7 +191,7 @@ export const deleteMessage = async (
 	client: SQSClient,
 	queueUrl: string,
 	receiptHandle: string,
-) => {
+): Promise<DeleteResult> => {
 	try {
 		await client.send(
 			new DeleteMessageCommand({
@@ -187,10 +199,39 @@ export const deleteMessage = async (
 				ReceiptHandle: receiptHandle,
 			}),
 		);
+		return {
+			status: SQSStatus.Success,
+		};
 	} catch (error) {
-		console.error(`Failed to delete message ${receiptHandle}`, error);
-		throw error;
+		const errorMsg = `Failed to delete message ${receiptHandle}`;
+		console.error(errorMsg, error);
+		return {
+			status: SQSStatus.Failure,
+			error,
+			errorMsg,
+		};
 	}
+};
+
+export const moveMessageToDeadLetterQueue = async (
+	client: SQSClient,
+	taskQueueUrl: string,
+	deadLetterQueueUrl: string,
+	messageBody: string,
+	receiptHandle: string,
+) => {
+	// SQS doesn't seem to offer an atomic way to move message from one queue to
+	// another. There is a chance that the write to the dead letter queue
+	// succeeds but the delete from the task queue fails
+	const sendResult = await sendMessage(client, deadLetterQueueUrl, messageBody);
+	if (sendResult.status == SQSStatus.Failure) {
+		const errorMessage = 'Failed to send message to dead letter queue.';
+		console.error(errorMessage, sendResult.error, sendResult.errorMsg);
+		throw Error(errorMessage);
+	}
+	// if the delete command throws an exception, it will be caught by
+	// deleteMessage and logged
+	await deleteMessage(client, taskQueueUrl, receiptHandle);
 };
 
 export const parseTranscriptJobMessage = (

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -227,10 +227,12 @@ export const moveMessageToDeadLetterQueue = async (
 	if (sendResult.status == SQSStatus.Failure) {
 		const errorMessage = 'Failed to send message to dead letter queue.';
 		console.error(errorMessage, sendResult.error, sendResult.errorMsg);
+		// rethrow exception, let another worker retry
 		throw Error(errorMessage);
 	}
 	// if the delete command throws an exception, it will be caught by
-	// deleteMessage and logged
+	// deleteMessage and logged. Another worker will reprocess the message in
+	// the main task queue and we'll have a duplicate in the dead letter queue.
 	await deleteMessage(client, taskQueueUrl, receiptHandle);
 };
 

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -469,6 +469,9 @@ export class TranscriptionService extends GuStack {
 		// allow worker to receive message from queue
 		transcriptionTaskQueue.grantConsumeMessages(transcriptionWorkerASG);
 
+		// allow worker to write messages to the dead letter queue
+		transcriptionDeadLetterQueue.grantSendMessages(transcriptionWorkerASG);
+
 		const transcriptTable = new Table(this, 'TranscriptTable', {
 			tableName: `${APP_NAME}-${this.stage}`,
 			partitionKey: {

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -442,6 +442,7 @@ export class TranscriptionService extends GuStack {
 			{
 				fifo: true,
 				queueName: `${APP_NAME}-task-dead-letter-queue-${this.stage}.fifo`,
+				contentBasedDeduplication: true,
 			},
 		);
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -146,7 +146,7 @@ const pollTranscriptionQueue = async (
 		if (ffmpegResult === undefined) {
 			// when ffmpeg fails to transcribe, move message to the dead letter
 			// queue
-			if (config.app.stage != 'DEV') {
+			if (config.app.stage != 'DEV' && config.app.deadLetterQueueUrl) {
 				console.log(
 					`moving message with message id ${taskMessage.MessageId} to dead letter queue`,
 				);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -157,6 +157,9 @@ const pollTranscriptionQueue = async (
 					taskMessage.Body,
 					receiptHandle,
 				);
+				console.log(
+					`moved message with message id ${taskMessage.MessageId} to dead letter queue.`,
+				);
 			} else {
 				console.log('skip moving message to dead letter queue in DEV');
 			}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -148,7 +148,7 @@ const pollTranscriptionQueue = async (
 			// queue
 			if (config.app.stage != 'DEV' && config.app.deadLetterQueueUrl) {
 				console.log(
-					`moving message with message id ${taskMessage.MessageId} to dead letter queue`,
+					`'ffmpeg failed, moving message with message id ${taskMessage.MessageId} to dead letter queue`,
 				);
 				await moveMessageToDeadLetterQueue(
 					sqsClient,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -8,6 +8,7 @@ import {
 	changeMessageVisibility,
 	getObjectWithPresignedUrl,
 	TranscriptionConfig,
+	moveMessageToDeadLetterQueue,
 } from '@guardian/transcription-service-backend-common';
 import {
 	OutputBucketKeys,
@@ -98,6 +99,12 @@ const pollTranscriptionQueue = async (
 	}
 
 	const taskMessage = message.message;
+	if (!taskMessage.Body) {
+		console.log('message missing body');
+		await updateScaleInProtection(region, stage, false);
+		return;
+	}
+
 	const receiptHandle = taskMessage.ReceiptHandle;
 	if (!receiptHandle) {
 		console.log('message missing receipt handle');
@@ -136,6 +143,25 @@ const pollTranscriptionQueue = async (
 		);
 
 		const ffmpegResult = await convertToWav(containerId, fileToTranscribe);
+		if (ffmpegResult === undefined) {
+			// when ffmpeg fails to transcribe, move message to the dead letter
+			// queue
+			if (config.app.stage != 'DEV') {
+				console.log(
+					`moving message with message id ${taskMessage.MessageId} to dead letter queue`,
+				);
+				await moveMessageToDeadLetterQueue(
+					sqsClient,
+					config.app.taskQueueUrl,
+					config.app.deadLetterQueueUrl,
+					taskMessage.Body,
+					receiptHandle,
+				);
+			} else {
+				console.log('skip moving message to dead letter queue in DEV');
+			}
+			return;
+		}
 
 		if (ffmpegResult.duration && ffmpegResult.duration !== 0) {
 			// Adding 300 seconds (5 minutes) and the file duration

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -94,7 +94,7 @@ export const getOrCreateContainer = async (
 export const convertToWav = async (
 	containerId: string,
 	file: string,
-): Promise<FfmpegResult> => {
+): Promise<FfmpegResult | void> => {
 	const fileName = path.basename(file);
 	const filePath = `${CONTAINER_FOLDER}/${fileName}`;
 	const wavPath = `${CONTAINER_FOLDER}/${fileName}-converted.wav`;
@@ -127,7 +127,7 @@ export const convertToWav = async (
 		};
 	} catch (error) {
 		console.log('ffmpeg failed error:', error);
-		throw error;
+		return;
 	}
 };
 

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -94,7 +94,7 @@ export const getOrCreateContainer = async (
 export const convertToWav = async (
 	containerId: string,
 	file: string,
-): Promise<FfmpegResult | void> => {
+): Promise<FfmpegResult | undefined> => {
 	const fileName = path.basename(file);
 	const filePath = `${CONTAINER_FOLDER}/${fileName}`;
 	const wavPath = `${CONTAINER_FOLDER}/${fileName}-converted.wav`;
@@ -127,7 +127,7 @@ export const convertToWav = async (
 		};
 	} catch (error) {
 		console.log('ffmpeg failed error:', error);
-		return;
+		return undefined;
 	}
 };
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,9 +4,9 @@ set -e
 SCRIPT_PATH=$( cd $(dirname $0) ; pwd -P )
 APP_NAME="transcription-service"
 
-# npm install
+npm install
 
-# dev-nginx setup-app nginx/nginx-mapping.yml
+dev-nginx setup-app nginx/nginx-mapping.yml
 
 if (! docker stats --no-stream 1>/dev/null 2>&1); then
   echo "Starting docker..."
@@ -23,14 +23,6 @@ fi
 
 # Starting localstack
 docker-compose up -d
-
-# Wait for localstack to be ready
-DEAD_LETTER_OUTPUT=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=$APP_NAME-task-dead-letter-queue-DEV.fifo --attributes "FifoQueue=true,ContentBasedDeduplication=true")
-echo $DEAD_LETTER_OUTPUT
-DEAD_LETTER_QUEUE_URL=$(echo $DEAD_LETTER_OUTPUT | jq .QueueUrl)
-DEAD_LETTER_QUEUE_URL_LOCALHOST=${QUEUE_URL/sqs.eu-west-1.localhost.localstack.cloud/localhost}
-echo "Created queue in localstack, url: ${DEAD_LETTER_QUEUE_URL_LOCALHOST}"
-
 # If the queue already exists this command appears to still work and returns the existing queue url
 QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=$APP_NAME-task-queue-DEV.fifo --attributes "FifoQueue=true,ContentBasedDeduplication=true" | jq .QueueUrl)
 # We don't install the localstack dns so need to replace the endpoint with localhost


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- updates CDK to allow worker instances to write sqs messages to the dead letter task queue
- when workers fail when processing a file that can't be converted to a wav, move the sqs message to the dead letter queue

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- [x] tested in CODE by attempting to transcribe a jpeg
- [x] transcription still working as expected for an mp3
