### PR TITLE
Improve logging using winston

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4963,6 +4963,14 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@colors/colors": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
 		"node_modules/@contentlayer/cli": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/@contentlayer/cli/-/cli-0.3.4.tgz",
@@ -5161,6 +5169,16 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@dabh/diagnostics": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+			"dependencies": {
+				"colorspace": "1.1.x",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
 			}
 		},
 		"node_modules/@effect-ts/core": {
@@ -8221,6 +8239,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/triple-beam": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+		},
 		"node_modules/@types/unist": {
 			"version": "2.0.10",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
@@ -8731,7 +8754,6 @@
 		},
 		"node_modules/async": {
 			"version": "3.2.5",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/asynckit": {
@@ -10085,6 +10107,37 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/colorspace": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+			"dependencies": {
+				"color": "^3.1.3",
+				"text-hex": "1.0.x"
+			}
+		},
+		"node_modules/colorspace/node_modules/color": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+			"dependencies": {
+				"color-convert": "^1.9.3",
+				"color-string": "^1.6.0"
+			}
+		},
+		"node_modules/colorspace/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/colorspace/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -10561,6 +10614,11 @@
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"license": "MIT"
+		},
+		"node_modules/enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
 		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
@@ -11789,6 +11847,11 @@
 				"bser": "2.1.1"
 			}
 		},
+		"node_modules/fecha": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+		},
 		"node_modules/fetch-blob": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -12185,6 +12248,11 @@
 			"engines": {
 				"node": "^10 || ^12 || >=14"
 			}
+		},
+		"node_modules/fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.5",
@@ -15116,6 +15184,11 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+		},
 		"node_modules/lazy-cache": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
@@ -15687,6 +15760,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/logform": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+			"dependencies": {
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"safe-stable-stringify": "^2.3.1",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/long": {
@@ -18115,6 +18204,14 @@
 				"wrappy": "1"
 			}
 		},
+		"node_modules/one-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"dependencies": {
+				"fn.name": "1.x.x"
+			}
+		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
 			"dev": true,
@@ -20141,6 +20238,14 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"license": "MIT"
@@ -20487,6 +20592,14 @@
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+			"engines": {
+				"node": "*"
+			}
 		},
 		"node_modules/stack-utils": {
 			"version": "2.0.6",
@@ -20949,6 +21062,11 @@
 				"node": "*"
 			}
 		},
+		"node_modules/text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"dev": true,
@@ -21065,6 +21183,14 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/triple-beam": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+			"engines": {
+				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/trough": {
@@ -21897,6 +22023,66 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/winston": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+			"integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
+			"dependencies": {
+				"@colors/colors": "^1.6.0",
+				"@dabh/diagnostics": "^2.0.2",
+				"async": "^3.2.3",
+				"is-stream": "^2.0.0",
+				"logform": "^2.4.0",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"safe-stable-stringify": "^2.3.1",
+				"stack-trace": "0.0.x",
+				"triple-beam": "^1.3.0",
+				"winston-transport": "^4.5.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/winston-transport": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+			"integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
+			"dependencies": {
+				"logform": "^2.3.2",
+				"readable-stream": "^3.6.0",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/winston-transport/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/winston/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/wordwrap": {
 			"version": "1.0.0",
 			"dev": true,
@@ -22112,7 +22298,8 @@
 				"@aws-sdk/client-sqs": "^3.496.0",
 				"@aws-sdk/client-ssm": "^3.496.0",
 				"@aws-sdk/lib-dynamodb": "^3.509.0",
-				"axios": "^1.6.7"
+				"axios": "^1.6.7",
+				"winston": "^3.11.0"
 			}
 		},
 		"packages/cdk": {
@@ -22437,8 +22624,6 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
-				"@aws-sdk/client-auto-scaling": "^3.514.0",
-				"@aws-sdk/client-sqs": "^3.514.0",
 				"@guardian/transcription-service-backend-common": "1.0.0",
 				"@guardian/transcription-service-common": "1.0.0"
 			},
@@ -22455,8 +22640,7 @@
 			"dev": true
 		},
 		"@alloc/quick-lru": {
-			"version": "5.2.0",
-			"dev": true
+			"version": "5.2.0"
 		},
 		"@ampproject/remapping": {
 			"version": "2.2.1",
@@ -26356,16 +26540,350 @@
 		"@codegenie/serverless-express": {
 			"version": "4.13.0"
 		},
+		"@colors/colors": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
+		},
+		"@contentlayer/cli": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@contentlayer/cli/-/cli-0.3.4.tgz",
+			"integrity": "sha512-vNDwgLuhYNu+m70NZ3XK9kexKNguuxPXg7Yvzj3B34cEilQjjzSrcTY/i+AIQm9V7uT5GGshx9ukzPf+SmoszQ==",
+			"requires": {
+				"@contentlayer/core": "0.3.4",
+				"@contentlayer/utils": "0.3.4",
+				"clipanion": "^3.2.1",
+				"typanion": "^3.12.1"
+			}
+		},
+		"@contentlayer/client": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@contentlayer/client/-/client-0.3.4.tgz",
+			"integrity": "sha512-QSlLyc3y4PtdC5lFw0L4wTZUH8BQnv2nk37hNCsPAqGf+dRO7TLAzdc+2/mVIRgK+vSH+pSOzjLsQpFxxXRTZA==",
+			"requires": {
+				"@contentlayer/core": "0.3.4"
+			}
+		},
+		"@contentlayer/core": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@contentlayer/core/-/core-0.3.4.tgz",
+			"integrity": "sha512-o68oBLwfYZ+2vtgfk1lgHxOl3LoxvRNiUfeQ8IWFWy/L4wnIkKIqLZX01zlRE5IzYM+ZMMN5V0cKQlO7DsyR9g==",
+			"requires": {
+				"@contentlayer/utils": "0.3.4",
+				"camel-case": "^4.1.2",
+				"comment-json": "^4.2.3",
+				"esbuild": "0.17.x || 0.18.x",
+				"gray-matter": "^4.0.3",
+				"mdx-bundler": "^9.2.1",
+				"rehype-stringify": "^9.0.3",
+				"remark-frontmatter": "^4.0.1",
+				"remark-parse": "^10.0.2",
+				"remark-rehype": "^10.1.0",
+				"source-map-support": "^0.5.21",
+				"type-fest": "^3.12.0",
+				"unified": "^10.1.2"
+			},
+			"dependencies": {
+				"@esbuild/darwin-arm64": {
+					"version": "0.18.20",
+					"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+					"integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+					"optional": true
+				},
+				"esbuild": {
+					"version": "0.18.20",
+					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+					"integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+					"requires": {
+						"@esbuild/android-arm": "0.18.20",
+						"@esbuild/android-arm64": "0.18.20",
+						"@esbuild/android-x64": "0.18.20",
+						"@esbuild/darwin-arm64": "0.18.20",
+						"@esbuild/darwin-x64": "0.18.20",
+						"@esbuild/freebsd-arm64": "0.18.20",
+						"@esbuild/freebsd-x64": "0.18.20",
+						"@esbuild/linux-arm": "0.18.20",
+						"@esbuild/linux-arm64": "0.18.20",
+						"@esbuild/linux-ia32": "0.18.20",
+						"@esbuild/linux-loong64": "0.18.20",
+						"@esbuild/linux-mips64el": "0.18.20",
+						"@esbuild/linux-ppc64": "0.18.20",
+						"@esbuild/linux-riscv64": "0.18.20",
+						"@esbuild/linux-s390x": "0.18.20",
+						"@esbuild/linux-x64": "0.18.20",
+						"@esbuild/netbsd-x64": "0.18.20",
+						"@esbuild/openbsd-x64": "0.18.20",
+						"@esbuild/sunos-x64": "0.18.20",
+						"@esbuild/win32-arm64": "0.18.20",
+						"@esbuild/win32-ia32": "0.18.20",
+						"@esbuild/win32-x64": "0.18.20"
+					}
+				},
+				"type-fest": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+					"integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="
+				}
+			}
+		},
+		"@contentlayer/source-files": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@contentlayer/source-files/-/source-files-0.3.4.tgz",
+			"integrity": "sha512-4njyn0OFPu7WY4tAjMxiJgWOKeiHuBOGdQ36EYE03iij/pPPRbiWbL+cmLccYXUFEW58mDwpqROZZm6pnxjRDQ==",
+			"requires": {
+				"@contentlayer/core": "0.3.4",
+				"@contentlayer/utils": "0.3.4",
+				"chokidar": "^3.5.3",
+				"fast-glob": "^3.2.12",
+				"gray-matter": "^4.0.3",
+				"imagescript": "^1.2.16",
+				"micromatch": "^4.0.5",
+				"ts-pattern": "^4.3.0",
+				"unified": "^10.1.2",
+				"yaml": "^2.3.1",
+				"zod": "^3.21.4"
+			}
+		},
+		"@contentlayer/source-remote-files": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@contentlayer/source-remote-files/-/source-remote-files-0.3.4.tgz",
+			"integrity": "sha512-cyiv4sNUySZvR0uAKlM+kSAELzNd2h2QT1R2e41dRKbwOUVxeLfmGiLugr0aVac6Q3xYcD99dbHyR1xWPV+w9w==",
+			"requires": {
+				"@contentlayer/core": "0.3.4",
+				"@contentlayer/source-files": "0.3.4",
+				"@contentlayer/utils": "0.3.4"
+			}
+		},
+		"@contentlayer/utils": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@contentlayer/utils/-/utils-0.3.4.tgz",
+			"integrity": "sha512-ZWWOhbUWYQ2QHoLIlcUnEo7X4ZbwcyFPuzVQWWMkK43BxCveyQtZwBIzfyx54sqVzi0GUmKP8bHzsLQT0QxaLQ==",
+			"requires": {
+				"@effect-ts/core": "^0.60.5",
+				"@effect-ts/otel": "^0.15.1",
+				"@effect-ts/otel-exporter-trace-otlp-grpc": "^0.15.1",
+				"@effect-ts/otel-sdk-trace-node": "^0.15.1",
+				"@js-temporal/polyfill": "^0.4.4",
+				"@opentelemetry/api": "^1.4.1",
+				"@opentelemetry/core": "^1.13.0",
+				"@opentelemetry/exporter-trace-otlp-grpc": "^0.39.1",
+				"@opentelemetry/resources": "^1.13.0",
+				"@opentelemetry/sdk-trace-base": "^1.13.0",
+				"@opentelemetry/sdk-trace-node": "^1.13.0",
+				"@opentelemetry/semantic-conventions": "^1.13.0",
+				"chokidar": "^3.5.3",
+				"hash-wasm": "^4.9.0",
+				"inflection": "^2.0.1",
+				"memfs": "^3.5.1",
+				"oo-ascii-tree": "^1.84.0",
+				"ts-pattern": "^4.3.0",
+				"type-fest": "^3.12.0"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+					"integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="
+				}
+			}
+		},
 		"@cspotcode/source-map-support": {
 			"version": "0.8.1",
-			"dev": true,
+			"devOptional": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "0.3.9"
 			}
 		},
+		"@dabh/diagnostics": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+			"requires": {
+				"colorspace": "1.1.x",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
+			}
+		},
+		"@effect-ts/core": {
+			"version": "0.60.5",
+			"resolved": "https://registry.npmjs.org/@effect-ts/core/-/core-0.60.5.tgz",
+			"integrity": "sha512-qi1WrtJA90XLMnj2hnUszW9Sx4dXP03ZJtCc5DiUBIOhF4Vw7plfb65/bdBySPoC9s7zy995TdUX1XBSxUkl5w==",
+			"requires": {
+				"@effect-ts/system": "^0.57.5"
+			}
+		},
+		"@effect-ts/otel": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@effect-ts/otel/-/otel-0.15.1.tgz",
+			"integrity": "sha512-AmZJHl7t0+Peh7Yb2+hqn6r9+rd9/UfeA4AMV9h0YGTdOyouyFfD3wzWlxnAUzAQ4Lrod4kC7Noruret4EpqpA==",
+			"requires": {}
+		},
+		"@effect-ts/otel-exporter-trace-otlp-grpc": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@effect-ts/otel-exporter-trace-otlp-grpc/-/otel-exporter-trace-otlp-grpc-0.15.1.tgz",
+			"integrity": "sha512-47gAg0O2pW5Jlo86jfzjdkwL5a7Bzb+Kj5WTmdu4CxYRfWn9ytKjuuYIfsNDW8neuhdKzn+P5wCddgEh0glYyQ==",
+			"requires": {
+				"@effect-ts/otel": "^0.15.1"
+			}
+		},
+		"@effect-ts/otel-sdk-trace-node": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@effect-ts/otel-sdk-trace-node/-/otel-sdk-trace-node-0.15.1.tgz",
+			"integrity": "sha512-a2sF0ylmn8xOJs8fNeT/spJ1gUcsksAJCALxo9WOfuTCMtTwMVtVhCKEPEeQoL7wFqU+JgPkVdP91+FJ/Rkeow==",
+			"requires": {
+				"@effect-ts/otel": "^0.15.1"
+			}
+		},
+		"@effect-ts/system": {
+			"version": "0.57.5",
+			"resolved": "https://registry.npmjs.org/@effect-ts/system/-/system-0.57.5.tgz",
+			"integrity": "sha512-/crHGujo0xnuHIYNc1VgP0HGJGFSoSqq88JFXe6FmFyXPpWt8Xu39LyLg7rchsxfXFeEdA9CrIZvLV5eswXV5g=="
+		},
+		"@esbuild-plugins/node-resolve": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-resolve/-/node-resolve-0.1.4.tgz",
+			"integrity": "sha512-haFQ0qhxEpqtWWY0kx1Y5oE3sMyO1PcoSiWEPrAw6tm/ZOOLXjSs6Q+v1v9eyuVF0nNt50YEvrcrvENmyoMv5g==",
+			"requires": {
+				"@types/resolve": "^1.17.1",
+				"debug": "^4.3.1",
+				"escape-string-regexp": "^4.0.0",
+				"resolve": "^1.19.0"
+			}
+		},
+		"@esbuild/aix-ppc64": {
+			"version": "0.19.11",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.11.tgz",
+			"integrity": "sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==",
+			"optional": true
+		},
+		"@esbuild/android-arm": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+			"integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+			"optional": true
+		},
+		"@esbuild/android-arm64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+			"integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+			"optional": true
+		},
+		"@esbuild/android-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+			"integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+			"optional": true
+		},
 		"@esbuild/darwin-arm64": {
 			"version": "0.19.11",
-			"dev": true,
+			"optional": true
+		},
+		"@esbuild/darwin-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+			"integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+			"optional": true
+		},
+		"@esbuild/freebsd-arm64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+			"integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+			"optional": true
+		},
+		"@esbuild/freebsd-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+			"integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+			"optional": true
+		},
+		"@esbuild/linux-arm": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+			"integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+			"optional": true
+		},
+		"@esbuild/linux-arm64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+			"integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+			"optional": true
+		},
+		"@esbuild/linux-ia32": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+			"integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+			"optional": true
+		},
+		"@esbuild/linux-loong64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+			"integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+			"optional": true
+		},
+		"@esbuild/linux-mips64el": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+			"integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+			"optional": true
+		},
+		"@esbuild/linux-ppc64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+			"integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+			"optional": true
+		},
+		"@esbuild/linux-riscv64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+			"integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+			"optional": true
+		},
+		"@esbuild/linux-s390x": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+			"integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+			"optional": true
+		},
+		"@esbuild/linux-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+			"integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+			"optional": true
+		},
+		"@esbuild/netbsd-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+			"integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+			"optional": true
+		},
+		"@esbuild/openbsd-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+			"integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+			"optional": true
+		},
+		"@esbuild/sunos-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+			"integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+			"optional": true
+		},
+		"@esbuild/win32-arm64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+			"integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+			"optional": true
+		},
+		"@esbuild/win32-ia32": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+			"integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+			"optional": true
+		},
+		"@esbuild/win32-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+			"integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
 			"optional": true
 		},
 		"@eslint-community/eslint-utils": {
@@ -26415,6 +26933,71 @@
 			"version": "8.56.0",
 			"dev": true
 		},
+		"@fal-works/esbuild-plugin-global-externals": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz",
+			"integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ=="
+		},
+		"@floating-ui/core": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+			"integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+			"requires": {
+				"@floating-ui/utils": "^0.2.1"
+			}
+		},
+		"@floating-ui/dom": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+			"integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+			"requires": {
+				"@floating-ui/core": "^1.0.0",
+				"@floating-ui/utils": "^0.2.0"
+			}
+		},
+		"@floating-ui/react": {
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.9.tgz",
+			"integrity": "sha512-p86wynZJVEkEq2BBjY/8p2g3biQ6TlgT4o/3KgFKyTWoJLU1GZ8wpctwRqtkEl2tseYA+kw7dBAIDFcednfI5w==",
+			"requires": {
+				"@floating-ui/react-dom": "^2.0.8",
+				"@floating-ui/utils": "^0.2.1",
+				"tabbable": "^6.0.1"
+			}
+		},
+		"@floating-ui/react-dom": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+			"requires": {
+				"@floating-ui/dom": "^1.6.1"
+			}
+		},
+		"@floating-ui/utils": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+			"integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+		},
+		"@grpc/grpc-js": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.1.tgz",
+			"integrity": "sha512-55ONqFytZExfOIjF1RjXPcVmT/jJqFzbbDqxK9jmRV4nxiYWtL9hENSW1Jfx0SdZfrvoqd44YJ/GJTqfRrawSQ==",
+			"requires": {
+				"@grpc/proto-loader": "^0.7.8",
+				"@types/node": ">=12.12.47"
+			}
+		},
+		"@grpc/proto-loader": {
+			"version": "0.7.10",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+			"integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
+			"requires": {
+				"lodash.camelcase": "^4.3.0",
+				"long": "^5.0.0",
+				"protobufjs": "^7.2.4",
+				"yargs": "^17.7.2"
+			}
+		},
 		"@guardian/cdk": {
 			"version": "53.0.3",
 			"dev": true,
@@ -26461,7 +27044,8 @@
 				"@aws-sdk/client-sqs": "^3.496.0",
 				"@aws-sdk/client-ssm": "^3.496.0",
 				"@aws-sdk/lib-dynamodb": "^3.509.0",
-				"axios": "^1.6.7"
+				"axios": "^1.6.7",
+				"winston": "^3.11.0"
 			}
 		},
 		"@guardian/transcription-service-common": {
@@ -26473,6 +27057,12 @@
 		"@guardian/tsconfig": {
 			"version": "0.2.0",
 			"dev": true
+		},
+		"@heroicons/react": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.1.tgz",
+			"integrity": "sha512-JyyN9Lo66kirbCMuMMRPtJxtKJoIsXKS569ebHGGRKbl8s4CtUfLnyKJxteA+vIKySocO4s1SkTkGS4xtG/yEA==",
+			"requires": {}
 		},
 		"@humanwhocodes/config-array": {
 			"version": "0.11.14",
@@ -26510,7 +27100,6 @@
 		},
 		"@isaacs/cliui": {
 			"version": "8.0.2",
-			"dev": true,
 			"requires": {
 				"string-width": "^5.1.2",
 				"string-width-cjs": "npm:string-width@^4.2.0",
@@ -26521,20 +27110,16 @@
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "6.0.1",
-					"dev": true
+					"version": "6.0.1"
 				},
 				"ansi-styles": {
-					"version": "6.2.1",
-					"dev": true
+					"version": "6.2.1"
 				},
 				"emoji-regex": {
-					"version": "9.2.2",
-					"dev": true
+					"version": "9.2.2"
 				},
 				"string-width": {
 					"version": "5.1.2",
-					"dev": true,
 					"requires": {
 						"eastasianwidth": "^0.2.0",
 						"emoji-regex": "^9.2.2",
@@ -26543,14 +27128,12 @@
 				},
 				"strip-ansi": {
 					"version": "7.1.0",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^6.0.1"
 					}
 				},
 				"wrap-ansi": {
 					"version": "8.1.0",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^6.1.0",
 						"string-width": "^5.0.1",
@@ -26852,7 +27435,6 @@
 		},
 		"@jridgewell/gen-mapping": {
 			"version": "0.3.3",
-			"dev": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -26860,23 +27442,74 @@
 			}
 		},
 		"@jridgewell/resolve-uri": {
-			"version": "3.1.1",
-			"dev": true
+			"version": "3.1.1"
 		},
 		"@jridgewell/set-array": {
-			"version": "1.1.2",
-			"dev": true
+			"version": "1.1.2"
 		},
 		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.15",
-			"dev": true
+			"version": "1.4.15"
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.9",
-			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"@js-temporal/polyfill": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.4.tgz",
+			"integrity": "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==",
+			"requires": {
+				"jsbi": "^4.3.0",
+				"tslib": "^2.4.1"
+			}
+		},
+		"@mdx-js/esbuild": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@mdx-js/esbuild/-/esbuild-2.3.0.tgz",
+			"integrity": "sha512-r/vsqsM0E+U4Wr0DK+0EfmABE/eg+8ITW4DjvYdh3ve/tK2safaqHArNnaqbOk1DjYGrhxtoXoGaM3BY8fGBTA==",
+			"requires": {
+				"@mdx-js/mdx": "^2.0.0",
+				"node-fetch": "^3.0.0",
+				"vfile": "^5.0.0"
+			},
+			"dependencies": {
+				"node-fetch": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+					"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+					"requires": {
+						"data-uri-to-buffer": "^4.0.0",
+						"fetch-blob": "^3.1.4",
+						"formdata-polyfill": "^4.0.10"
+					}
+				}
+			}
+		},
+		"@mdx-js/mdx": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.3.0.tgz",
+			"integrity": "sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==",
+			"requires": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/mdx": "^2.0.0",
+				"estree-util-build-jsx": "^2.0.0",
+				"estree-util-is-identifier-name": "^2.0.0",
+				"estree-util-to-js": "^1.1.0",
+				"estree-walker": "^3.0.0",
+				"hast-util-to-estree": "^2.0.0",
+				"markdown-extensions": "^1.0.0",
+				"periscopic": "^3.0.0",
+				"remark-mdx": "^2.0.0",
+				"remark-parse": "^10.0.0",
+				"remark-rehype": "^10.0.0",
+				"unified": "^10.0.0",
+				"unist-util-position-from-estree": "^1.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"unist-util-visit": "^4.0.0",
+				"vfile": "^5.0.0"
 			}
 		},
 		"@next/env": {
@@ -26936,19 +27569,16 @@
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
-			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
 			}
 		},
 		"@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"dev": true
+			"version": "2.0.5"
 		},
 		"@nodelib/fs.walk": {
 			"version": "1.2.8",
-			"dev": true,
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
@@ -27012,10 +27642,358 @@
 				}
 			}
 		},
+		"@opentelemetry/api": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+			"integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
+		},
+		"@opentelemetry/api-logs": {
+			"version": "0.39.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.39.1.tgz",
+			"integrity": "sha512-9BJ8lMcOzEN0lu+Qji801y707oFO4xT3db6cosPvl+k7ItUHKN5ofWqtSbM9gbt1H4JJ/4/2TVrqI9Rq7hNv6Q==",
+			"requires": {
+				"@opentelemetry/api": "^1.0.0"
+			}
+		},
+		"@opentelemetry/context-async-hooks": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.21.0.tgz",
+			"integrity": "sha512-t0iulGPiMjG/NrSjinPQoIf8ST/o9V0dGOJthfrFporJlNdlKIQPfC7lkrV+5s2dyBThfmSbJlp/4hO1eOcDXA==",
+			"requires": {}
+		},
+		"@opentelemetry/core": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.21.0.tgz",
+			"integrity": "sha512-KP+OIweb3wYoP7qTYL/j5IpOlu52uxBv5M4+QhSmmUfLyTgu1OIS71msK3chFo1D6Y61BIH3wMiMYRCxJCQctA==",
+			"requires": {
+				"@opentelemetry/semantic-conventions": "1.21.0"
+			}
+		},
+		"@opentelemetry/exporter-trace-otlp-grpc": {
+			"version": "0.39.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.39.1.tgz",
+			"integrity": "sha512-l5RhLKx6U+yuLhMrtgavTDthX50E1mZM3/SSySC7OPZiArFHV/b/9x9jxAzrOgIQUDxyj4N0V9aLKSA2t7Qzxg==",
+			"requires": {
+				"@grpc/grpc-js": "^1.7.1",
+				"@opentelemetry/core": "1.13.0",
+				"@opentelemetry/otlp-grpc-exporter-base": "0.39.1",
+				"@opentelemetry/otlp-transformer": "0.39.1",
+				"@opentelemetry/resources": "1.13.0",
+				"@opentelemetry/sdk-trace-base": "1.13.0"
+			},
+			"dependencies": {
+				"@opentelemetry/core": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+					"integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+					"requires": {
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/resources": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.13.0.tgz",
+					"integrity": "sha512-euqjOkiN6xhjE//0vQYGvbStxoD/WWQRhDiO0OTLlnLBO9Yw2Gd/VoSx2H+svsebjzYk5OxLuREBmcdw6rbUNg==",
+					"requires": {
+						"@opentelemetry/core": "1.13.0",
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.13.0.tgz",
+					"integrity": "sha512-moTiQtc0uPR1hQLt6gLDJH9IIkeBhgRb71OKjNHZPE1VF45fHtD6nBDi5J/DkTHTwYP5X3kBJLa3xN7ub6J4eg==",
+					"requires": {
+						"@opentelemetry/core": "1.13.0",
+						"@opentelemetry/resources": "1.13.0",
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+					"integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw=="
+				}
+			}
+		},
+		"@opentelemetry/otlp-exporter-base": {
+			"version": "0.39.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.39.1.tgz",
+			"integrity": "sha512-Pv5X8fbi6jD/RJBePyn7MnCSuE6MbPB6dl+7YYBWJ5RcMGYMwvLXjd4h2jWsPV2TSUg38H/RoSP0aXvQ06Y7iw==",
+			"requires": {
+				"@opentelemetry/core": "1.13.0"
+			},
+			"dependencies": {
+				"@opentelemetry/core": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+					"integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+					"requires": {
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+					"integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw=="
+				}
+			}
+		},
+		"@opentelemetry/otlp-grpc-exporter-base": {
+			"version": "0.39.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.39.1.tgz",
+			"integrity": "sha512-u3ErFRQqQFKjjIMuwLWxz/tLPYInfmiAmSy//fGSCzCh2ZdJgqQjMOAxBgqFtCF2xFL+OmMhyuC2ThMzceGRWA==",
+			"requires": {
+				"@grpc/grpc-js": "^1.7.1",
+				"@opentelemetry/core": "1.13.0",
+				"@opentelemetry/otlp-exporter-base": "0.39.1",
+				"protobufjs": "^7.2.2"
+			},
+			"dependencies": {
+				"@opentelemetry/core": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+					"integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+					"requires": {
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+					"integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw=="
+				}
+			}
+		},
+		"@opentelemetry/otlp-transformer": {
+			"version": "0.39.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.39.1.tgz",
+			"integrity": "sha512-0hgVnXXz5efI382B/24NxD4b6Zxlh7nxCdJkxkdmQMbn0yRiwoq/ZT+QG8eUL6JNzsBAV1WJlF5aJNsL8skHvw==",
+			"requires": {
+				"@opentelemetry/api-logs": "0.39.1",
+				"@opentelemetry/core": "1.13.0",
+				"@opentelemetry/resources": "1.13.0",
+				"@opentelemetry/sdk-logs": "0.39.1",
+				"@opentelemetry/sdk-metrics": "1.13.0",
+				"@opentelemetry/sdk-trace-base": "1.13.0"
+			},
+			"dependencies": {
+				"@opentelemetry/core": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+					"integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+					"requires": {
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/resources": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.13.0.tgz",
+					"integrity": "sha512-euqjOkiN6xhjE//0vQYGvbStxoD/WWQRhDiO0OTLlnLBO9Yw2Gd/VoSx2H+svsebjzYk5OxLuREBmcdw6rbUNg==",
+					"requires": {
+						"@opentelemetry/core": "1.13.0",
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.13.0.tgz",
+					"integrity": "sha512-moTiQtc0uPR1hQLt6gLDJH9IIkeBhgRb71OKjNHZPE1VF45fHtD6nBDi5J/DkTHTwYP5X3kBJLa3xN7ub6J4eg==",
+					"requires": {
+						"@opentelemetry/core": "1.13.0",
+						"@opentelemetry/resources": "1.13.0",
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+					"integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw=="
+				}
+			}
+		},
+		"@opentelemetry/propagator-b3": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.21.0.tgz",
+			"integrity": "sha512-3ZTobj2VDIOzLsIvvYCdpw6tunxUVElPxDvog9lS49YX4hohHeD84A8u9Ns/6UYUcaN5GSoEf891lzhcBFiOLA==",
+			"requires": {
+				"@opentelemetry/core": "1.21.0"
+			}
+		},
+		"@opentelemetry/propagator-jaeger": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.21.0.tgz",
+			"integrity": "sha512-8TQSwXjBmaDx7JkxRD7hdmBmRK2RGRgzHX1ArJfJhIc5trzlVweyorzqQrXOvqVEdEg+zxUMHkL5qbGH/HDTPA==",
+			"requires": {
+				"@opentelemetry/core": "1.21.0"
+			}
+		},
+		"@opentelemetry/resources": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.21.0.tgz",
+			"integrity": "sha512-1Z86FUxPKL6zWVy2LdhueEGl9AHDJcx+bvHStxomruz6Whd02mE3lNUMjVJ+FGRoktx/xYQcxccYb03DiUP6Yw==",
+			"requires": {
+				"@opentelemetry/core": "1.21.0",
+				"@opentelemetry/semantic-conventions": "1.21.0"
+			}
+		},
+		"@opentelemetry/sdk-logs": {
+			"version": "0.39.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.39.1.tgz",
+			"integrity": "sha512-/gmgKfZ1ZVFporKuwsewqIyvaUIGpv76JZ7lBpHQQPb37IMpaXO6pdqFI4ebHAWfNIm3akMyhmdtzivcgF3lgw==",
+			"requires": {
+				"@opentelemetry/core": "1.13.0",
+				"@opentelemetry/resources": "1.13.0"
+			},
+			"dependencies": {
+				"@opentelemetry/core": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+					"integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+					"requires": {
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/resources": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.13.0.tgz",
+					"integrity": "sha512-euqjOkiN6xhjE//0vQYGvbStxoD/WWQRhDiO0OTLlnLBO9Yw2Gd/VoSx2H+svsebjzYk5OxLuREBmcdw6rbUNg==",
+					"requires": {
+						"@opentelemetry/core": "1.13.0",
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+					"integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw=="
+				}
+			}
+		},
+		"@opentelemetry/sdk-metrics": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.13.0.tgz",
+			"integrity": "sha512-MOjZX6AnSOqLliCcZUrb+DQKjAWXBiGeICGbHAGe5w0BB18PJIeIo995lO5JSaFfHpmUMgJButTPfJJD27W3Vg==",
+			"requires": {
+				"@opentelemetry/core": "1.13.0",
+				"@opentelemetry/resources": "1.13.0",
+				"lodash.merge": "4.6.2"
+			},
+			"dependencies": {
+				"@opentelemetry/core": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.13.0.tgz",
+					"integrity": "sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==",
+					"requires": {
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/resources": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.13.0.tgz",
+					"integrity": "sha512-euqjOkiN6xhjE//0vQYGvbStxoD/WWQRhDiO0OTLlnLBO9Yw2Gd/VoSx2H+svsebjzYk5OxLuREBmcdw6rbUNg==",
+					"requires": {
+						"@opentelemetry/core": "1.13.0",
+						"@opentelemetry/semantic-conventions": "1.13.0"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+					"integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw=="
+				}
+			}
+		},
+		"@opentelemetry/sdk-trace-base": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.21.0.tgz",
+			"integrity": "sha512-yrElGX5Fv0umzp8Nxpta/XqU71+jCAyaLk34GmBzNcrW43nqbrqvdPs4gj4MVy/HcTjr6hifCDCYA3rMkajxxA==",
+			"requires": {
+				"@opentelemetry/core": "1.21.0",
+				"@opentelemetry/resources": "1.21.0",
+				"@opentelemetry/semantic-conventions": "1.21.0"
+			}
+		},
+		"@opentelemetry/sdk-trace-node": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.21.0.tgz",
+			"integrity": "sha512-1pdm8jnqs+LuJ0Bvx6sNL28EhC8Rv7NYV8rnoXq3GIQo7uOHBDAFSj7makAfbakrla7ecO1FRfI8emnR4WvhYA==",
+			"requires": {
+				"@opentelemetry/context-async-hooks": "1.21.0",
+				"@opentelemetry/core": "1.21.0",
+				"@opentelemetry/propagator-b3": "1.21.0",
+				"@opentelemetry/propagator-jaeger": "1.21.0",
+				"@opentelemetry/sdk-trace-base": "1.21.0",
+				"semver": "^7.5.2"
+			}
+		},
+		"@opentelemetry/semantic-conventions": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.21.0.tgz",
+			"integrity": "sha512-lkC8kZYntxVKr7b8xmjCVUgE0a8xgDakPyDo9uSWavXPyYqLgYYGdEd2j8NxihRyb6UwpX3G/hFUF4/9q2V+/g=="
+		},
 		"@pkgjs/parseargs": {
 			"version": "0.11.0",
-			"dev": true,
 			"optional": true
+		},
+		"@popperjs/core": {
+			"version": "2.11.8",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
+		},
+		"@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+		},
+		"@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+		},
+		"@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+		},
+		"@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+		},
+		"@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"requires": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+		},
+		"@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+		},
+		"@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+		},
+		"@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+		},
+		"@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
 		},
 		"@sinclair/typebox": {
 			"version": "0.27.8",
@@ -27480,21 +28458,38 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"@tailwindcss/forms": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.7.tgz",
+			"integrity": "sha512-QE7X69iQI+ZXwldE+rzasvbJiyV/ju1FGHH0Qn2W3FKbuYtqp8LKcy6iSw79fVUT5/Vvf+0XgLCeYVG+UV6hOw==",
+			"dev": true,
+			"requires": {
+				"mini-svg-data-uri": "^1.2.3"
+			}
+		},
 		"@tsconfig/node10": {
 			"version": "1.0.9",
-			"dev": true
+			"devOptional": true
 		},
 		"@tsconfig/node12": {
 			"version": "1.0.11",
-			"dev": true
+			"devOptional": true
 		},
 		"@tsconfig/node14": {
 			"version": "1.0.3",
-			"dev": true
+			"devOptional": true
 		},
 		"@tsconfig/node16": {
 			"version": "1.0.4",
-			"dev": true
+			"devOptional": true
+		},
+		"@types/acorn": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
+			"integrity": "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==",
+			"requires": {
+				"@types/estree": "*"
+			}
 		},
 		"@types/aws-lambda": {
 			"version": "8.10.133",
@@ -27555,6 +28550,27 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/debug": {
+			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+			"integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+			"requires": {
+				"@types/ms": "*"
+			}
+		},
+		"@types/estree": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+		},
+		"@types/estree-jsx": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.4.tgz",
+			"integrity": "sha512-5idy3hvI9lAMqsyilBM+N+boaCf1MgoefbDxN6KEO5aK17TOHwFAYT9sjxzeKAiIWRUBgLxmZ9mPcnzZXtTcRQ==",
+			"requires": {
+				"@types/estree": "*"
+			}
+		},
 		"@types/express": {
 			"version": "4.17.21",
 			"dev": true,
@@ -27586,6 +28602,14 @@
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
+			}
+		},
+		"@types/hast": {
+			"version": "2.3.10",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+			"integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+			"requires": {
+				"@types/unist": "^2"
 			}
 		},
 		"@types/http-errors": {
@@ -27633,13 +28657,30 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/mdast": {
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+			"integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+			"requires": {
+				"@types/unist": "^2"
+			}
+		},
+		"@types/mdx": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.11.tgz",
+			"integrity": "sha512-HM5bwOaIQJIQbAYfax35HCKxx7a3KrK3nBtIqJgSOitivTD1y3oW9P3rxY9RkXYPUk7y/AjAohfHKmFpGE79zw=="
+		},
 		"@types/mime": {
 			"version": "1.3.5",
 			"dev": true
 		},
+		"@types/ms": {
+			"version": "0.7.34",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+			"integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
+		},
 		"@types/node": {
 			"version": "20.11.5",
-			"dev": true,
 			"requires": {
 				"undici-types": "~5.26.4"
 			}
@@ -27647,6 +28688,11 @@
 		"@types/normalize-package-data": {
 			"version": "2.4.4",
 			"dev": true
+		},
+		"@types/parse5": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
+			"integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
 		},
 		"@types/passport": {
 			"version": "1.0.16",
@@ -27679,8 +28725,7 @@
 			}
 		},
 		"@types/prop-types": {
-			"version": "15.7.11",
-			"dev": true
+			"version": "15.7.11"
 		},
 		"@types/qs": {
 			"version": "6.9.11",
@@ -27692,7 +28737,6 @@
 		},
 		"@types/react": {
 			"version": "18.2.51",
-			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -27706,9 +28750,13 @@
 				"@types/react": "*"
 			}
 		},
+		"@types/resolve": {
+			"version": "1.20.6",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+			"integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ=="
+		},
 		"@types/scheduler": {
-			"version": "0.16.8",
-			"dev": true
+			"version": "0.16.8"
 		},
 		"@types/semver": {
 			"version": "7.5.6",
@@ -27734,6 +28782,16 @@
 		"@types/stack-utils": {
 			"version": "2.0.3",
 			"dev": true
+		},
+		"@types/triple-beam": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+		},
+		"@types/unist": {
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+			"integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
 		},
 		"@types/uuid": {
 			"version": "9.0.8",
@@ -27836,8 +28894,7 @@
 			}
 		},
 		"@ungap/structured-clone": {
-			"version": "1.2.0",
-			"dev": true
+			"version": "1.2.0"
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -27851,17 +28908,15 @@
 			}
 		},
 		"acorn": {
-			"version": "8.11.3",
-			"dev": true
+			"version": "8.11.3"
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
-			"dev": true,
 			"requires": {}
 		},
 		"acorn-walk": {
 			"version": "8.3.2",
-			"dev": true
+			"devOptional": true
 		},
 		"agent-base": {
 			"version": "7.1.0",
@@ -27894,28 +28949,37 @@
 				}
 			}
 		},
+		"ansi-red": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+			"integrity": "sha512-ewaIr5y+9CUTGFwZfpECUbFlGcC0GCw1oqR9RI6h1gQCd9Aj2GxSckCnPsVJnmfMZbwFYE+leZGASgkWl06Jow==",
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
 		"ansi-regex": {
-			"version": "5.0.1",
-			"dev": true
+			"version": "5.0.1"
 		},
 		"ansi-styles": {
 			"version": "4.3.0",
-			"dev": true,
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw=="
 		},
 		"ansicolors": {
 			"version": "0.3.2",
 			"dev": true
 		},
 		"any-promise": {
-			"version": "1.3.0",
-			"dev": true
+			"version": "1.3.0"
 		},
 		"anymatch": {
 			"version": "3.1.3",
-			"dev": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -27956,11 +29020,10 @@
 		},
 		"arg": {
 			"version": "4.1.3",
-			"dev": true
+			"devOptional": true
 		},
 		"argparse": {
-			"version": "2.0.1",
-			"dev": true
+			"version": "2.0.1"
 		},
 		"array-buffer-byte-length": {
 			"version": "1.0.0",
@@ -27983,6 +29046,11 @@
 				"get-intrinsic": "^1.2.1",
 				"is-string": "^1.0.7"
 			}
+		},
+		"array-timsort": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+			"integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="
 		},
 		"array-union": {
 			"version": "2.1.0",
@@ -28036,14 +29104,26 @@
 			"version": "2.0.0",
 			"dev": true
 		},
+		"astring": {
+			"version": "1.8.6",
+			"resolved": "https://registry.npmjs.org/astring/-/astring-1.8.6.tgz",
+			"integrity": "sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg=="
+		},
 		"async": {
-			"version": "3.2.5",
-			"dev": true
+			"version": "3.2.5"
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"autolinker": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.28.1.tgz",
+			"integrity": "sha512-zQAFO1Dlsn69eXaO6+7YZc+v84aquQKbwpzCE3L0stj56ERn9hutFxPopViLjo9G+rWwjozRhgS5KJ25Xy19cQ==",
+			"requires": {
+				"gulp-header": "^1.7.1"
+			}
 		},
 		"autoprefixer": {
 			"version": "10.4.17",
@@ -28364,6 +29444,11 @@
 				"proxy-from-env": "^1.1.0"
 			}
 		},
+		"b4a": {
+			"version": "1.6.6",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+			"integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg=="
+		},
 		"babel-jest": {
 			"version": "29.7.0",
 			"dev": true,
@@ -28441,9 +29526,46 @@
 				"babel-preset-current-node-syntax": "^1.0.0"
 			}
 		},
+		"bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+		},
 		"balanced-match": {
-			"version": "1.0.2",
-			"dev": true
+			"version": "1.0.2"
+		},
+		"bare-events": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.0.tgz",
+			"integrity": "sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==",
+			"optional": true
+		},
+		"bare-fs": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.1.5.tgz",
+			"integrity": "sha512-5t0nlecX+N2uJqdxe9d18A98cp2u9BETelbjKpiVgQqzzmVNFYWEAjQHqS+2Khgto1vcwhik9cXucaj5ve2WWA==",
+			"optional": true,
+			"requires": {
+				"bare-events": "^2.0.0",
+				"bare-os": "^2.0.0",
+				"bare-path": "^2.0.0",
+				"streamx": "^2.13.0"
+			}
+		},
+		"bare-os": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.0.tgz",
+			"integrity": "sha512-hD0rOPfYWOMpVirTACt4/nK8mC55La12K5fY1ij8HAdfQakD62M+H4o4tpfKzVGLgRDTuk3vjA4GqGXXCeFbag==",
+			"optional": true
+		},
+		"bare-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.0.tgz",
+			"integrity": "sha512-DIIg7ts8bdRKwJRJrUMy/PICEaQZaPGZ26lsSx9MJSwIhSrcdHn7/C8W+XmnG/rKi6BaRcz+JO00CjZteybDtw==",
+			"optional": true,
+			"requires": {
+				"bare-os": "^2.1.0"
+			}
 		},
 		"base64-js": {
 			"version": "1.5.1"
@@ -28457,8 +29579,38 @@
 			"integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="
 		},
 		"binary-extensions": {
-			"version": "2.2.0",
-			"dev": true
+			"version": "2.2.0"
+		},
+		"bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"requires": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+					"requires": {
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.1.13"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
 		},
 		"body-parser": {
 			"version": "1.20.1",
@@ -28493,14 +29645,12 @@
 		},
 		"brace-expansion": {
 			"version": "2.0.1",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0"
 			}
 		},
 		"braces": {
 			"version": "3.0.2",
-			"dev": true,
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
@@ -28541,8 +29691,7 @@
 			"version": "1.0.1"
 		},
 		"buffer-from": {
-			"version": "1.1.2",
-			"dev": true
+			"version": "1.1.2"
 		},
 		"busboy": {
 			"version": "1.6.0",
@@ -28565,13 +29714,21 @@
 			"version": "3.1.0",
 			"dev": true
 		},
+		"camel-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+			"requires": {
+				"pascal-case": "^3.1.2",
+				"tslib": "^2.0.3"
+			}
+		},
 		"camelcase": {
 			"version": "6.3.0",
 			"dev": true
 		},
 		"camelcase-css": {
-			"version": "2.0.1",
-			"dev": true
+			"version": "2.0.1"
 		},
 		"caniuse-lite": {
 			"version": "1.0.30001579"
@@ -28583,6 +29740,11 @@
 				"ansicolors": "~0.3.2",
 				"redeyed": "~2.1.0"
 			}
+		},
+		"ccount": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
 		},
 		"cdk": {
 			"version": "file:packages/cdk",
@@ -28724,9 +29886,28 @@
 			"version": "1.0.2",
 			"dev": true
 		},
+		"character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+		},
+		"character-entities-html4": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="
+		},
+		"character-entities-legacy": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
+		},
+		"character-reference-invalid": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+			"integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
+		},
 		"chokidar": {
 			"version": "3.5.3",
-			"dev": true,
 			"requires": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -28740,12 +29921,16 @@
 			"dependencies": {
 				"glob-parent": {
 					"version": "5.1.2",
-					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
 					}
 				}
 			}
+		},
+		"chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
 		},
 		"ci-info": {
 			"version": "3.9.0",
@@ -28754,6 +29939,11 @@
 		"cjs-module-lexer": {
 			"version": "1.2.3",
 			"dev": true
+		},
+		"classnames": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
 		},
 		"clean-stack": {
 			"version": "3.0.1",
@@ -28830,11 +30020,15 @@
 			"version": "file:packages/client",
 			"requires": {
 				"@guardian/transcription-service-common": "1.0.0",
+				"@heroicons/react": "^2.1.1",
+				"@tailwindcss/forms": "^0.5.7",
 				"@types/google.accounts": "0.0.14",
 				"@types/node": "^20",
 				"@types/react": "^18",
 				"@types/react-dom": "^18",
 				"autoprefixer": "^10.0.1",
+				"flowbite": "^2.3.0",
+				"flowbite-react": "^0.7.2",
 				"history": "^5.3.0",
 				"jwt-decode": "^4.0.0",
 				"next": "14.1.0",
@@ -28848,9 +30042,16 @@
 		"client-only": {
 			"version": "0.0.1"
 		},
+		"clipanion": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/clipanion/-/clipanion-3.2.1.tgz",
+			"integrity": "sha512-dYFdjLb7y1ajfxQopN05mylEpK9ZX0sO1/RfMXdfmwjlIsPkbh4p7A682x++zFPLDCo1x3p82dtljHf5cW2LKA==",
+			"requires": {
+				"typanion": "^3.8.0"
+			}
+		},
 		"cliui": {
 			"version": "8.0.1",
-			"dev": true,
 			"requires": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -28870,24 +30071,78 @@
 				"fs-extra": "^10.1.0"
 			}
 		},
+		"coffee-script": {
+			"version": "1.12.7",
+			"resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+			"integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+		},
 		"collect-v8-coverage": {
 			"version": "1.0.2",
 			"dev": true
 		},
+		"color": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+			"integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+			"requires": {
+				"color-convert": "^2.0.1",
+				"color-string": "^1.9.0"
+			}
+		},
 		"color-convert": {
 			"version": "2.0.1",
-			"dev": true,
 			"requires": {
 				"color-name": "~1.1.4"
 			}
 		},
 		"color-name": {
-			"version": "1.1.4",
-			"dev": true
+			"version": "1.1.4"
+		},
+		"color-string": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+			"requires": {
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
+			}
 		},
 		"colorette": {
 			"version": "2.0.20",
 			"dev": true
+		},
+		"colorspace": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+			"requires": {
+				"color": "^3.1.3",
+				"text-hex": "1.0.x"
+			},
+			"dependencies": {
+				"color": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+					"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+					"requires": {
+						"color-convert": "^1.9.3",
+						"color-string": "^1.6.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+				}
+			}
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -28897,12 +30152,48 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"comma-separated-tokens": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
+		},
 		"commander": {
 			"version": "3.0.2"
+		},
+		"comment-json": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.3.tgz",
+			"integrity": "sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==",
+			"requires": {
+				"array-timsort": "^1.0.3",
+				"core-util-is": "^1.0.3",
+				"esprima": "^4.0.1",
+				"has-own-prop": "^2.0.0",
+				"repeat-string": "^1.6.1"
+			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"dev": true
+		},
+		"concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			}
+		},
+		"concat-with-sourcemaps": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+			"integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+			"requires": {
+				"source-map": "^0.6.1"
+			}
 		},
 		"constructs": {
 			"version": "10.3.0",
@@ -28917,6 +30208,19 @@
 		"content-type": {
 			"version": "1.0.5"
 		},
+		"contentlayer": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/contentlayer/-/contentlayer-0.3.4.tgz",
+			"integrity": "sha512-FYDdTUFaN4yqep0waswrhcXjmMJnPD5iXDTtxcUCGdklfuIrXM2xLx51xl748cHmGA6IsC+27YZFxU6Ym13QIA==",
+			"requires": {
+				"@contentlayer/cli": "0.3.4",
+				"@contentlayer/client": "0.3.4",
+				"@contentlayer/core": "0.3.4",
+				"@contentlayer/source-files": "0.3.4",
+				"@contentlayer/source-remote-files": "0.3.4",
+				"@contentlayer/utils": "0.3.4"
+			}
+		},
 		"convert-source-map": {
 			"version": "2.0.0",
 			"dev": true
@@ -28926,6 +30230,11 @@
 		},
 		"cookie-signature": {
 			"version": "1.0.6"
+		},
+		"core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"create-jest": {
 			"version": "29.7.0",
@@ -28942,11 +30251,10 @@
 		},
 		"create-require": {
 			"version": "1.1.1",
-			"dev": true
+			"devOptional": true
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
-			"dev": true,
 			"requires": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -28954,12 +30262,20 @@
 			}
 		},
 		"cssesc": {
-			"version": "3.0.0",
-			"dev": true
+			"version": "3.0.0"
 		},
 		"csstype": {
-			"version": "3.1.3",
-			"dev": true
+			"version": "3.1.3"
+		},
+		"data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+		},
+		"debounce": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+			"integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
 		},
 		"debug": {
 			"version": "4.3.4",
@@ -28971,10 +30287,31 @@
 			"version": "5.0.1",
 			"dev": true
 		},
+		"decode-named-character-reference": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+			"integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+			"requires": {
+				"character-entities": "^2.0.0"
+			}
+		},
+		"decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"requires": {
+				"mimic-response": "^3.1.0"
+			}
+		},
 		"dedent": {
 			"version": "1.5.1",
 			"dev": true,
 			"requires": {}
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
 		"deep-is": {
 			"version": "0.1.4",
@@ -29009,20 +30346,42 @@
 		"depd": {
 			"version": "2.0.0"
 		},
+		"dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
+		},
 		"destroy": {
 			"version": "1.2.0"
+		},
+		"detect-libc": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
 		},
 		"detect-newline": {
 			"version": "3.1.0",
 			"dev": true
 		},
+		"devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"requires": {
+				"dequal": "^2.0.0"
+			}
+		},
+		"diacritics-map": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/diacritics-map/-/diacritics-map-0.1.0.tgz",
+			"integrity": "sha512-3omnDTYrGigU0i4cJjvaKwD52B8aoqyX/NEIkukFFkogBemsIbhSa1O414fpTp5nuszJG6lvQ5vBvDVNCbSsaQ=="
+		},
 		"didyoumean": {
-			"version": "1.2.2",
-			"dev": true
+			"version": "1.2.2"
 		},
 		"diff": {
 			"version": "4.0.2",
-			"dev": true
+			"devOptional": true
 		},
 		"diff-sequences": {
 			"version": "29.6.3",
@@ -29036,8 +30395,7 @@
 			}
 		},
 		"dlv": {
-			"version": "1.1.3",
-			"dev": true
+			"version": "1.1.3"
 		},
 		"doctrine": {
 			"version": "3.0.0",
@@ -29047,8 +30405,12 @@
 			}
 		},
 		"eastasianwidth": {
-			"version": "0.2.0",
-			"dev": true
+			"version": "0.2.0"
+		},
+		"easy-bem": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/easy-bem/-/easy-bem-1.1.1.tgz",
+			"integrity": "sha512-GJRqdiy2h+EXy6a8E6R+ubmqUM08BK0FWNq41k24fup6045biQ8NXxoXimiwegMQvFFV3t1emADdGNL1TlS61A=="
 		},
 		"ecdsa-sig-formatter": {
 			"version": "1.0.11",
@@ -29075,11 +30437,23 @@
 			"dev": true
 		},
 		"emoji-regex": {
-			"version": "8.0.0",
-			"dev": true
+			"version": "8.0.0"
+		},
+		"enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
 		},
 		"encodeurl": {
 			"version": "1.0.2"
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
 		},
 		"enhanced-resolve": {
 			"version": "5.15.0",
@@ -29168,7 +30542,6 @@
 		},
 		"esbuild": {
 			"version": "0.19.11",
-			"dev": true,
 			"requires": {
 				"@esbuild/aix-ppc64": "0.19.11",
 				"@esbuild/android-arm": "0.19.11",
@@ -29193,18 +30566,144 @@
 				"@esbuild/win32-arm64": "0.19.11",
 				"@esbuild/win32-ia32": "0.19.11",
 				"@esbuild/win32-x64": "0.19.11"
+			},
+			"dependencies": {
+				"@esbuild/android-arm": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.11.tgz",
+					"integrity": "sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==",
+					"optional": true
+				},
+				"@esbuild/android-arm64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.11.tgz",
+					"integrity": "sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==",
+					"optional": true
+				},
+				"@esbuild/android-x64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.11.tgz",
+					"integrity": "sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==",
+					"optional": true
+				},
+				"@esbuild/darwin-x64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.11.tgz",
+					"integrity": "sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==",
+					"optional": true
+				},
+				"@esbuild/freebsd-arm64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.11.tgz",
+					"integrity": "sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==",
+					"optional": true
+				},
+				"@esbuild/freebsd-x64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.11.tgz",
+					"integrity": "sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==",
+					"optional": true
+				},
+				"@esbuild/linux-arm": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.11.tgz",
+					"integrity": "sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==",
+					"optional": true
+				},
+				"@esbuild/linux-arm64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.11.tgz",
+					"integrity": "sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==",
+					"optional": true
+				},
+				"@esbuild/linux-ia32": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.11.tgz",
+					"integrity": "sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==",
+					"optional": true
+				},
+				"@esbuild/linux-loong64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.11.tgz",
+					"integrity": "sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==",
+					"optional": true
+				},
+				"@esbuild/linux-mips64el": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.11.tgz",
+					"integrity": "sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==",
+					"optional": true
+				},
+				"@esbuild/linux-ppc64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.11.tgz",
+					"integrity": "sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==",
+					"optional": true
+				},
+				"@esbuild/linux-riscv64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.11.tgz",
+					"integrity": "sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==",
+					"optional": true
+				},
+				"@esbuild/linux-s390x": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.11.tgz",
+					"integrity": "sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==",
+					"optional": true
+				},
+				"@esbuild/linux-x64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.11.tgz",
+					"integrity": "sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==",
+					"optional": true
+				},
+				"@esbuild/netbsd-x64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.11.tgz",
+					"integrity": "sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==",
+					"optional": true
+				},
+				"@esbuild/openbsd-x64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.11.tgz",
+					"integrity": "sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==",
+					"optional": true
+				},
+				"@esbuild/sunos-x64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.11.tgz",
+					"integrity": "sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==",
+					"optional": true
+				},
+				"@esbuild/win32-arm64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.11.tgz",
+					"integrity": "sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==",
+					"optional": true
+				},
+				"@esbuild/win32-ia32": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.11.tgz",
+					"integrity": "sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==",
+					"optional": true
+				},
+				"@esbuild/win32-x64": {
+					"version": "0.19.11",
+					"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.11.tgz",
+					"integrity": "sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==",
+					"optional": true
+				}
 			}
 		},
 		"escalade": {
-			"version": "3.1.1",
-			"dev": true
+			"version": "3.1.1"
 		},
 		"escape-html": {
 			"version": "1.0.3"
 		},
 		"escape-string-regexp": {
-			"version": "4.0.0",
-			"dev": true
+			"version": "4.0.0"
 		},
 		"eslint": {
 			"version": "8.56.0",
@@ -29433,6 +30932,71 @@
 			"version": "5.3.0",
 			"dev": true
 		},
+		"estree-util-attach-comments": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-2.1.1.tgz",
+			"integrity": "sha512-+5Ba/xGGS6mnwFbXIuQiDPTbuTxuMCooq3arVv7gPZtYpjp+VXH/NkHAP35OOefPhNG/UGqU3vt/LTABwcHX0w==",
+			"requires": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"estree-util-build-jsx": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-2.2.2.tgz",
+			"integrity": "sha512-m56vOXcOBuaF+Igpb9OPAy7f9w9OIkb5yhjsZuaPm7HoGi4oTOQi0h2+yZ+AtKklYFZ+rPC4n0wYCJCEU1ONqg==",
+			"requires": {
+				"@types/estree-jsx": "^1.0.0",
+				"estree-util-is-identifier-name": "^2.0.0",
+				"estree-walker": "^3.0.0"
+			}
+		},
+		"estree-util-is-identifier-name": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-2.1.0.tgz",
+			"integrity": "sha512-bEN9VHRyXAUOjkKVQVvArFym08BTWB0aJPppZZr0UNyAqWsLaVfAqP7hbaTJjzHifmB5ebnR8Wm7r7yGN/HonQ=="
+		},
+		"estree-util-to-js": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-1.2.0.tgz",
+			"integrity": "sha512-IzU74r1PK5IMMGZXUVZbmiu4A1uhiPgW5hm1GjcOfr4ZzHaMPpLNJjR7HjXiIOzi25nZDrgFTobHTkV5Q6ITjA==",
+			"requires": {
+				"@types/estree-jsx": "^1.0.0",
+				"astring": "^1.8.0",
+				"source-map": "^0.7.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.7.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+					"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
+				}
+			}
+		},
+		"estree-util-value-to-estree": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-1.3.0.tgz",
+			"integrity": "sha512-Y+ughcF9jSUJvncXwqRageavjrNPAI+1M/L3BI3PyLp1nmgYTGUXU6t5z1Y7OWuThoDdhPME07bQU+d5LxdJqw==",
+			"requires": {
+				"is-plain-obj": "^3.0.0"
+			}
+		},
+		"estree-util-visit": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-1.2.1.tgz",
+			"integrity": "sha512-xbgqcrkIVbIG+lI/gzbvd9SGTJL4zqJKBFttUl5pP27KhAjtMKbX/mQXJ7qgyXpMgVy/zvpm0xoQQaGL8OloOw==",
+			"requires": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/unist": "^2.0.0"
+			}
+		},
+		"estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"requires": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"esutils": {
 			"version": "2.0.3",
 			"dev": true
@@ -29465,6 +31029,62 @@
 		"exit": {
 			"version": "0.1.2",
 			"dev": true
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
+			"requires": {
+				"fill-range": "^2.1.0"
+			},
+			"dependencies": {
+				"fill-range": {
+					"version": "2.2.4",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+					"requires": {
+						"is-number": "^2.1.0",
+						"isobject": "^2.0.0",
+						"randomatic": "^3.0.0",
+						"repeat-element": "^1.1.2",
+						"repeat-string": "^1.5.2"
+					}
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+					"integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"isobject": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+					"integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
 		},
 		"expect": {
 			"version": "29.7.0",
@@ -29532,13 +31152,25 @@
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"requires": {
+				"is-extendable": "^0.1.0"
+			}
+		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"dev": true
 		},
+		"fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+		},
 		"fast-glob": {
 			"version": "3.3.2",
-			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -29549,7 +31181,6 @@
 			"dependencies": {
 				"glob-parent": {
 					"version": "5.1.2",
-					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
 					}
@@ -29572,9 +31203,16 @@
 		},
 		"fastq": {
 			"version": "1.16.0",
-			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"fault": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+			"integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+			"requires": {
+				"format": "^0.2.0"
 			}
 		},
 		"fb-watchman": {
@@ -29582,6 +31220,20 @@
 			"dev": true,
 			"requires": {
 				"bser": "2.1.1"
+			}
+		},
+		"fecha": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+		},
+		"fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"requires": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
 			}
 		},
 		"fflate": {
@@ -29614,7 +31266,6 @@
 		},
 		"fill-range": {
 			"version": "7.0.1",
-			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
 			}
@@ -29663,6 +31314,152 @@
 			"version": "3.2.9",
 			"dev": true
 		},
+		"flowbite": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/flowbite/-/flowbite-2.3.0.tgz",
+			"integrity": "sha512-pm3JRo8OIJHGfFYWgaGpPv8E+UdWy0Z3gEAGufw+G/1dusaU/P1zoBLiQpf2/+bYAi+GBQtPVG86KYlV0W+AFQ==",
+			"requires": {
+				"@popperjs/core": "^2.9.3",
+				"mini-svg-data-uri": "^1.4.3"
+			}
+		},
+		"flowbite-react": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/flowbite-react/-/flowbite-react-0.7.2.tgz",
+			"integrity": "sha512-Qq+yKW3955ZWjABzNq02NAS91rE86AHjCVRTXHXZ3dkcoGghqViIpsDCxOBo0NO7xnKkshYU3DocmczcP4pYTA==",
+			"requires": {
+				"@floating-ui/react": "^0.26.2",
+				"contentlayer": "^0.3.4",
+				"flowbite": "^2.0.0",
+				"markdown-toc": "^1.2.0",
+				"next-contentlayer": "^0.3.4",
+				"react-icons": "^4.11.0",
+				"react-indiana-drag-scroll": "^2.2.0",
+				"react-markdown": "^9.0.0",
+				"sharp": "^0.32.6",
+				"tailwind-merge": "^2.0.0"
+			},
+			"dependencies": {
+				"@next/env": {
+					"version": "13.5.6",
+					"resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz",
+					"integrity": "sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==",
+					"peer": true
+				},
+				"@next/swc-darwin-arm64": {
+					"version": "13.5.6",
+					"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.6.tgz",
+					"integrity": "sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==",
+					"optional": true,
+					"peer": true
+				},
+				"@next/swc-darwin-x64": {
+					"version": "13.5.6",
+					"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.6.tgz",
+					"integrity": "sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==",
+					"optional": true,
+					"peer": true
+				},
+				"@next/swc-linux-arm64-gnu": {
+					"version": "13.5.6",
+					"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.6.tgz",
+					"integrity": "sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==",
+					"optional": true,
+					"peer": true
+				},
+				"@next/swc-linux-arm64-musl": {
+					"version": "13.5.6",
+					"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.6.tgz",
+					"integrity": "sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==",
+					"optional": true,
+					"peer": true
+				},
+				"@next/swc-linux-x64-gnu": {
+					"version": "13.5.6",
+					"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz",
+					"integrity": "sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==",
+					"optional": true,
+					"peer": true
+				},
+				"@next/swc-linux-x64-musl": {
+					"version": "13.5.6",
+					"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz",
+					"integrity": "sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==",
+					"optional": true,
+					"peer": true
+				},
+				"@next/swc-win32-arm64-msvc": {
+					"version": "13.5.6",
+					"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.6.tgz",
+					"integrity": "sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==",
+					"optional": true,
+					"peer": true
+				},
+				"@next/swc-win32-ia32-msvc": {
+					"version": "13.5.6",
+					"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.6.tgz",
+					"integrity": "sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==",
+					"optional": true,
+					"peer": true
+				},
+				"@next/swc-win32-x64-msvc": {
+					"version": "13.5.6",
+					"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.6.tgz",
+					"integrity": "sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==",
+					"optional": true,
+					"peer": true
+				},
+				"next": {
+					"version": "13.5.6",
+					"resolved": "https://registry.npmjs.org/next/-/next-13.5.6.tgz",
+					"integrity": "sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==",
+					"peer": true,
+					"requires": {
+						"@next/env": "13.5.6",
+						"@next/swc-darwin-arm64": "13.5.6",
+						"@next/swc-darwin-x64": "13.5.6",
+						"@next/swc-linux-arm64-gnu": "13.5.6",
+						"@next/swc-linux-arm64-musl": "13.5.6",
+						"@next/swc-linux-x64-gnu": "13.5.6",
+						"@next/swc-linux-x64-musl": "13.5.6",
+						"@next/swc-win32-arm64-msvc": "13.5.6",
+						"@next/swc-win32-ia32-msvc": "13.5.6",
+						"@next/swc-win32-x64-msvc": "13.5.6",
+						"@swc/helpers": "0.5.2",
+						"busboy": "1.6.0",
+						"caniuse-lite": "^1.0.30001406",
+						"postcss": "8.4.31",
+						"styled-jsx": "5.1.1",
+						"watchpack": "2.4.0"
+					}
+				},
+				"next-contentlayer": {
+					"version": "0.3.4",
+					"resolved": "https://registry.npmjs.org/next-contentlayer/-/next-contentlayer-0.3.4.tgz",
+					"integrity": "sha512-UtUCwgAl159KwfhNaOwyiI7Lg6sdioyKMeh+E7jxx0CJ29JuXGxBEYmCI6+72NxFGIFZKx8lvttbbQhbnYWYSw==",
+					"requires": {
+						"@contentlayer/core": "0.3.4",
+						"@contentlayer/utils": "0.3.4"
+					}
+				},
+				"postcss": {
+					"version": "8.4.31",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+					"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+					"peer": true,
+					"requires": {
+						"nanoid": "^3.3.6",
+						"picocolors": "^1.0.0",
+						"source-map-js": "^1.0.2"
+					}
+				}
+			}
+		},
+		"fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+		},
 		"follow-redirects": {
 			"version": "1.15.5",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
@@ -29674,17 +31471,20 @@
 				"is-callable": "^1.1.3"
 			}
 		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ=="
+		},
 		"foreground-child": {
 			"version": "3.1.1",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.0",
 				"signal-exit": "^4.0.1"
 			},
 			"dependencies": {
 				"signal-exit": {
-					"version": "4.1.0",
-					"dev": true
+					"version": "4.1.0"
 				}
 			}
 		},
@@ -29698,6 +31498,19 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"format": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+			"integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="
+		},
+		"formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"requires": {
+				"fetch-blob": "^3.1.2"
+			}
+		},
 		"forwarded": {
 			"version": "0.2.0"
 		},
@@ -29708,6 +31521,11 @@
 		"fresh": {
 			"version": "0.5.2"
 		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+		},
 		"fs-extra": {
 			"version": "10.1.0",
 			"dev": true,
@@ -29717,13 +31535,17 @@
 				"universalify": "^2.0.0"
 			}
 		},
+		"fs-monkey": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
+			"integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew=="
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"dev": true
 		},
 		"fsevents": {
 			"version": "2.3.2",
-			"dev": true,
 			"optional": true
 		},
 		"function-bind": {
@@ -29768,8 +31590,7 @@
 			"dev": true
 		},
 		"get-caller-file": {
-			"version": "2.0.5",
-			"dev": true
+			"version": "2.0.5"
 		},
 		"get-east-asian-width": {
 			"version": "1.2.0",
@@ -29822,6 +31643,11 @@
 				"git-up": "^7.0.0"
 			}
 		},
+		"github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+		},
 		"glob": {
 			"version": "7.2.3",
 			"dev": true,
@@ -29853,7 +31679,6 @@
 		},
 		"glob-parent": {
 			"version": "6.0.2",
-			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.3"
 			}
@@ -29963,6 +31788,36 @@
 			"version": "1.4.0",
 			"dev": true
 		},
+		"gray-matter": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+			"integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+			"requires": {
+				"js-yaml": "^3.13.1",
+				"kind-of": "^6.0.2",
+				"section-matter": "^1.0.0",
+				"strip-bom-string": "^1.0.0"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				}
+			}
+		},
 		"gtoken": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
@@ -29993,6 +31848,16 @@
 				}
 			}
 		},
+		"gulp-header": {
+			"version": "1.8.12",
+			"resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
+			"integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
+			"requires": {
+				"concat-with-sourcemaps": "*",
+				"lodash.template": "^4.4.0",
+				"through2": "^2.0.0"
+			}
+		},
 		"has-bigints": {
 			"version": "1.0.2",
 			"dev": true
@@ -30000,6 +31865,11 @@
 		"has-flag": {
 			"version": "4.0.0",
 			"dev": true
+		},
+		"has-own-prop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+			"integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
 		},
 		"has-property-descriptors": {
 			"version": "1.0.1",
@@ -30019,10 +31889,527 @@
 				"has-symbols": "^1.0.2"
 			}
 		},
+		"hash-wasm": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.11.0.tgz",
+			"integrity": "sha512-HVusNXlVqHe0fzIzdQOGolnFN6mX/fqcrSAOcTBXdvzrXVHwTz11vXeKRmkR5gTuwVpvHZEIyKoePDvuAR+XwQ=="
+		},
 		"hasown": {
 			"version": "2.0.0",
 			"requires": {
 				"function-bind": "^1.1.2"
+			}
+		},
+		"hast-util-from-parse5": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
+			"integrity": "sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==",
+			"requires": {
+				"@types/hast": "^2.0.0",
+				"@types/unist": "^2.0.0",
+				"hastscript": "^7.0.0",
+				"property-information": "^6.0.0",
+				"vfile": "^5.0.0",
+				"vfile-location": "^4.0.0",
+				"web-namespaces": "^2.0.0"
+			}
+		},
+		"hast-util-parse-selector": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+			"integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+			"requires": {
+				"@types/hast": "^2.0.0"
+			}
+		},
+		"hast-util-raw": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.3.tgz",
+			"integrity": "sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==",
+			"requires": {
+				"@types/hast": "^2.0.0",
+				"@types/parse5": "^6.0.0",
+				"hast-util-from-parse5": "^7.0.0",
+				"hast-util-to-parse5": "^7.0.0",
+				"html-void-elements": "^2.0.0",
+				"parse5": "^6.0.0",
+				"unist-util-position": "^4.0.0",
+				"unist-util-visit": "^4.0.0",
+				"vfile": "^5.0.0",
+				"web-namespaces": "^2.0.0",
+				"zwitch": "^2.0.0"
+			}
+		},
+		"hast-util-to-estree": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-2.3.3.tgz",
+			"integrity": "sha512-ihhPIUPxN0v0w6M5+IiAZZrn0LH2uZomeWwhn7uP7avZC6TE7lIiEh2yBMPr5+zi1aUCXq6VoYRgs2Bw9xmycQ==",
+			"requires": {
+				"@types/estree": "^1.0.0",
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^2.0.0",
+				"@types/unist": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"estree-util-attach-comments": "^2.0.0",
+				"estree-util-is-identifier-name": "^2.0.0",
+				"hast-util-whitespace": "^2.0.0",
+				"mdast-util-mdx-expression": "^1.0.0",
+				"mdast-util-mdxjs-esm": "^1.0.0",
+				"property-information": "^6.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"style-to-object": "^0.4.1",
+				"unist-util-position": "^4.0.0",
+				"zwitch": "^2.0.0"
+			}
+		},
+		"hast-util-to-html": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz",
+			"integrity": "sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==",
+			"requires": {
+				"@types/hast": "^2.0.0",
+				"@types/unist": "^2.0.0",
+				"ccount": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-raw": "^7.0.0",
+				"hast-util-whitespace": "^2.0.0",
+				"html-void-elements": "^2.0.0",
+				"property-information": "^6.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"stringify-entities": "^4.0.0",
+				"zwitch": "^2.0.4"
+			}
+		},
+		"hast-util-to-jsx-runtime": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.0.tgz",
+			"integrity": "sha512-H/y0+IWPdsLLS738P8tDnrQ8Z+dj12zQQ6WC11TIM21C8WFVoIxcqWXf2H3hiTVZjF1AWqoimGwrTWecWrnmRQ==",
+			"requires": {
+				"@types/estree": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"property-information": "^6.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"style-to-object": "^1.0.0",
+				"unist-util-position": "^5.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"dependencies": {
+				"@types/hast": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+					"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+					"requires": {
+						"@types/unist": "*"
+					}
+				},
+				"@types/mdast": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+					"integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+					"requires": {
+						"@types/unist": "*"
+					}
+				},
+				"@types/unist": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+					"integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+				},
+				"estree-util-is-identifier-name": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+					"integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="
+				},
+				"hast-util-whitespace": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+					"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+					"requires": {
+						"@types/hast": "^3.0.0"
+					}
+				},
+				"inline-style-parser": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.2.tgz",
+					"integrity": "sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ=="
+				},
+				"mdast-util-from-markdown": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+					"integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+					"requires": {
+						"@types/mdast": "^4.0.0",
+						"@types/unist": "^3.0.0",
+						"decode-named-character-reference": "^1.0.0",
+						"devlop": "^1.0.0",
+						"mdast-util-to-string": "^4.0.0",
+						"micromark": "^4.0.0",
+						"micromark-util-decode-numeric-character-reference": "^2.0.0",
+						"micromark-util-decode-string": "^2.0.0",
+						"micromark-util-normalize-identifier": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0",
+						"unist-util-stringify-position": "^4.0.0"
+					}
+				},
+				"mdast-util-mdx-expression": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.0.tgz",
+					"integrity": "sha512-fGCu8eWdKUKNu5mohVGkhBXCXGnOTLuFqOvGMvdikr+J1w7lDJgxThOKpwRWzzbyXAU2hhSwsmssOY4yTokluw==",
+					"requires": {
+						"@types/estree-jsx": "^1.0.0",
+						"@types/hast": "^3.0.0",
+						"@types/mdast": "^4.0.0",
+						"devlop": "^1.0.0",
+						"mdast-util-from-markdown": "^2.0.0",
+						"mdast-util-to-markdown": "^2.0.0"
+					}
+				},
+				"mdast-util-mdxjs-esm": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+					"integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+					"requires": {
+						"@types/estree-jsx": "^1.0.0",
+						"@types/hast": "^3.0.0",
+						"@types/mdast": "^4.0.0",
+						"devlop": "^1.0.0",
+						"mdast-util-from-markdown": "^2.0.0",
+						"mdast-util-to-markdown": "^2.0.0"
+					}
+				},
+				"mdast-util-phrasing": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+					"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+					"requires": {
+						"@types/mdast": "^4.0.0",
+						"unist-util-is": "^6.0.0"
+					}
+				},
+				"mdast-util-to-markdown": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
+					"integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+					"requires": {
+						"@types/mdast": "^4.0.0",
+						"@types/unist": "^3.0.0",
+						"longest-streak": "^3.0.0",
+						"mdast-util-phrasing": "^4.0.0",
+						"mdast-util-to-string": "^4.0.0",
+						"micromark-util-decode-string": "^2.0.0",
+						"unist-util-visit": "^5.0.0",
+						"zwitch": "^2.0.0"
+					}
+				},
+				"mdast-util-to-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+					"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+					"requires": {
+						"@types/mdast": "^4.0.0"
+					}
+				},
+				"micromark": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+					"integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+					"requires": {
+						"@types/debug": "^4.0.0",
+						"debug": "^4.0.0",
+						"decode-named-character-reference": "^1.0.0",
+						"devlop": "^1.0.0",
+						"micromark-core-commonmark": "^2.0.0",
+						"micromark-factory-space": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-combine-extensions": "^2.0.0",
+						"micromark-util-decode-numeric-character-reference": "^2.0.0",
+						"micromark-util-encode": "^2.0.0",
+						"micromark-util-normalize-identifier": "^2.0.0",
+						"micromark-util-resolve-all": "^2.0.0",
+						"micromark-util-sanitize-uri": "^2.0.0",
+						"micromark-util-subtokenize": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-core-commonmark": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
+					"integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
+					"requires": {
+						"decode-named-character-reference": "^1.0.0",
+						"devlop": "^1.0.0",
+						"micromark-factory-destination": "^2.0.0",
+						"micromark-factory-label": "^2.0.0",
+						"micromark-factory-space": "^2.0.0",
+						"micromark-factory-title": "^2.0.0",
+						"micromark-factory-whitespace": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-classify-character": "^2.0.0",
+						"micromark-util-html-tag-name": "^2.0.0",
+						"micromark-util-normalize-identifier": "^2.0.0",
+						"micromark-util-resolve-all": "^2.0.0",
+						"micromark-util-subtokenize": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-destination": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
+					"integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-label": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
+					"integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
+					"requires": {
+						"devlop": "^1.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-space": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+					"integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-title": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
+					"integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
+					"requires": {
+						"micromark-factory-space": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-whitespace": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
+					"integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
+					"requires": {
+						"micromark-factory-space": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-character": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+					"integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-chunked": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
+					"integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-classify-character": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
+					"integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-combine-extensions": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
+					"integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
+					"requires": {
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-decode-numeric-character-reference": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
+					"integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-decode-string": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
+					"integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
+					"requires": {
+						"decode-named-character-reference": "^1.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-decode-numeric-character-reference": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-encode": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+					"integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA=="
+				},
+				"micromark-util-html-tag-name": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
+					"integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw=="
+				},
+				"micromark-util-normalize-identifier": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
+					"integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-resolve-all": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
+					"integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
+					"requires": {
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-sanitize-uri": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+					"integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-encode": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-subtokenize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
+					"integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
+					"requires": {
+						"devlop": "^1.0.0",
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-symbol": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+					"integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+				},
+				"micromark-util-types": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+					"integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+				},
+				"style-to-object": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.5.tgz",
+					"integrity": "sha512-rDRwHtoDD3UMMrmZ6BzOW0naTjMsVZLIjsGleSKS/0Oz+cgCfAPRspaqJuE8rDzpKha/nEvnM0IF4seEAZUTKQ==",
+					"requires": {
+						"inline-style-parser": "0.2.2"
+					}
+				},
+				"unist-util-is": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+					"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-position": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+					"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-stringify-position": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+					"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-visit": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+					"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-is": "^6.0.0",
+						"unist-util-visit-parents": "^6.0.0"
+					}
+				},
+				"unist-util-visit-parents": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+					"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-is": "^6.0.0"
+					}
+				}
+			}
+		},
+		"hast-util-to-parse5": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.1.0.tgz",
+			"integrity": "sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==",
+			"requires": {
+				"@types/hast": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"property-information": "^6.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"web-namespaces": "^2.0.0",
+				"zwitch": "^2.0.0"
+			}
+		},
+		"hast-util-whitespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
+			"integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng=="
+		},
+		"hastscript": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+			"integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+			"requires": {
+				"@types/hast": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-parse-selector": "^3.0.0",
+				"property-information": "^6.0.0",
+				"space-separated-tokens": "^2.0.0"
 			}
 		},
 		"history": {
@@ -30038,6 +32425,16 @@
 		"html-escaper": {
 			"version": "2.0.2",
 			"dev": true
+		},
+		"html-url-attributes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.0.tgz",
+			"integrity": "sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow=="
+		},
+		"html-void-elements": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
+			"integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A=="
 		},
 		"http-errors": {
 			"version": "2.0.0",
@@ -30087,6 +32484,11 @@
 			"version": "1.0.1",
 			"dev": true
 		},
+		"imagescript": {
+			"version": "1.2.18",
+			"resolved": "https://registry.npmjs.org/imagescript/-/imagescript-1.2.18.tgz",
+			"integrity": "sha512-8AwTawraXovLo2PgKvFt96SZqJDwl0CnHDyrtoPUQHMmoA7u9M8EnqFZwCofSM+Uo623Z580iKW74bs2fzjoYQ=="
+		},
 		"import-fresh": {
 			"version": "3.3.0",
 			"dev": true,
@@ -30111,6 +32513,11 @@
 			"version": "4.0.0",
 			"dev": true
 		},
+		"inflection": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/inflection/-/inflection-2.0.1.tgz",
+			"integrity": "sha512-wzkZHqpb4eGrOKBl34xy3umnYHx8Si5R1U4fwmdxLo5gdH6mEK8gclckTj/qWqy4Je0bsDYe/qazZYuO7xe3XQ=="
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"dev": true,
@@ -30121,6 +32528,16 @@
 		},
 		"inherits": {
 			"version": "2.0.4"
+		},
+		"ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+		},
+		"inline-style-parser": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+			"integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
 		},
 		"internal-slot": {
 			"version": "1.0.6",
@@ -30133,6 +32550,20 @@
 		},
 		"ipaddr.js": {
 			"version": "1.9.1"
+		},
+		"is-alphabetical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+			"integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
+		},
+		"is-alphanumerical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+			"integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+			"requires": {
+				"is-alphabetical": "^2.0.0",
+				"is-decimal": "^2.0.0"
+			}
 		},
 		"is-arguments": {
 			"version": "1.1.1",
@@ -30163,7 +32594,6 @@
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
-			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
 			}
@@ -30176,12 +32606,16 @@
 				"has-tostringtag": "^1.0.0"
 			}
 		},
+		"is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+		},
 		"is-callable": {
 			"version": "1.2.7"
 		},
 		"is-core-module": {
 			"version": "2.13.1",
-			"dev": true,
 			"requires": {
 				"hasown": "^2.0.0"
 			}
@@ -30193,17 +32627,25 @@
 				"has-tostringtag": "^1.0.0"
 			}
 		},
+		"is-decimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+			"integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="
+		},
 		"is-docker": {
 			"version": "2.2.1",
 			"dev": true
 		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
+		},
 		"is-extglob": {
-			"version": "2.1.1",
-			"dev": true
+			"version": "2.1.1"
 		},
 		"is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"dev": true
+			"version": "3.0.0"
 		},
 		"is-generator-fn": {
 			"version": "2.1.0",
@@ -30217,18 +32659,21 @@
 		},
 		"is-glob": {
 			"version": "4.0.3",
-			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
+		},
+		"is-hexadecimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+			"integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
 		},
 		"is-negative-zero": {
 			"version": "2.0.2",
 			"dev": true
 		},
 		"is-number": {
-			"version": "7.0.0",
-			"dev": true
+			"version": "7.0.0"
 		},
 		"is-number-object": {
 			"version": "1.0.7",
@@ -30240,6 +32685,27 @@
 		"is-path-inside": {
 			"version": "3.0.3",
 			"dev": true
+		},
+		"is-plain-obj": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+			"integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"is-reference": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
+			"integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
+			"requires": {
+				"@types/estree": "*"
+			}
 		},
 		"is-regex": {
 			"version": "1.1.4",
@@ -30304,8 +32770,12 @@
 			"version": "1.0.0"
 		},
 		"isexe": {
-			"version": "2.0.0",
-			"dev": true
+			"version": "2.0.0"
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -30350,7 +32820,6 @@
 		},
 		"jackspeak": {
 			"version": "2.3.6",
-			"dev": true,
 			"requires": {
 				"@isaacs/cliui": "^8.0.2",
 				"@pkgjs/parseargs": "^0.11.0"
@@ -30758,8 +33227,7 @@
 			}
 		},
 		"jiti": {
-			"version": "1.21.0",
-			"dev": true
+			"version": "1.21.0"
 		},
 		"jmespath": {
 			"version": "0.16.0"
@@ -30769,10 +33237,14 @@
 		},
 		"js-yaml": {
 			"version": "4.1.0",
-			"dev": true,
 			"requires": {
 				"argparse": "^2.0.1"
 			}
+		},
+		"jsbi": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+			"integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
 		},
 		"jsesc": {
 			"version": "2.5.2",
@@ -30854,9 +33326,27 @@
 				"json-buffer": "3.0.1"
 			}
 		},
+		"kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+		},
 		"kleur": {
 			"version": "3.0.3",
 			"dev": true
+		},
+		"kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+		},
+		"lazy-cache": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+			"integrity": "sha512-7vp2Acd2+Kz4XkzxGxaB1FWOi8KjWIWsgdfD5MCb86DWvlLqhRPM+d6Pro3iNEL5VT9mstz5hKAlcd+QR6H3aA==",
+			"requires": {
+				"set-getter": "^0.1.0"
+			}
 		},
 		"leven": {
 			"version": "3.1.0",
@@ -30871,12 +33361,10 @@
 			}
 		},
 		"lilconfig": {
-			"version": "3.0.0",
-			"dev": true
+			"version": "3.0.0"
 		},
 		"lines-and-columns": {
-			"version": "1.2.4",
-			"dev": true
+			"version": "1.2.4"
 		},
 		"lint-staged": {
 			"version": "15.2.0",
@@ -30961,6 +33449,40 @@
 				}
 			}
 		},
+		"list-item": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+			"integrity": "sha512-S3D0WZ4J6hyM8o5SNKWaMYB1ALSacPZ2nHGEuCjmHZ+dc03gFeNZoNDcqfcnO4vDhTZmNrqrpYZCdXsRh22bzw==",
+			"requires": {
+				"expand-range": "^1.8.1",
+				"extend-shallow": "^2.0.1",
+				"is-number": "^2.1.0",
+				"repeat-string": "^1.5.2"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+					"integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
 		"listr2": {
 			"version": "8.0.0",
 			"dev": true,
@@ -31019,9 +33541,13 @@
 				"p-locate": "^5.0.0"
 			}
 		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA=="
+		},
 		"lodash.camelcase": {
-			"version": "4.3.0",
-			"dev": true
+			"version": "4.3.0"
 		},
 		"lodash.includes": {
 			"version": "4.3.0"
@@ -31050,11 +33576,27 @@
 			"dev": true
 		},
 		"lodash.merge": {
-			"version": "4.6.2",
-			"dev": true
+			"version": "4.6.2"
 		},
 		"lodash.once": {
 			"version": "4.1.1"
+		},
+		"lodash.template": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+			"integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+			"requires": {
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.templatesettings": "^4.0.0"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+			"integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+			"requires": {
+				"lodash._reinterpolate": "^3.0.0"
+			}
 		},
 		"lodash.upperfirst": {
 			"version": "4.3.1",
@@ -31136,10 +33678,41 @@
 				}
 			}
 		},
+		"logform": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+			"requires": {
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"safe-stable-stringify": "^2.3.1",
+				"triple-beam": "^1.3.0"
+			}
+		},
+		"long": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+			"integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+		},
+		"longest-streak": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"lower-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+			"requires": {
+				"tslib": "^2.0.3"
 			}
 		},
 		"lru-cache": {
@@ -31157,7 +33730,7 @@
 		},
 		"make-error": {
 			"version": "1.3.6",
-			"dev": true
+			"devOptional": true
 		},
 		"makeerror": {
 			"version": "1.0.12",
@@ -31166,8 +33739,721 @@
 				"tmpl": "1.0.5"
 			}
 		},
+		"markdown-extensions": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
+			"integrity": "sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q=="
+		},
+		"markdown-link": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/markdown-link/-/markdown-link-0.1.1.tgz",
+			"integrity": "sha512-TurLymbyLyo+kAUUAV9ggR9EPcDjP/ctlv9QAFiqUH7c+t6FlsbivPo9OKTU8xdOx9oNd2drW/Fi5RRElQbUqA=="
+		},
+		"markdown-toc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/markdown-toc/-/markdown-toc-1.2.0.tgz",
+			"integrity": "sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==",
+			"requires": {
+				"concat-stream": "^1.5.2",
+				"diacritics-map": "^0.1.0",
+				"gray-matter": "^2.1.0",
+				"lazy-cache": "^2.0.2",
+				"list-item": "^1.1.1",
+				"markdown-link": "^0.1.1",
+				"minimist": "^1.2.0",
+				"mixin-deep": "^1.1.3",
+				"object.pick": "^1.2.0",
+				"remarkable": "^1.7.1",
+				"repeat-string": "^1.6.1",
+				"strip-color": "^0.1.0"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"gray-matter": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
+					"integrity": "sha512-vbmvP1Fe/fxuT2QuLVcqb2BfK7upGhhbLIt9/owWEvPYrZZEkelLcq2HqzxosV+PQ67dUFLaAeNpH7C4hhICAA==",
+					"requires": {
+						"ansi-red": "^0.1.1",
+						"coffee-script": "^1.12.4",
+						"extend-shallow": "^2.0.1",
+						"js-yaml": "^3.8.1",
+						"toml": "^2.3.2"
+					}
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"toml": {
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
+					"integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ=="
+				}
+			}
+		},
+		"math-random": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
+		},
+		"mdast-util-definitions": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
+			"integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"@types/unist": "^2.0.0",
+				"unist-util-visit": "^4.0.0"
+			}
+		},
+		"mdast-util-from-markdown": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+			"integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"@types/unist": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"mdast-util-to-string": "^3.1.0",
+				"micromark": "^3.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-decode-string": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"mdast-util-frontmatter": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.1.tgz",
+			"integrity": "sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"mdast-util-to-markdown": "^1.3.0",
+				"micromark-extension-frontmatter": "^1.0.0"
+			}
+		},
+		"mdast-util-mdx": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-2.0.1.tgz",
+			"integrity": "sha512-38w5y+r8nyKlGvNjSEqWrhG0w5PmnRA+wnBvm+ulYCct7nsGYhFVb0lljS9bQav4psDAS1eGkP2LMVcZBi/aqw==",
+			"requires": {
+				"mdast-util-from-markdown": "^1.0.0",
+				"mdast-util-mdx-expression": "^1.0.0",
+				"mdast-util-mdx-jsx": "^2.0.0",
+				"mdast-util-mdxjs-esm": "^1.0.0",
+				"mdast-util-to-markdown": "^1.0.0"
+			},
+			"dependencies": {
+				"mdast-util-mdx-jsx": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-2.1.4.tgz",
+					"integrity": "sha512-DtMn9CmVhVzZx3f+optVDF8yFgQVt7FghCRNdlIaS3X5Bnym3hZwPbg/XW86vdpKjlc1PVj26SpnLGeJBXD3JA==",
+					"requires": {
+						"@types/estree-jsx": "^1.0.0",
+						"@types/hast": "^2.0.0",
+						"@types/mdast": "^3.0.0",
+						"@types/unist": "^2.0.0",
+						"ccount": "^2.0.0",
+						"mdast-util-from-markdown": "^1.1.0",
+						"mdast-util-to-markdown": "^1.3.0",
+						"parse-entities": "^4.0.0",
+						"stringify-entities": "^4.0.0",
+						"unist-util-remove-position": "^4.0.0",
+						"unist-util-stringify-position": "^3.0.0",
+						"vfile-message": "^3.0.0"
+					}
+				},
+				"unist-util-remove-position": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-4.0.2.tgz",
+					"integrity": "sha512-TkBb0HABNmxzAcfLf4qsIbFbaPDvMO6wa3b3j4VcEzFVaw1LBKwnW4/sRJ/atSLSzoIg41JWEdnE7N6DIhGDGQ==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-visit": "^4.0.0"
+					}
+				},
+				"vfile-message": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+					"integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0"
+					}
+				}
+			}
+		},
+		"mdast-util-mdx-expression": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-1.3.2.tgz",
+			"integrity": "sha512-xIPmR5ReJDu/DHH1OoIT1HkuybIfRGYRywC+gJtI7qHjCJp/M9jrmBEJW22O8lskDWm562BX2W8TiAwRTb0rKA==",
+			"requires": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^2.0.0",
+				"@types/mdast": "^3.0.0",
+				"mdast-util-from-markdown": "^1.0.0",
+				"mdast-util-to-markdown": "^1.0.0"
+			}
+		},
+		"mdast-util-mdx-jsx": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.1.0.tgz",
+			"integrity": "sha512-A8AJHlR7/wPQ3+Jre1+1rq040fX9A4Q1jG8JxmSNp/PLPHg80A6475wxTp3KzHpApFH6yWxFotHrJQA3dXP6/w==",
+			"requires": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"devlop": "^1.1.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"parse-entities": "^4.0.0",
+				"stringify-entities": "^4.0.0",
+				"unist-util-remove-position": "^5.0.0",
+				"unist-util-stringify-position": "^4.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"dependencies": {
+				"@types/hast": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+					"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+					"requires": {
+						"@types/unist": "*"
+					}
+				},
+				"@types/mdast": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+					"integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+					"requires": {
+						"@types/unist": "*"
+					}
+				},
+				"@types/unist": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+					"integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+				},
+				"mdast-util-from-markdown": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+					"integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+					"requires": {
+						"@types/mdast": "^4.0.0",
+						"@types/unist": "^3.0.0",
+						"decode-named-character-reference": "^1.0.0",
+						"devlop": "^1.0.0",
+						"mdast-util-to-string": "^4.0.0",
+						"micromark": "^4.0.0",
+						"micromark-util-decode-numeric-character-reference": "^2.0.0",
+						"micromark-util-decode-string": "^2.0.0",
+						"micromark-util-normalize-identifier": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0",
+						"unist-util-stringify-position": "^4.0.0"
+					}
+				},
+				"mdast-util-phrasing": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+					"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+					"requires": {
+						"@types/mdast": "^4.0.0",
+						"unist-util-is": "^6.0.0"
+					}
+				},
+				"mdast-util-to-markdown": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
+					"integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+					"requires": {
+						"@types/mdast": "^4.0.0",
+						"@types/unist": "^3.0.0",
+						"longest-streak": "^3.0.0",
+						"mdast-util-phrasing": "^4.0.0",
+						"mdast-util-to-string": "^4.0.0",
+						"micromark-util-decode-string": "^2.0.0",
+						"unist-util-visit": "^5.0.0",
+						"zwitch": "^2.0.0"
+					}
+				},
+				"mdast-util-to-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+					"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+					"requires": {
+						"@types/mdast": "^4.0.0"
+					}
+				},
+				"micromark": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+					"integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+					"requires": {
+						"@types/debug": "^4.0.0",
+						"debug": "^4.0.0",
+						"decode-named-character-reference": "^1.0.0",
+						"devlop": "^1.0.0",
+						"micromark-core-commonmark": "^2.0.0",
+						"micromark-factory-space": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-combine-extensions": "^2.0.0",
+						"micromark-util-decode-numeric-character-reference": "^2.0.0",
+						"micromark-util-encode": "^2.0.0",
+						"micromark-util-normalize-identifier": "^2.0.0",
+						"micromark-util-resolve-all": "^2.0.0",
+						"micromark-util-sanitize-uri": "^2.0.0",
+						"micromark-util-subtokenize": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-core-commonmark": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
+					"integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
+					"requires": {
+						"decode-named-character-reference": "^1.0.0",
+						"devlop": "^1.0.0",
+						"micromark-factory-destination": "^2.0.0",
+						"micromark-factory-label": "^2.0.0",
+						"micromark-factory-space": "^2.0.0",
+						"micromark-factory-title": "^2.0.0",
+						"micromark-factory-whitespace": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-classify-character": "^2.0.0",
+						"micromark-util-html-tag-name": "^2.0.0",
+						"micromark-util-normalize-identifier": "^2.0.0",
+						"micromark-util-resolve-all": "^2.0.0",
+						"micromark-util-subtokenize": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-destination": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
+					"integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-label": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
+					"integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
+					"requires": {
+						"devlop": "^1.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-space": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+					"integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-title": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
+					"integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
+					"requires": {
+						"micromark-factory-space": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-whitespace": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
+					"integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
+					"requires": {
+						"micromark-factory-space": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-character": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+					"integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-chunked": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
+					"integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-classify-character": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
+					"integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-combine-extensions": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
+					"integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
+					"requires": {
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-decode-numeric-character-reference": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
+					"integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-decode-string": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
+					"integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
+					"requires": {
+						"decode-named-character-reference": "^1.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-decode-numeric-character-reference": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-encode": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+					"integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA=="
+				},
+				"micromark-util-html-tag-name": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
+					"integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw=="
+				},
+				"micromark-util-normalize-identifier": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
+					"integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-resolve-all": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
+					"integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
+					"requires": {
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-sanitize-uri": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+					"integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-encode": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-subtokenize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
+					"integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
+					"requires": {
+						"devlop": "^1.0.0",
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-symbol": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+					"integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+				},
+				"micromark-util-types": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+					"integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+				},
+				"unist-util-is": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+					"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-stringify-position": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+					"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-visit": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+					"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-is": "^6.0.0",
+						"unist-util-visit-parents": "^6.0.0"
+					}
+				},
+				"unist-util-visit-parents": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+					"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-is": "^6.0.0"
+					}
+				}
+			}
+		},
+		"mdast-util-mdxjs-esm": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-1.3.1.tgz",
+			"integrity": "sha512-SXqglS0HrEvSdUEfoXFtcg7DRl7S2cwOXc7jkuusG472Mmjag34DUDeOJUZtl+BVnyeO1frIgVpHlNRWc2gk/w==",
+			"requires": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^2.0.0",
+				"@types/mdast": "^3.0.0",
+				"mdast-util-from-markdown": "^1.0.0",
+				"mdast-util-to-markdown": "^1.0.0"
+			}
+		},
+		"mdast-util-phrasing": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+			"integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"unist-util-is": "^5.0.0"
+			}
+		},
+		"mdast-util-to-hast": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.1.0.tgz",
+			"integrity": "sha512-/e2l/6+OdGp/FB+ctrJ9Avz71AN/GRH3oi/3KAx/kMnoUsD6q0woXlDT8lLEeViVKE7oZxE7RXzvO3T8kF2/sA==",
+			"requires": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"trim-lines": "^3.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"dependencies": {
+				"@types/hast": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+					"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+					"requires": {
+						"@types/unist": "*"
+					}
+				},
+				"@types/mdast": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+					"integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+					"requires": {
+						"@types/unist": "*"
+					}
+				},
+				"@types/unist": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+					"integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+				},
+				"micromark-util-character": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+					"integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-encode": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+					"integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA=="
+				},
+				"micromark-util-sanitize-uri": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+					"integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-encode": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-symbol": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+					"integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+				},
+				"micromark-util-types": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+					"integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+				},
+				"unist-util-is": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+					"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-position": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+					"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-stringify-position": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+					"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-visit": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+					"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-is": "^6.0.0",
+						"unist-util-visit-parents": "^6.0.0"
+					}
+				},
+				"unist-util-visit-parents": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+					"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-is": "^6.0.0"
+					}
+				},
+				"vfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+					"integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-stringify-position": "^4.0.0",
+						"vfile-message": "^4.0.0"
+					}
+				}
+			}
+		},
+		"mdast-util-to-markdown": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+			"integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"@types/unist": "^2.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-phrasing": "^3.0.0",
+				"mdast-util-to-string": "^3.0.0",
+				"micromark-util-decode-string": "^1.0.0",
+				"unist-util-visit": "^4.0.0",
+				"zwitch": "^2.0.0"
+			}
+		},
+		"mdast-util-to-string": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+			"integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+			"requires": {
+				"@types/mdast": "^3.0.0"
+			}
+		},
+		"mdx-bundler": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/mdx-bundler/-/mdx-bundler-9.2.1.tgz",
+			"integrity": "sha512-hWEEip1KU9MCNqeH2rqwzAZ1pdqPPbfkx9OTJjADqGPQz4t9BO85fhI7AP9gVYrpmfArf9/xJZUN0yBErg/G/Q==",
+			"requires": {
+				"@babel/runtime": "^7.16.3",
+				"@esbuild-plugins/node-resolve": "^0.1.4",
+				"@fal-works/esbuild-plugin-global-externals": "^2.1.2",
+				"@mdx-js/esbuild": "^2.0.0",
+				"gray-matter": "^4.0.3",
+				"remark-frontmatter": "^4.0.1",
+				"remark-mdx-frontmatter": "^1.1.1",
+				"uuid": "^8.3.2",
+				"vfile": "^5.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+				}
+			}
+		},
 		"media-typer": {
 			"version": "0.3.0"
+		},
+		"memfs": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
+			"integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+			"requires": {
+				"fs-monkey": "^1.0.4"
+			}
 		},
 		"merge-descriptors": {
 			"version": "1.0.1"
@@ -31177,15 +34463,380 @@
 			"dev": true
 		},
 		"merge2": {
-			"version": "1.4.1",
-			"dev": true
+			"version": "1.4.1"
 		},
 		"methods": {
 			"version": "1.1.2"
 		},
+		"micromark": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+			"integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+			"requires": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-core-commonmark": "^1.0.1",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-combine-extensions": "^1.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-encode": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-resolve-all": "^1.0.0",
+				"micromark-util-sanitize-uri": "^1.0.0",
+				"micromark-util-subtokenize": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.1",
+				"uvu": "^0.5.0"
+			}
+		},
+		"micromark-core-commonmark": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+			"integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+			"requires": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-factory-destination": "^1.0.0",
+				"micromark-factory-label": "^1.0.0",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-factory-title": "^1.0.0",
+				"micromark-factory-whitespace": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-classify-character": "^1.0.0",
+				"micromark-util-html-tag-name": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-resolve-all": "^1.0.0",
+				"micromark-util-subtokenize": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.1",
+				"uvu": "^0.5.0"
+			}
+		},
+		"micromark-extension-frontmatter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.1.1.tgz",
+			"integrity": "sha512-m2UH9a7n3W8VAH9JO9y01APpPKmNNNs71P0RbknEmYSaZU5Ghogv38BYO94AI5Xw6OYfxZRdHZZ2nYjs/Z+SZQ==",
+			"requires": {
+				"fault": "^2.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-extension-mdx-expression": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.8.tgz",
+			"integrity": "sha512-zZpeQtc5wfWKdzDsHRBY003H2Smg+PUi2REhqgIhdzAa5xonhP03FcXxqFSerFiNUr5AWmHpaNPQTBVOS4lrXw==",
+			"requires": {
+				"@types/estree": "^1.0.0",
+				"micromark-factory-mdx-expression": "^1.0.0",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-events-to-acorn": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"micromark-extension-mdx-jsx": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-1.0.5.tgz",
+			"integrity": "sha512-gPH+9ZdmDflbu19Xkb8+gheqEDqkSpdCEubQyxuz/Hn8DOXiXvrXeikOoBA71+e8Pfi0/UYmU3wW3H58kr7akA==",
+			"requires": {
+				"@types/acorn": "^4.0.0",
+				"@types/estree": "^1.0.0",
+				"estree-util-is-identifier-name": "^2.0.0",
+				"micromark-factory-mdx-expression": "^1.0.0",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0",
+				"vfile-message": "^3.0.0"
+			},
+			"dependencies": {
+				"vfile-message": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+					"integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0"
+					}
+				}
+			}
+		},
+		"micromark-extension-mdx-md": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-1.0.1.tgz",
+			"integrity": "sha512-7MSuj2S7xjOQXAjjkbjBsHkMtb+mDGVW6uI2dBL9snOBCbZmoNgDAeZ0nSn9j3T42UE/g2xVNMn18PJxZvkBEA==",
+			"requires": {
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-extension-mdxjs": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-1.0.1.tgz",
+			"integrity": "sha512-7YA7hF6i5eKOfFUzZ+0z6avRG52GpWR8DL+kN47y3f2KhxbBZMhmxe7auOeaTBrW2DenbbZTf1ea9tA2hDpC2Q==",
+			"requires": {
+				"acorn": "^8.0.0",
+				"acorn-jsx": "^5.0.0",
+				"micromark-extension-mdx-expression": "^1.0.0",
+				"micromark-extension-mdx-jsx": "^1.0.0",
+				"micromark-extension-mdx-md": "^1.0.0",
+				"micromark-extension-mdxjs-esm": "^1.0.0",
+				"micromark-util-combine-extensions": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-extension-mdxjs-esm": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-1.0.5.tgz",
+			"integrity": "sha512-xNRBw4aoURcyz/S69B19WnZAkWJMxHMT5hE36GtDAyhoyn/8TuAeqjFJQlwk+MKQsUD7b3l7kFX+vlfVWgcX1w==",
+			"requires": {
+				"@types/estree": "^1.0.0",
+				"micromark-core-commonmark": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-events-to-acorn": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"unist-util-position-from-estree": "^1.1.0",
+				"uvu": "^0.5.0",
+				"vfile-message": "^3.0.0"
+			},
+			"dependencies": {
+				"vfile-message": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+					"integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0"
+					}
+				}
+			}
+		},
+		"micromark-factory-destination": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+			"integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+			"requires": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-factory-label": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+			"integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+			"requires": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"micromark-factory-mdx-expression": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.9.tgz",
+			"integrity": "sha512-jGIWzSmNfdnkJq05c7b0+Wv0Kfz3NJ3N4cBjnbO4zjXIlxJr+f8lk+5ZmwFvqdAbUy2q6B5rCY//g0QAAaXDWA==",
+			"requires": {
+				"@types/estree": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-events-to-acorn": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"unist-util-position-from-estree": "^1.0.0",
+				"uvu": "^0.5.0",
+				"vfile-message": "^3.0.0"
+			},
+			"dependencies": {
+				"vfile-message": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+					"integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0"
+					}
+				}
+			}
+		},
+		"micromark-factory-space": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+			"integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+			"requires": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-factory-title": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+			"integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+			"requires": {
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-factory-whitespace": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+			"integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+			"requires": {
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-util-character": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+			"integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+			"requires": {
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-util-chunked": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+			"integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+			"requires": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"micromark-util-classify-character": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+			"integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+			"requires": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-util-combine-extensions": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+			"integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+			"requires": {
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-util-decode-numeric-character-reference": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+			"integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+			"requires": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"micromark-util-decode-string": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+			"integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+			"requires": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"micromark-util-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+			"integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw=="
+		},
+		"micromark-util-events-to-acorn": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-1.2.3.tgz",
+			"integrity": "sha512-ij4X7Wuc4fED6UoLWkmo0xJQhsktfNh1J0m8g4PbIMPlx+ek/4YdW5mvbye8z/aZvAPUoxgXHrwVlXAPKMRp1w==",
+			"requires": {
+				"@types/acorn": "^4.0.0",
+				"@types/estree": "^1.0.0",
+				"@types/unist": "^2.0.0",
+				"estree-util-visit": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0",
+				"vfile-message": "^3.0.0"
+			},
+			"dependencies": {
+				"vfile-message": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+					"integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0"
+					}
+				}
+			}
+		},
+		"micromark-util-html-tag-name": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+			"integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q=="
+		},
+		"micromark-util-normalize-identifier": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+			"integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+			"requires": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"micromark-util-resolve-all": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+			"integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+			"requires": {
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-util-sanitize-uri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+			"integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+			"requires": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-encode": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"micromark-util-subtokenize": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+			"integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+			"requires": {
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"micromark-util-symbol": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+			"integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="
+		},
+		"micromark-util-types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+			"integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
+		},
 		"micromatch": {
 			"version": "4.0.5",
-			"dev": true,
 			"requires": {
 				"braces": "^3.0.2",
 				"picomatch": "^2.3.1"
@@ -31207,20 +34858,51 @@
 			"version": "2.1.0",
 			"dev": true
 		},
+		"mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+		},
+		"mini-svg-data-uri": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+			"integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg=="
+		},
 		"minimatch": {
 			"version": "9.0.3",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^2.0.1"
 			}
 		},
 		"minimist": {
-			"version": "1.2.8",
-			"dev": true
+			"version": "1.2.8"
 		},
 		"minipass": {
-			"version": "7.0.4",
-			"dev": true
+			"version": "7.0.4"
+		},
+		"mixin-deep": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
 		},
 		"mnemonist": {
 			"version": "0.38.3",
@@ -31228,12 +34910,16 @@
 				"obliterator": "^1.6.1"
 			}
 		},
+		"mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
+		},
 		"ms": {
 			"version": "2.1.2"
 		},
 		"mz": {
 			"version": "2.7.0",
-			"dev": true,
 			"requires": {
 				"any-promise": "^1.0.0",
 				"object-assign": "^4.0.1",
@@ -31242,6 +34928,11 @@
 		},
 		"nanoid": {
 			"version": "3.3.7"
+		},
+		"napi-build-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -31284,6 +34975,33 @@
 					}
 				}
 			}
+		},
+		"no-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+			"requires": {
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node-abi": {
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.54.0.tgz",
+			"integrity": "sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==",
+			"requires": {
+				"semver": "^7.3.5"
+			}
+		},
+		"node-addon-api": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+			"integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+		},
+		"node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
 		},
 		"node-fetch": {
 			"version": "2.7.0",
@@ -31369,8 +35087,7 @@
 			}
 		},
 		"normalize-path": {
-			"version": "3.0.0",
-			"dev": true
+			"version": "3.0.0"
 		},
 		"normalize-range": {
 			"version": "0.1.2",
@@ -31387,12 +35104,10 @@
 			"version": "0.9.15"
 		},
 		"object-assign": {
-			"version": "4.1.1",
-			"dev": true
+			"version": "4.1.1"
 		},
 		"object-hash": {
-			"version": "3.0.0",
-			"dev": true
+			"version": "3.0.0"
 		},
 		"object-inspect": {
 			"version": "1.13.1"
@@ -31434,6 +35149,14 @@
 				"get-intrinsic": "^1.2.1"
 			}
 		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
 		"object.values": {
 			"version": "1.1.7",
 			"dev": true,
@@ -31454,9 +35177,16 @@
 		},
 		"once": {
 			"version": "1.4.0",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"one-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"requires": {
+				"fn.name": "1.x.x"
 			}
 		},
 		"onetime": {
@@ -31465,6 +35195,11 @@
 			"requires": {
 				"mimic-fn": "^2.1.0"
 			}
+		},
+		"oo-ascii-tree": {
+			"version": "1.94.0",
+			"resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.94.0.tgz",
+			"integrity": "sha512-i6UllReifEW2InBJHVFJNxrledRp3yr/yKVbpDmgWTguRe8/7BtBK3njzjvZNcPLEAtiWWxr0o9SpwYjapmTOw=="
 		},
 		"optionator": {
 			"version": "0.9.3",
@@ -31515,6 +35250,21 @@
 				"callsites": "^3.0.0"
 			}
 		},
+		"parse-entities": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.1.tgz",
+			"integrity": "sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==",
+			"requires": {
+				"@types/unist": "^2.0.0",
+				"character-entities": "^2.0.0",
+				"character-entities-legacy": "^3.0.0",
+				"character-reference-invalid": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"is-alphanumerical": "^2.0.0",
+				"is-decimal": "^2.0.0",
+				"is-hexadecimal": "^2.0.0"
+			}
+		},
 		"parse-json": {
 			"version": "5.2.0",
 			"dev": true,
@@ -31539,8 +35289,22 @@
 				"parse-path": "^7.0.0"
 			}
 		},
+		"parse5": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+		},
 		"parseurl": {
 			"version": "1.3.3"
+		},
+		"pascal-case": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
 		},
 		"passport": {
 			"version": "0.7.0",
@@ -31593,24 +35357,20 @@
 			"dev": true
 		},
 		"path-key": {
-			"version": "3.1.1",
-			"dev": true
+			"version": "3.1.1"
 		},
 		"path-parse": {
-			"version": "1.0.7",
-			"dev": true
+			"version": "1.0.7"
 		},
 		"path-scurry": {
 			"version": "1.10.1",
-			"dev": true,
 			"requires": {
 				"lru-cache": "^9.1.1 || ^10.0.0",
 				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
 			},
 			"dependencies": {
 				"lru-cache": {
-					"version": "10.2.0",
-					"dev": true
+					"version": "10.2.0"
 				}
 			}
 		},
@@ -31624,24 +35384,31 @@
 		"pause": {
 			"version": "0.0.1"
 		},
+		"periscopic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
+			"requires": {
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^3.0.0",
+				"is-reference": "^3.0.0"
+			}
+		},
 		"picocolors": {
 			"version": "1.0.0"
 		},
 		"picomatch": {
-			"version": "2.3.1",
-			"dev": true
+			"version": "2.3.1"
 		},
 		"pidtree": {
 			"version": "0.6.0",
 			"dev": true
 		},
 		"pify": {
-			"version": "2.3.0",
-			"dev": true
+			"version": "2.3.0"
 		},
 		"pirates": {
-			"version": "4.0.6",
-			"dev": true
+			"version": "4.0.6"
 		},
 		"pkg-dir": {
 			"version": "4.2.0",
@@ -31683,7 +35450,6 @@
 		},
 		"postcss": {
 			"version": "8.4.33",
-			"dev": true,
 			"requires": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
@@ -31692,7 +35458,6 @@
 		},
 		"postcss-import": {
 			"version": "15.1.0",
-			"dev": true,
 			"requires": {
 				"postcss-value-parser": "^4.0.0",
 				"read-cache": "^1.0.0",
@@ -31701,14 +35466,12 @@
 		},
 		"postcss-js": {
 			"version": "4.0.1",
-			"dev": true,
 			"requires": {
 				"camelcase-css": "^2.0.1"
 			}
 		},
 		"postcss-load-config": {
 			"version": "4.0.2",
-			"dev": true,
 			"requires": {
 				"lilconfig": "^3.0.0",
 				"yaml": "^2.3.4"
@@ -31716,22 +35479,73 @@
 		},
 		"postcss-nested": {
 			"version": "6.0.1",
-			"dev": true,
 			"requires": {
 				"postcss-selector-parser": "^6.0.11"
 			}
 		},
 		"postcss-selector-parser": {
 			"version": "6.0.15",
-			"dev": true,
 			"requires": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
 			}
 		},
 		"postcss-value-parser": {
-			"version": "4.2.0",
-			"dev": true
+			"version": "4.2.0"
+		},
+		"prebuild-install": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+			"requires": {
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^1.0.1",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"tar-fs": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+					"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+					"requires": {
+						"chownr": "^1.1.1",
+						"mkdirp-classic": "^0.5.2",
+						"pump": "^3.0.0",
+						"tar-stream": "^2.1.4"
+					}
+				},
+				"tar-stream": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+					"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+					"requires": {
+						"bl": "^4.0.3",
+						"end-of-stream": "^1.4.1",
+						"fs-constants": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^3.1.1"
+					}
+				}
+			}
 		},
 		"prelude-ls": {
 			"version": "1.2.1",
@@ -31756,12 +35570,41 @@
 				}
 			}
 		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
 		"prompts": {
 			"version": "2.4.2",
 			"dev": true,
 			"requires": {
 				"kleur": "^3.0.3",
 				"sisteransi": "^1.0.5"
+			}
+		},
+		"property-information": {
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.1.tgz",
+			"integrity": "sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w=="
+		},
+		"protobufjs": {
+			"version": "7.2.6",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+			"integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+			"requires": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
 			}
 		},
 		"protocols": {
@@ -31784,6 +35627,15 @@
 			"version": "1.1.8",
 			"dev": true
 		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
 		"punycode": {
 			"version": "2.3.1",
 			"dev": true
@@ -31802,8 +35654,29 @@
 			"version": "0.2.0"
 		},
 		"queue-microtask": {
-			"version": "1.2.3",
-			"dev": true
+			"version": "1.2.3"
+		},
+		"queue-tick": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+			"integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+		},
+		"randomatic": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+			"requires": {
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+				}
+			}
 		},
 		"range-parser": {
 			"version": "1.2.1"
@@ -31815,6 +35688,24 @@
 				"http-errors": "2.0.0",
 				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
+			}
+		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"dependencies": {
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+				}
 			}
 		},
 		"react": {
@@ -31830,13 +35721,393 @@
 				"scheduler": "^0.23.0"
 			}
 		},
+		"react-icons": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+			"integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+			"requires": {}
+		},
+		"react-indiana-drag-scroll": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/react-indiana-drag-scroll/-/react-indiana-drag-scroll-2.2.0.tgz",
+			"integrity": "sha512-+W/3B2OQV0FrbdnsoIo4dww/xpH0MUQJz6ziQb7H+oBko3OCbXuzDFYnho6v6yhGrYDNWYPuFUewb89IONEl/A==",
+			"requires": {
+				"classnames": "^2.2.6",
+				"debounce": "^1.2.0",
+				"easy-bem": "^1.1.1"
+			}
+		},
 		"react-is": {
 			"version": "18.2.0",
 			"dev": true
 		},
+		"react-markdown": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.1.tgz",
+			"integrity": "sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==",
+			"requires": {
+				"@types/hast": "^3.0.0",
+				"devlop": "^1.0.0",
+				"hast-util-to-jsx-runtime": "^2.0.0",
+				"html-url-attributes": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-rehype": "^11.0.0",
+				"unified": "^11.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"dependencies": {
+				"@types/hast": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+					"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+					"requires": {
+						"@types/unist": "*"
+					}
+				},
+				"@types/mdast": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+					"integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+					"requires": {
+						"@types/unist": "*"
+					}
+				},
+				"@types/unist": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+					"integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+				},
+				"is-plain-obj": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+					"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+				},
+				"mdast-util-from-markdown": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
+					"integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+					"requires": {
+						"@types/mdast": "^4.0.0",
+						"@types/unist": "^3.0.0",
+						"decode-named-character-reference": "^1.0.0",
+						"devlop": "^1.0.0",
+						"mdast-util-to-string": "^4.0.0",
+						"micromark": "^4.0.0",
+						"micromark-util-decode-numeric-character-reference": "^2.0.0",
+						"micromark-util-decode-string": "^2.0.0",
+						"micromark-util-normalize-identifier": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0",
+						"unist-util-stringify-position": "^4.0.0"
+					}
+				},
+				"mdast-util-to-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+					"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+					"requires": {
+						"@types/mdast": "^4.0.0"
+					}
+				},
+				"micromark": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
+					"integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+					"requires": {
+						"@types/debug": "^4.0.0",
+						"debug": "^4.0.0",
+						"decode-named-character-reference": "^1.0.0",
+						"devlop": "^1.0.0",
+						"micromark-core-commonmark": "^2.0.0",
+						"micromark-factory-space": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-combine-extensions": "^2.0.0",
+						"micromark-util-decode-numeric-character-reference": "^2.0.0",
+						"micromark-util-encode": "^2.0.0",
+						"micromark-util-normalize-identifier": "^2.0.0",
+						"micromark-util-resolve-all": "^2.0.0",
+						"micromark-util-sanitize-uri": "^2.0.0",
+						"micromark-util-subtokenize": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-core-commonmark": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
+					"integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
+					"requires": {
+						"decode-named-character-reference": "^1.0.0",
+						"devlop": "^1.0.0",
+						"micromark-factory-destination": "^2.0.0",
+						"micromark-factory-label": "^2.0.0",
+						"micromark-factory-space": "^2.0.0",
+						"micromark-factory-title": "^2.0.0",
+						"micromark-factory-whitespace": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-classify-character": "^2.0.0",
+						"micromark-util-html-tag-name": "^2.0.0",
+						"micromark-util-normalize-identifier": "^2.0.0",
+						"micromark-util-resolve-all": "^2.0.0",
+						"micromark-util-subtokenize": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-destination": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
+					"integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-label": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
+					"integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
+					"requires": {
+						"devlop": "^1.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-space": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
+					"integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-title": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
+					"integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
+					"requires": {
+						"micromark-factory-space": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-factory-whitespace": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
+					"integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
+					"requires": {
+						"micromark-factory-space": "^2.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-character": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+					"integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-chunked": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
+					"integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-classify-character": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
+					"integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-combine-extensions": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
+					"integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
+					"requires": {
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-decode-numeric-character-reference": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
+					"integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-decode-string": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
+					"integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
+					"requires": {
+						"decode-named-character-reference": "^1.0.0",
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-decode-numeric-character-reference": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-encode": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+					"integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA=="
+				},
+				"micromark-util-html-tag-name": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
+					"integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw=="
+				},
+				"micromark-util-normalize-identifier": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
+					"integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
+					"requires": {
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-resolve-all": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
+					"integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
+					"requires": {
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-sanitize-uri": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+					"integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+					"requires": {
+						"micromark-util-character": "^2.0.0",
+						"micromark-util-encode": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0"
+					}
+				},
+				"micromark-util-subtokenize": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
+					"integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
+					"requires": {
+						"devlop": "^1.0.0",
+						"micromark-util-chunked": "^2.0.0",
+						"micromark-util-symbol": "^2.0.0",
+						"micromark-util-types": "^2.0.0"
+					}
+				},
+				"micromark-util-symbol": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+					"integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw=="
+				},
+				"micromark-util-types": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+					"integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
+				},
+				"remark-parse": {
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+					"integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+					"requires": {
+						"@types/mdast": "^4.0.0",
+						"mdast-util-from-markdown": "^2.0.0",
+						"micromark-util-types": "^2.0.0",
+						"unified": "^11.0.0"
+					}
+				},
+				"remark-rehype": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.0.tgz",
+					"integrity": "sha512-z3tJrAs2kIs1AqIIy6pzHmAHlF1hWQ+OdY4/hv+Wxe35EhyLKcajL33iUEn3ScxtFox9nUvRufR/Zre8Q08H/g==",
+					"requires": {
+						"@types/hast": "^3.0.0",
+						"@types/mdast": "^4.0.0",
+						"mdast-util-to-hast": "^13.0.0",
+						"unified": "^11.0.0",
+						"vfile": "^6.0.0"
+					}
+				},
+				"unified": {
+					"version": "11.0.4",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.4.tgz",
+					"integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"bail": "^2.0.0",
+						"devlop": "^1.0.0",
+						"extend": "^3.0.0",
+						"is-plain-obj": "^4.0.0",
+						"trough": "^2.0.0",
+						"vfile": "^6.0.0"
+					}
+				},
+				"unist-util-is": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+					"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-stringify-position": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+					"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-visit": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+					"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-is": "^6.0.0",
+						"unist-util-visit-parents": "^6.0.0"
+					}
+				},
+				"unist-util-visit-parents": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+					"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-is": "^6.0.0"
+					}
+				},
+				"vfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+					"integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-stringify-position": "^4.0.0",
+						"vfile-message": "^4.0.0"
+					}
+				}
+			}
+		},
 		"read-cache": {
 			"version": "1.0.0",
-			"dev": true,
 			"requires": {
 				"pify": "^2.3.0"
 			}
@@ -31901,9 +36172,29 @@
 				}
 			}
 		},
+		"readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
 		"readdirp": {
 			"version": "3.6.0",
-			"dev": true,
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
@@ -31927,13 +36218,126 @@
 				"set-function-name": "^2.0.0"
 			}
 		},
+		"rehype-stringify": {
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.4.tgz",
+			"integrity": "sha512-Uk5xu1YKdqobe5XpSskwPvo1XeHUUucWEQSl8hTrXt5selvca1e8K1EZ37E6YoZ4BT8BCqCdVfQW7OfHfthtVQ==",
+			"requires": {
+				"@types/hast": "^2.0.0",
+				"hast-util-to-html": "^8.0.0",
+				"unified": "^10.0.0"
+			}
+		},
+		"remark-frontmatter": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
+			"integrity": "sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"mdast-util-frontmatter": "^1.0.0",
+				"micromark-extension-frontmatter": "^1.0.0",
+				"unified": "^10.0.0"
+			}
+		},
+		"remark-mdx": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.3.0.tgz",
+			"integrity": "sha512-g53hMkpM0I98MU266IzDFMrTD980gNF3BJnkyFcmN+dD873mQeD5rdMO3Y2X+x8umQfbSE0PcoEDl7ledSA+2g==",
+			"requires": {
+				"mdast-util-mdx": "^2.0.0",
+				"micromark-extension-mdxjs": "^1.0.0"
+			}
+		},
+		"remark-mdx-frontmatter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/remark-mdx-frontmatter/-/remark-mdx-frontmatter-1.1.1.tgz",
+			"integrity": "sha512-7teX9DW4tI2WZkXS4DBxneYSY7NHiXl4AKdWDO9LXVweULlCT8OPWsOjLEnMIXViN1j+QcY8mfbq3k0EK6x3uA==",
+			"requires": {
+				"estree-util-is-identifier-name": "^1.0.0",
+				"estree-util-value-to-estree": "^1.0.0",
+				"js-yaml": "^4.0.0",
+				"toml": "^3.0.0"
+			},
+			"dependencies": {
+				"estree-util-is-identifier-name": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-1.1.0.tgz",
+					"integrity": "sha512-OVJZ3fGGt9By77Ix9NhaRbzfbDV/2rx9EP7YIDJTmsZSEc5kYn2vWcNccYyahJL2uAQZK2a5Or2i0wtIKTPoRQ=="
+				}
+			}
+		},
+		"remark-parse": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+			"integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"mdast-util-from-markdown": "^1.0.0",
+				"unified": "^10.0.0"
+			}
+		},
+		"remark-rehype": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
+			"integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+			"requires": {
+				"@types/hast": "^2.0.0",
+				"@types/mdast": "^3.0.0",
+				"mdast-util-to-hast": "^12.1.0",
+				"unified": "^10.0.0"
+			},
+			"dependencies": {
+				"mdast-util-to-hast": {
+					"version": "12.3.0",
+					"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
+					"integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+					"requires": {
+						"@types/hast": "^2.0.0",
+						"@types/mdast": "^3.0.0",
+						"mdast-util-definitions": "^5.0.0",
+						"micromark-util-sanitize-uri": "^1.1.0",
+						"trim-lines": "^3.0.0",
+						"unist-util-generated": "^2.0.0",
+						"unist-util-position": "^4.0.0",
+						"unist-util-visit": "^4.0.0"
+					}
+				}
+			}
+		},
+		"remarkable": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+			"integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
+			"requires": {
+				"argparse": "^1.0.10",
+				"autolinker": "~0.28.0"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				}
+			}
+		},
+		"repeat-element": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+			"integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ=="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
+		},
 		"require-directory": {
-			"version": "2.1.1",
-			"dev": true
+			"version": "2.1.1"
 		},
 		"resolve": {
 			"version": "1.22.8",
-			"dev": true,
 			"requires": {
 				"is-core-module": "^2.13.0",
 				"path-parse": "^1.0.7",
@@ -31974,8 +36378,7 @@
 			}
 		},
 		"reusify": {
-			"version": "1.0.4",
-			"dev": true
+			"version": "1.0.4"
 		},
 		"rfdc": {
 			"version": "1.3.1",
@@ -31990,9 +36393,16 @@
 		},
 		"run-parallel": {
 			"version": "1.2.0",
-			"dev": true,
 			"requires": {
 				"queue-microtask": "^1.2.2"
+			}
+		},
+		"sade": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+			"requires": {
+				"mri": "^1.1.0"
 			}
 		},
 		"safe-array-concat": {
@@ -32023,6 +36433,11 @@
 				"is-regex": "^1.1.4"
 			}
 		},
+		"safe-stable-stringify": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
+		},
 		"safer-buffer": {
 			"version": "2.1.2"
 		},
@@ -32033,6 +36448,15 @@
 			"version": "0.23.0",
 			"requires": {
 				"loose-envify": "^1.1.0"
+			}
+		},
+		"section-matter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+			"integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"kind-of": "^6.0.0"
 			}
 		},
 		"semver": {
@@ -32103,19 +36527,40 @@
 				"has-property-descriptors": "^1.0.0"
 			}
 		},
+		"set-getter": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz",
+			"integrity": "sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==",
+			"requires": {
+				"to-object-path": "^0.3.0"
+			}
+		},
 		"setprototypeof": {
 			"version": "1.2.0"
 		},
+		"sharp": {
+			"version": "0.32.6",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+			"integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+			"requires": {
+				"color": "^4.2.3",
+				"detect-libc": "^2.0.2",
+				"node-addon-api": "^6.1.0",
+				"prebuild-install": "^7.1.1",
+				"semver": "^7.5.4",
+				"simple-get": "^4.0.1",
+				"tar-fs": "^3.0.4",
+				"tunnel-agent": "^0.6.0"
+			}
+		},
 		"shebang-command": {
 			"version": "2.0.0",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "^3.0.0"
 			}
 		},
 		"shebang-regex": {
-			"version": "3.0.0",
-			"dev": true
+			"version": "3.0.0"
 		},
 		"side-channel": {
 			"version": "1.0.4",
@@ -32128,6 +36573,36 @@
 		"signal-exit": {
 			"version": "3.0.7",
 			"dev": true
+		},
+		"simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+		},
+		"simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"requires": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
+		"simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+			"requires": {
+				"is-arrayish": "^0.3.1"
+			},
+			"dependencies": {
+				"is-arrayish": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+				}
+			}
 		},
 		"simple-update-notifier": {
 			"version": "2.0.0",
@@ -32154,19 +36629,22 @@
 			}
 		},
 		"source-map": {
-			"version": "0.6.1",
-			"dev": true
+			"version": "0.6.1"
 		},
 		"source-map-js": {
 			"version": "1.0.2"
 		},
 		"source-map-support": {
 			"version": "0.5.21",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			}
+		},
+		"space-separated-tokens": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+			"integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
 		},
 		"spdx-correct": {
 			"version": "3.2.0",
@@ -32195,6 +36673,11 @@
 		"sprintf-js": {
 			"version": "1.0.3"
 		},
+		"stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="
+		},
 		"stack-utils": {
 			"version": "2.0.6",
 			"dev": true,
@@ -32214,6 +36697,31 @@
 		"streamsearch": {
 			"version": "1.1.0"
 		},
+		"streamx": {
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.0.tgz",
+			"integrity": "sha512-a7Fi0PoUeusrUcMS4+HxivnZqYsw2MFEP841TIyLxTcEIucHcJsk+0ARcq3tGq1xDn+xK7sKHetvfMzI1/CzMA==",
+			"requires": {
+				"bare-events": "^2.2.0",
+				"fast-fifo": "^1.1.0",
+				"queue-tick": "^1.0.1"
+			}
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
 		"string-argv": {
 			"version": "0.3.2",
 			"dev": true
@@ -32228,7 +36736,6 @@
 		},
 		"string-width": {
 			"version": "4.2.3",
-			"dev": true,
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -32237,7 +36744,6 @@
 		},
 		"string-width-cjs": {
 			"version": "npm:string-width@4.2.3",
-			"dev": true,
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -32271,16 +36777,23 @@
 				"es-abstract": "^1.22.1"
 			}
 		},
+		"stringify-entities": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
+			"integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
+			"requires": {
+				"character-entities-html4": "^2.0.0",
+				"character-entities-legacy": "^3.0.0"
+			}
+		},
 		"strip-ansi": {
 			"version": "6.0.1",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
 		},
 		"strip-ansi-cjs": {
 			"version": "npm:strip-ansi@6.0.1",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
@@ -32288,6 +36801,16 @@
 		"strip-bom": {
 			"version": "4.0.0",
 			"dev": true
+		},
+		"strip-bom-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+			"integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="
+		},
+		"strip-color": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+			"integrity": "sha512-p9LsUieSjWNNAxVCXLeilaDlmuUOrDS5/dF9znM1nZc7EGX5+zEFC0bEevsNIaldjlks+2jns5Siz6F9iK6jwA=="
 		},
 		"strip-final-newline": {
 			"version": "2.0.0",
@@ -32300,6 +36823,14 @@
 		"strnum": {
 			"version": "1.0.5"
 		},
+		"style-to-object": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+			"integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
+			"requires": {
+				"inline-style-parser": "0.1.1"
+			}
+		},
 		"styled-jsx": {
 			"version": "5.1.1",
 			"requires": {
@@ -32308,7 +36839,6 @@
 		},
 		"sucrase": {
 			"version": "3.35.0",
-			"dev": true,
 			"requires": {
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"commander": "^4.0.0",
@@ -32320,12 +36850,10 @@
 			},
 			"dependencies": {
 				"commander": {
-					"version": "4.1.1",
-					"dev": true
+					"version": "4.1.1"
 				},
 				"glob": {
 					"version": "10.3.10",
-					"dev": true,
 					"requires": {
 						"foreground-child": "^3.1.0",
 						"jackspeak": "^2.3.5",
@@ -32352,12 +36880,23 @@
 			}
 		},
 		"supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"dev": true
+			"version": "1.0.0"
+		},
+		"tabbable": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+			"integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+		},
+		"tailwind-merge": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.2.1.tgz",
+			"integrity": "sha512-o+2GTLkthfa5YUt4JxPfzMIpQzZ3adD1vLVkvKE1Twl9UAhGsEbIZhHHZVRttyW177S8PDJI3bTQNaebyofK3Q==",
+			"requires": {
+				"@babel/runtime": "^7.23.7"
+			}
 		},
 		"tailwindcss": {
 			"version": "3.4.1",
-			"dev": true,
 			"requires": {
 				"@alloc/quick-lru": "^5.2.0",
 				"arg": "^5.0.2",
@@ -32384,18 +36923,37 @@
 			},
 			"dependencies": {
 				"arg": {
-					"version": "5.0.2",
-					"dev": true
+					"version": "5.0.2"
 				},
 				"lilconfig": {
-					"version": "2.1.0",
-					"dev": true
+					"version": "2.1.0"
 				}
 			}
 		},
 		"tapable": {
 			"version": "2.2.1",
 			"dev": true
+		},
+		"tar-fs": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
+			"integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+			"requires": {
+				"bare-fs": "^2.1.1",
+				"bare-path": "^2.1.0",
+				"pump": "^3.0.0",
+				"tar-stream": "^3.1.5"
+			}
+		},
+		"tar-stream": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+			"requires": {
+				"b4a": "^1.6.4",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
 		},
 		"test-exclude": {
 			"version": "6.0.0",
@@ -32423,22 +36981,34 @@
 				}
 			}
 		},
+		"text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+		},
 		"text-table": {
 			"version": "0.2.0",
 			"dev": true
 		},
 		"thenify": {
 			"version": "3.3.1",
-			"dev": true,
 			"requires": {
 				"any-promise": "^1.0.0"
 			}
 		},
 		"thenify-all": {
 			"version": "1.6.0",
-			"dev": true,
 			"requires": {
 				"thenify": ">= 3.1.0 < 4"
+			}
+		},
+		"through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"requires": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
 			}
 		},
 		"tmpl": {
@@ -32449,15 +37019,42 @@
 			"version": "2.0.0",
 			"dev": true
 		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
 		"to-regex-range": {
 			"version": "5.0.1",
-			"dev": true,
 			"requires": {
 				"is-number": "^7.0.0"
 			}
 		},
 		"toidentifier": {
 			"version": "1.0.1"
+		},
+		"toml": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+			"integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
 		},
 		"touch": {
 			"version": "3.1.0",
@@ -32471,14 +37068,28 @@
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 		},
+		"trim-lines": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+			"integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
+		},
+		"triple-beam": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="
+		},
+		"trough": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+			"integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
+		},
 		"ts-api-utils": {
 			"version": "1.0.3",
 			"dev": true,
 			"requires": {}
 		},
 		"ts-interface-checker": {
-			"version": "0.1.13",
-			"dev": true
+			"version": "0.1.13"
 		},
 		"ts-jest": {
 			"version": "29.1.1",
@@ -32496,7 +37107,7 @@
 		},
 		"ts-node": {
 			"version": "10.9.2",
-			"dev": true,
+			"devOptional": true,
 			"requires": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -32512,6 +37123,11 @@
 				"v8-compile-cache-lib": "^3.0.1",
 				"yn": "3.1.1"
 			}
+		},
+		"ts-pattern": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.3.0.tgz",
+			"integrity": "sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg=="
 		},
 		"tsconfig-paths": {
 			"version": "3.15.0",
@@ -32538,6 +37154,19 @@
 		},
 		"tslib": {
 			"version": "2.6.2"
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"typanion": {
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
+			"integrity": "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug=="
 		},
 		"type-check": {
 			"version": "0.4.0",
@@ -32600,9 +37229,14 @@
 				"is-typed-array": "^1.1.9"
 			}
 		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+		},
 		"typescript": {
 			"version": "5.3.3",
-			"dev": true
+			"devOptional": true
 		},
 		"uid2": {
 			"version": "0.0.4"
@@ -32622,8 +37256,127 @@
 			"dev": true
 		},
 		"undici-types": {
-			"version": "5.26.5",
-			"dev": true
+			"version": "5.26.5"
+		},
+		"unified": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+			"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+			"requires": {
+				"@types/unist": "^2.0.0",
+				"bail": "^2.0.0",
+				"extend": "^3.0.0",
+				"is-buffer": "^2.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^5.0.0"
+			},
+			"dependencies": {
+				"is-plain-obj": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+					"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+				}
+			}
+		},
+		"unist-util-generated": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
+			"integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A=="
+		},
+		"unist-util-is": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+			"integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+			"requires": {
+				"@types/unist": "^2.0.0"
+			}
+		},
+		"unist-util-position": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
+			"integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
+			"requires": {
+				"@types/unist": "^2.0.0"
+			}
+		},
+		"unist-util-position-from-estree": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-1.1.2.tgz",
+			"integrity": "sha512-poZa0eXpS+/XpoQwGwl79UUdea4ol2ZuCYguVaJS4qzIOMDzbqz8a3erUCOmubSZkaOuGamb3tX790iwOIROww==",
+			"requires": {
+				"@types/unist": "^2.0.0"
+			}
+		},
+		"unist-util-remove-position": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+			"integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"unist-util-visit": "^5.0.0"
+			},
+			"dependencies": {
+				"@types/unist": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+					"integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+				},
+				"unist-util-is": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+					"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-visit": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+					"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-is": "^6.0.0",
+						"unist-util-visit-parents": "^6.0.0"
+					}
+				},
+				"unist-util-visit-parents": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+					"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-is": "^6.0.0"
+					}
+				}
+			}
+		},
+		"unist-util-stringify-position": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+			"integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+			"requires": {
+				"@types/unist": "^2.0.0"
+			}
+		},
+		"unist-util-visit": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+			"integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+			"requires": {
+				"@types/unist": "^2.0.0",
+				"unist-util-is": "^5.0.0",
+				"unist-util-visit-parents": "^5.1.1"
+			}
+		},
+		"unist-util-visit-parents": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+			"integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+			"requires": {
+				"@types/unist": "^2.0.0",
+				"unist-util-is": "^5.0.0"
+			}
 		},
 		"universalify": {
 			"version": "2.0.1",
@@ -32675,8 +37428,7 @@
 			}
 		},
 		"util-deprecate": {
-			"version": "1.0.2",
-			"dev": true
+			"version": "1.0.2"
 		},
 		"utils-merge": {
 			"version": "1.0.1"
@@ -32684,9 +37436,32 @@
 		"uuid": {
 			"version": "8.0.0"
 		},
+		"uvu": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+			"integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+			"requires": {
+				"dequal": "^2.0.0",
+				"diff": "^5.0.0",
+				"kleur": "^4.0.3",
+				"sade": "^1.7.3"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+					"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A=="
+				},
+				"kleur": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+					"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
+				}
+			}
+		},
 		"v8-compile-cache-lib": {
 			"version": "3.0.1",
-			"dev": true
+			"devOptional": true
 		},
 		"v8-to-istanbul": {
 			"version": "9.2.0",
@@ -32718,6 +37493,61 @@
 		"vary": {
 			"version": "1.1.2"
 		},
+		"vfile": {
+			"version": "5.3.7",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+			"integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+			"requires": {
+				"@types/unist": "^2.0.0",
+				"is-buffer": "^2.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"vfile-message": "^3.0.0"
+			},
+			"dependencies": {
+				"vfile-message": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+					"integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0"
+					}
+				}
+			}
+		},
+		"vfile-location": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
+			"integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
+			"requires": {
+				"@types/unist": "^2.0.0",
+				"vfile": "^5.0.0"
+			}
+		},
+		"vfile-message": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+			"integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"dependencies": {
+				"@types/unist": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+					"integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+				},
+				"unist-util-stringify-position": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+					"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				}
+			}
+		},
 		"walker": {
 			"version": "1.0.8",
 			"dev": true,
@@ -32731,6 +37561,16 @@
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
 			}
+		},
+		"web-namespaces": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+			"integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
+		},
+		"web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
 		},
 		"webidl-conversions": {
 			"version": "3.0.1",
@@ -32748,7 +37588,6 @@
 		},
 		"which": {
 			"version": "2.0.2",
-			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -32781,6 +37620,58 @@
 				"string-width": "^4.0.0"
 			}
 		},
+		"winston": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+			"integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
+			"requires": {
+				"@colors/colors": "^1.6.0",
+				"@dabh/diagnostics": "^2.0.2",
+				"async": "^3.2.3",
+				"is-stream": "^2.0.0",
+				"logform": "^2.4.0",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"safe-stable-stringify": "^2.3.1",
+				"stack-trace": "0.0.x",
+				"triple-beam": "^1.3.0",
+				"winston-transport": "^4.5.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
+		"winston-transport": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+			"integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
+			"requires": {
+				"logform": "^2.3.2",
+				"readable-stream": "^3.6.0",
+				"triple-beam": "^1.3.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"wordwrap": {
 			"version": "1.0.0",
 			"dev": true
@@ -32798,8 +37689,6 @@
 		"worker-capacity-manager": {
 			"version": "file:packages/worker-capacity-manager",
 			"requires": {
-				"@aws-sdk/client-auto-scaling": "^3.514.0",
-				"@aws-sdk/client-sqs": "^3.514.0",
 				"@guardian/transcription-service-backend-common": "1.0.0",
 				"@guardian/transcription-service-common": "1.0.0",
 				"@types/aws-lambda": "^8.10.133",
@@ -32809,7 +37698,6 @@
 		},
 		"wrap-ansi": {
 			"version": "7.0.0",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -32818,7 +37706,6 @@
 		},
 		"wrap-ansi-cjs": {
 			"version": "npm:wrap-ansi@7.0.0",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -32826,8 +37713,7 @@
 			}
 		},
 		"wrappy": {
-			"version": "1.0.2",
-			"dev": true
+			"version": "1.0.2"
 		},
 		"write-file-atomic": {
 			"version": "4.0.2",
@@ -32847,20 +37733,22 @@
 		"xmlbuilder": {
 			"version": "11.0.1"
 		},
+		"xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+		},
 		"y18n": {
-			"version": "5.0.8",
-			"dev": true
+			"version": "5.0.8"
 		},
 		"yallist": {
 			"version": "4.0.0"
 		},
 		"yaml": {
-			"version": "2.3.4",
-			"dev": true
+			"version": "2.3.4"
 		},
 		"yargs": {
 			"version": "17.7.2",
-			"dev": true,
 			"requires": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -32872,12 +37760,11 @@
 			}
 		},
 		"yargs-parser": {
-			"version": "21.1.1",
-			"dev": true
+			"version": "21.1.1"
 		},
 		"yn": {
 			"version": "3.1.1",
-			"dev": true
+			"devOptional": true
 		},
 		"yocto-queue": {
 			"version": "0.1.0",
@@ -32885,6 +37772,11 @@
 		},
 		"zod": {
 			"version": "3.22.4"
+		},
+		"zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
 		}
 	}
 }

--- a/packages/api/src/controllers/GoogleAuth.ts
+++ b/packages/api/src/controllers/GoogleAuth.ts
@@ -2,7 +2,10 @@ import jwt from 'jsonwebtoken';
 import passport from 'passport';
 import { stringify } from 'qs';
 import { URL } from 'url';
-import { TranscriptionConfig } from '@guardian/transcription-service-backend-common';
+import {
+	logger,
+	TranscriptionConfig,
+} from '@guardian/transcription-service-backend-common';
 import { NextFunction, Request, RequestHandler, Response } from 'express';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,7 +43,7 @@ export class GoogleAuth {
 			const email = req.user?.email;
 			const { state } = req.query;
 			const returnUrl = new URL(this.rootUrl);
-			console.log(`user ${email} logged in`);
+			logger.info(`user ${email} logged in`);
 
 			// preserve query string and path from state
 			if (typeof state === 'string') {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -15,6 +15,7 @@ import {
 	isFailure,
 	getSignedDownloadUrl,
 	getObjectMetadata,
+	logger,
 } from '@guardian/transcription-service-backend-common';
 import {
 	ClientConfig,
@@ -84,19 +85,19 @@ const getApp = async () => {
 			);
 			if (!objectMetadata) {
 				res.status(404).send('missing s3 object metadata');
-				console.error('missing s3 object metadata');
+				logger.error('missing s3 object metadata');
 				return;
 			}
 			const parsedObjectMetadata =
 				inputBucketObjectMetadata.safeParse(objectMetadata);
 			if (!parsedObjectMetadata.success) {
 				res.status(404).send('missing s3 object metadata');
-				console.error('invalid s3 object metadata');
+				logger.error('invalid s3 object metadata');
 				return;
 			}
 			const uploadedBy = parsedObjectMetadata.data['user-email'];
 			if (uploadedBy != userEmail) {
-				console.error(
+				logger.error(
 					`s3 object uploaded by ${uploadedBy} does not belong to user ${userEmail}`,
 				);
 				res.status(404).send('missing s3 object metadata');
@@ -147,7 +148,7 @@ const getApp = async () => {
 			);
 			if (!exportRequest.success) {
 				const msg = `Failed to parse export request ${exportRequest.error.message}`;
-				console.error(msg);
+				logger.error(msg);
 				res.status(400).send(msg);
 				return;
 			}
@@ -158,14 +159,14 @@ const getApp = async () => {
 			);
 			if (!item) {
 				const msg = `Failed to fetch item with id ${exportRequest.data.id} from database.`;
-				console.error(msg);
+				logger.error(msg);
 				res.status(500).send(msg);
 				return;
 			}
 			const parsedItem = TranscriptionItem.safeParse(item);
 			if (!parsedItem.success) {
 				const msg = `Failed to parse item ${exportRequest.data.id} from dynamodb. Error: ${parsedItem.error.message}`;
-				console.error(msg);
+				logger.error(msg);
 				res.status(500).send(msg);
 				return;
 			}
@@ -177,7 +178,7 @@ const getApp = async () => {
 			);
 			if (!exportResult) {
 				const msg = `Failed to create google document for item with id ${parsedItem.data.id}`;
-				console.error(msg);
+				logger.error(msg);
 				res.status(500).send(msg);
 				return;
 			}
@@ -252,7 +253,7 @@ const getApp = async () => {
 
 let api;
 if (runningOnAws) {
-	console.log('Running on lambda');
+	logger.info('Running on lambda');
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let serverlessExpressHandler: any;
@@ -268,12 +269,12 @@ if (runningOnAws) {
 		return serverlessExpressHandler(event, context);
 	};
 } else {
-	console.log('running locally');
+	logger.info('running locally');
 	// Running locally. Start Express ourselves
 	const port = 9103;
 	getApp().then((app) => {
 		app.listen(port, () => {
-			console.log(`Server now listening on port: ${port}`);
+			logger.info(`Server now listening on port: ${port}`);
 		});
 	});
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -129,6 +129,7 @@ const getApp = async () => {
 				filename: body.data.fileName,
 				userEmail,
 			});
+			res.send('Message sent');
 		}),
 	]);
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -124,7 +124,11 @@ const getApp = async () => {
 				res.status(500).send(sendResult.errorMsg);
 				return;
 			}
-			res.send('Message sent');
+			logger.info('API successfully sent the message to SQS', {
+				id: s3Key,
+				filename: body.data.fileName,
+				userEmail,
+			});
 		}),
 	]);
 

--- a/packages/api/src/services/googleDrive.ts
+++ b/packages/api/src/services/googleDrive.ts
@@ -1,6 +1,9 @@
 import { OAuth2Client } from 'google-auth-library/build/src/auth/oauth2client';
 import { google, drive_v3, docs_v1 } from 'googleapis';
-import { TranscriptionConfig } from '@guardian/transcription-service-backend-common';
+import {
+	logger,
+	TranscriptionConfig,
+} from '@guardian/transcription-service-backend-common';
 import { ZTokenResponse } from '@guardian/transcription-service-common';
 
 export const getOrCreateTranscriptFolder = async (
@@ -30,7 +33,7 @@ export const getOrCreateTranscriptFolder = async (
 		});
 		return file.data.id;
 	} catch (err) {
-		console.error('Failed to create folder', err);
+		logger.error('Failed to create folder', err);
 		return null;
 	}
 };
@@ -110,7 +113,7 @@ export const createTranscriptDocument = async (
 		'Guardian Transcribe Tool',
 	);
 	if (!folderId) {
-		console.error('Failed to get or create folder');
+		logger.error('Failed to get or create folder');
 		return undefined;
 	}
 	const docId = await uploadToGoogleDocs(

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -9,7 +9,8 @@
 		"@aws-sdk/lib-dynamodb": "^3.509.0",
 		"@aws-sdk/client-cloudwatch": "^3.496.0",
 		"@aws-sdk/client-auto-scaling": "^3.514.0",
-		"axios": "^1.6.7"
+		"axios": "^1.6.7",
+		"winston": "^3.11.0"
 	},
 	"private": true,
 	"main": "src/index.ts",

--- a/packages/backend-common/src/cloudwatch.ts
+++ b/packages/backend-common/src/cloudwatch.ts
@@ -3,6 +3,7 @@ import {
 	PutMetricDataCommand,
 	PutMetricDataInput,
 } from '@aws-sdk/client-cloudwatch';
+import { logger } from './logging';
 
 export const getCloudwatchClient = (region: string) => {
 	return new CloudWatchClient({ region });
@@ -15,7 +16,7 @@ export const putMetricData = async (
 	try {
 		await client.send(new PutMetricDataCommand(metricData));
 	} catch (error) {
-		console.error('Error writing to cloudwatch', error);
+		logger.error('Error writing to cloudwatch', error);
 		throw error;
 	}
 };

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -1,6 +1,7 @@
 import { findParameter, getParameters } from './configHelpers';
 import { Parameter, SSM } from '@aws-sdk/client-ssm';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
+import { logger } from '@guardian/transcription-service-backend-common';
 export interface TranscriptionConfig {
 	auth: {
 		clientId: string;
@@ -69,7 +70,7 @@ export const getConfig = async (): Promise<TranscriptionConfig> => {
 		return param.Name;
 	});
 
-	console.log(`Parameters fetched: ${parameterNames.join(', ')}`);
+	logger.info(`Parameters fetched: ${parameterNames.join(', ')}`);
 	const taskQueueUrl = findParameter(parameters, paramPath, 'taskQueueUrl');
 	const deadLetterQueueUrl =
 		stage === 'DEV'

--- a/packages/backend-common/src/configHelpers.ts
+++ b/packages/backend-common/src/configHelpers.ts
@@ -3,6 +3,7 @@ import {
 	Parameter,
 	SSM,
 } from '@aws-sdk/client-ssm';
+import { logger } from '@guardian/transcription-service-backend-common';
 
 export const getParameters = async (
 	paramPath: string,
@@ -27,15 +28,13 @@ export const getParameters = async (
 		} while (nextToken);
 
 		if (parameters) {
-			console.log('Fetched parameters from Parameter Store');
+			logger.info('Fetched parameters from Parameter Store');
 			return parameters;
 		} else {
 			throw new Error('No parameters fetched from Parameter Store');
 		}
 	} catch (err) {
-		console.log(
-			`Error fetching parameters from Parameter Store with error: ${err}`,
-		);
+		logger.error('Error fetching parameters from Parameter Store', err);
 		throw err;
 	}
 };

--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -6,6 +6,7 @@ import {
 } from '@aws-sdk/lib-dynamodb';
 
 import { z } from 'zod';
+import { logger } from '@guardian/transcription-service-backend-common';
 
 export const getDynamoClient = (
 	region: string,
@@ -52,9 +53,9 @@ export const writeTranscriptionItem = async (
 
 	try {
 		await client.send(command);
-		console.log(`saved to db item ${item.id}`);
+		logger.info(`saved to db item ${item.id}`);
 	} catch (error) {
-		console.error('error writing to db', error);
+		logger.error('error writing to db', error);
 		throw error;
 	}
 };
@@ -74,7 +75,7 @@ export const getTranscriptionItem = async (
 		const result = await client.send(command);
 		return result.Item;
 	} catch (error) {
-		console.error(`Failed to get item ${itemId} from dynamodb`, error);
+		logger.error(`Failed to get item ${itemId} from dynamodb`, error);
 		return undefined;
 	}
 };

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -5,3 +5,4 @@ export * from './configHelpers';
 export * from './utils';
 export * from './dynamodb';
 export * from './asg';
+export * from './logging';

--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -61,7 +61,7 @@ class ServerLogger {
 		this.log({
 			level: 'warn',
 			message,
-			stack_trace: error?.stack,
+			stack_trace: error instanceof Error ? error.stack : undefined,
 		});
 	}
 

--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -1,0 +1,7 @@
+import winston from 'winston';
+
+export const logger = winston.createLogger({
+	level: 'info',
+	format: winston.format.json(),
+	transports: [new winston.transports.Console()],
+});

--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -2,6 +2,7 @@ import winston from 'winston';
 
 export interface LoggerFunctions {
 	setCommonMetadata(id: string, userEmail: string): void;
+	resetCommonMetadata(): void;
 	debug(message: string): void;
 	info(message: string, meta?: Record<string, string>): void;
 	warn(message: string, error?: Error | unknown): void;
@@ -41,6 +42,11 @@ class ServerLogger {
 			userEmail: this.userEmail,
 			...logObject.meta,
 		});
+	}
+
+	resetCommonMetadata(): void {
+		this.userEmail = undefined;
+		this.id = undefined;
 	}
 
 	setCommonMetadata(id: string, userEmail: string): void {

--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -1,6 +1,7 @@
 import winston from 'winston';
 
 export interface LoggerFunctions {
+	setCommonMetadata(id: string, userEmail: string): void;
 	debug(message: string): void;
 	info(message: string, meta?: Record<string, string>): void;
 	warn(message: string, error?: Error | unknown): void;
@@ -18,6 +19,8 @@ const { combine, timestamp, json } = winston.format;
 
 class ServerLogger {
 	underlyingLogger: winston.Logger;
+	id: string | undefined;
+	userEmail: string | undefined;
 
 	constructor() {
 		const winstonConfig: winston.LoggerOptions = {
@@ -31,11 +34,18 @@ class ServerLogger {
 
 	private log(logObject: LogEvent): void {
 		this.underlyingLogger.log({
-			message: logObject.message, //.replace(/(\r\n|\n|\r)/gm, ' '),
+			message: logObject.message,
 			level: logObject.level,
 			stack_trace: logObject.stack_trace,
+			id: this.id,
+			userEmail: this.userEmail,
 			...logObject.meta,
 		});
+	}
+
+	setCommonMetadata(id: string, userEmail: string): void {
+		this.userEmail = userEmail;
+		this.id = id;
 	}
 
 	debug(message: string): void {

--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -1,11 +1,5 @@
 import winston from 'winston';
 
-// export const logger = winston.createLogger({
-// 	level: 'info',
-// 	format: winston.format.json(),
-// 	transports: [new winston.transports.Console()],
-// });
-
 export interface LoggerFunctions {
 	debug(message: string): void;
 	info(message: string, meta?: Record<string, string>): void;

--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -1,7 +1,77 @@
 import winston from 'winston';
 
-export const logger = winston.createLogger({
-	level: 'info',
-	format: winston.format.json(),
-	transports: [new winston.transports.Console()],
-});
+// export const logger = winston.createLogger({
+// 	level: 'info',
+// 	format: winston.format.json(),
+// 	transports: [new winston.transports.Console()],
+// });
+
+export interface LoggerFunctions {
+	debug(message: string): void;
+	info(message: string, meta?: Record<string, string>): void;
+	warn(message: string, error?: Error | unknown): void;
+	error(message: string, error?: Error | unknown): void;
+}
+
+interface LogEvent {
+	level: 'debug' | 'info' | 'warn' | 'error';
+	message: string;
+	stack_trace?: string;
+	meta?: Record<string, string>;
+}
+
+class ServerLogger {
+	underlyingLogger: winston.Logger;
+
+	constructor() {
+		const winstonConfig: winston.LoggerOptions = {
+			level: 'info',
+			format: winston.format.json(),
+			transports: [new winston.transports.Console()],
+		};
+
+		this.underlyingLogger = winston.createLogger(winstonConfig);
+	}
+
+	private log(logObject: LogEvent): void {
+		this.underlyingLogger.log({
+			message: logObject.message.replace(/(\r\n|\n|\r)/gm, ''),
+			level: logObject.level,
+			stack_trace: logObject.stack_trace,
+			meta: logObject.meta,
+		});
+	}
+
+	debug(message: string): void {
+		this.log({
+			level: 'debug',
+			message,
+		});
+	}
+
+	info(message: string, meta?: Record<string, string>): void {
+		this.log({
+			level: 'info',
+			message,
+			meta: meta,
+		});
+	}
+
+	warn(message: string, error?: Error): void {
+		this.log({
+			level: 'warn',
+			message,
+			stack_trace: error?.stack,
+		});
+	}
+
+	error(message: string, error?: Error | unknown): void {
+		this.log({
+			level: 'error',
+			message,
+			stack_trace: error instanceof Error ? error.stack : undefined,
+		});
+	}
+}
+
+export const logger: LoggerFunctions = new ServerLogger();

--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -35,10 +35,10 @@ class ServerLogger {
 
 	private log(logObject: LogEvent): void {
 		this.underlyingLogger.log({
-			message: logObject.message.replace(/(\r\n|\n|\r)/gm, ''),
+			message: logObject.message.replace(/(\r\n|\n|\r)/gm, ' '),
 			level: logObject.level,
 			stack_trace: logObject.stack_trace,
-			meta: logObject.meta,
+			...logObject.meta,
 		});
 	}
 

--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -31,7 +31,7 @@ class ServerLogger {
 
 	private log(logObject: LogEvent): void {
 		this.underlyingLogger.log({
-			message: logObject.message.replace(/(\r\n|\n|\r)/gm, ' '),
+			message: logObject.message, //.replace(/(\r\n|\n|\r)/gm, ' '),
 			level: logObject.level,
 			stack_trace: logObject.stack_trace,
 			...logObject.meta,

--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -14,13 +14,15 @@ interface LogEvent {
 	meta?: Record<string, string>;
 }
 
+const { combine, timestamp, json } = winston.format;
+
 class ServerLogger {
 	underlyingLogger: winston.Logger;
 
 	constructor() {
 		const winstonConfig: winston.LoggerOptions = {
 			level: 'info',
-			format: winston.format.json(),
+			format: combine(timestamp({ alias: '@timestamp' }), json()),
 			transports: [new winston.transports.Console()],
 		};
 

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import { Readable } from 'stream';
 import { z } from 'zod';
 import axios from 'axios';
+import { logger } from '@guardian/transcription-service-backend-common';
 
 const ReadableBody = z.instanceof(Readable);
 
@@ -77,7 +78,7 @@ export const getFile = async (
 		await downloadS3Data(body, destinationPath, key);
 		return destinationPath;
 	} catch (e) {
-		console.error(e);
+		logger.error(`failed to get S3 file ${key} in bucket ${bucket}`, e);
 		throw e;
 	}
 };
@@ -106,15 +107,15 @@ const downloadS3Data = async (
 	await new Promise<void>((resolve, reject) => {
 		stream
 			.on('finish', () => {
-				console.log(` pipe done `);
+				logger.debug('stream pipe done');
 				resolve();
 			})
 			.on('error', (error) => {
-				console.log(`Failed to write the S3 object ${key} into file`);
+				logger.error(`Failed to write the S3 object ${key} into file`);
 				reject(error);
 			});
 	});
-	console.log('successfully retrieved file from S3 into ', destinationPath);
+	logger.info(`successfully retrieved file from S3 into ${destinationPath}`);
 	return destinationPath;
 };
 

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -12,6 +12,7 @@ import {
 	TranscriptionJob,
 } from '@guardian/transcription-service-common';
 import { getSignedUploadUrl } from '@guardian/transcription-service-backend-common';
+import { logger } from '@guardian/transcription-service-backend-common';
 
 enum SQSStatus {
 	Success,
@@ -102,7 +103,7 @@ const sendMessage = async (
 				MessageGroupId: 'api-transcribe-request',
 			}),
 		);
-		console.log(`Message sent. Message id: ${result.MessageId}`);
+		logger.info(`Message sent. Message id: ${result.MessageId}`);
 		if (result.MessageId) {
 			return {
 				status: SQSStatus.Success,
@@ -115,7 +116,7 @@ const sendMessage = async (
 		};
 	} catch (e) {
 		const msg = `Failed to send message ${messageBody}`;
-		console.error(msg, e);
+		logger.error(msg, e);
 		return {
 			status: SQSStatus.Failure,
 			error: e,
@@ -138,12 +139,12 @@ export const changeMessageVisibility = async (
 
 	try {
 		await client.send(command);
-		console.log(
+		logger.info(
 			`Successfully updated the VisibilityTimeout of the message to ${timeoutOverride}`,
 		);
 	} catch (error) {
 		const errorMsg = `Failed to update VisibilityTimeout to ${timeoutOverride} for message`;
-		console.error(errorMsg, error);
+		logger.error(errorMsg, error);
 		throw error;
 	}
 };
@@ -178,7 +179,7 @@ export const getNextMessage = async (
 		};
 	} catch (error) {
 		const errorMsg = 'Failed to receive messages';
-		console.error(errorMsg, error);
+		logger.error(errorMsg, error);
 		return {
 			status: SQSStatus.Failure,
 			error,
@@ -204,7 +205,7 @@ export const deleteMessage = async (
 		};
 	} catch (error) {
 		const errorMsg = `Failed to delete message ${receiptHandle}`;
-		console.error(errorMsg, error);
+		logger.error(errorMsg, error);
 		return {
 			status: SQSStatus.Failure,
 			error,
@@ -244,7 +245,7 @@ export const parseTranscriptJobMessage = (
 	if (job.success) {
 		return job.data;
 	}
-	console.error(
+	logger.error(
 		`Failed to parse message ${message.MessageId}, contents: ${message.Body}`,
 	);
 	return undefined;

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -25,7 +25,7 @@ const uploadFileAndTranscribe = async (file: File, token: string) => {
 	}
 
 	const uploadStatus = await uploadToS3(body.data.presignedS3Url, blob);
-	if (!uploadStatus) {
+	if (!uploadStatus.isSuccess) {
 		console.error('Failed to upload to s3');
 		return false;
 	}

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,4 +1,3 @@
-import { logger } from '@guardian/transcription-service-backend-common';
 interface UploadSuccess {
 	isSuccess: true;
 }
@@ -38,7 +37,7 @@ export const uploadToS3 = async (
 		};
 	} catch (error) {
 		const errorMsg = `S3 upload failed: ${error}`;
-		logger.error(errorMsg, error);
+		console.error(errorMsg, error);
 		return {
 			isSuccess: false,
 			errorMsg,

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,3 +1,4 @@
+import { logger } from '@guardian/transcription-service-backend-common';
 interface UploadSuccess {
 	isSuccess: true;
 }
@@ -37,7 +38,7 @@ export const uploadToS3 = async (
 		};
 	} catch (error) {
 		const errorMsg = `S3 upload failed: ${error}`;
-		console.error(errorMsg, error);
+		logger.error(errorMsg, error);
 		return {
 			isSuccess: false,
 			errorMsg,

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -2,6 +2,7 @@ import { Handler } from 'aws-lambda';
 import { sendEmail, getSESClient } from './ses';
 import { IncomingSQSEvent } from './sqs-event-types';
 import {
+	logger,
 	TranscriptionConfig,
 	getConfig,
 	getFileFromS3,
@@ -66,7 +67,7 @@ export const getTranscriptsText = async (
 
 		return result;
 	} catch (error) {
-		console.log(`failed to get transcription texts from S3`, error);
+		logger.error(`failed to get transcription texts from S3`, error);
 		throw error;
 	}
 };
@@ -83,7 +84,7 @@ const processMessage = async (event: unknown) => {
 
 	const parsedEvent = IncomingSQSEvent.safeParse(event);
 	if (!parsedEvent.success) {
-		console.error('Failed to parse SQS message', parsedEvent.error.message);
+		logger.error(`Failed to parse SQS message ${parsedEvent.error.message}`);
 		throw new Error('Failed to parse SQS message');
 	}
 
@@ -125,7 +126,7 @@ const processMessage = async (event: unknown) => {
 				),
 			);
 		} catch (error) {
-			console.error(
+			logger.error(
 				'Failed to process sqs message - transcription data may be missing from dynamo or email failed to send',
 				error,
 			);

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -125,6 +125,12 @@ const processMessage = async (event: unknown) => {
 					config.app.rootUrl,
 				),
 			);
+
+			logger.info('Output handler successfully sent email notification', {
+				id: transcriptionOutput.id,
+				filename: transcriptionOutput.originalFilename,
+				userEmail: transcriptionOutput.userEmail,
+			});
 		} catch (error) {
 			logger.error(
 				'Failed to process sqs message - transcription data may be missing from dynamo or email failed to send',

--- a/packages/output-handler/src/ses.ts
+++ b/packages/output-handler/src/ses.ts
@@ -1,4 +1,6 @@
 import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses';
+import { logger } from '@guardian/transcription-service-backend-common';
+
 export const getSESClient = (region: string) => {
 	return new SESClient({ region });
 };
@@ -10,7 +12,7 @@ export const sendEmail = async (
 	originalFilename: string,
 	body: string,
 ) => {
-	console.log(`Sending email from ${fromAddress} to ${recipientEmail}`);
+	logger.info(`Sending email from ${fromAddress} to ${recipientEmail}`);
 	const sendCommand = new SendEmailCommand({
 		Source: fromAddress,
 		Destination: {
@@ -32,7 +34,7 @@ export const sendEmail = async (
 	try {
 		await client.send(sendCommand);
 	} catch (error) {
-		console.error('Error sending email:', error);
+		logger.error('Error sending email:', error);
 		throw error;
 	}
 };

--- a/packages/worker-capacity-manager/src/asg.ts
+++ b/packages/worker-capacity-manager/src/asg.ts
@@ -2,6 +2,7 @@ import {
 	AutoScalingClient,
 	SetDesiredCapacityCommand,
 } from '@aws-sdk/client-auto-scaling';
+import { logger } from '@guardian/transcription-service-backend-common';
 
 export const setDesiredCapacity = async (
 	asgClient: AutoScalingClient,
@@ -15,7 +16,7 @@ export const setDesiredCapacity = async (
 		});
 		await asgClient.send(command);
 	} catch (error) {
-		console.error("Couldn't set desired capacity", error);
+		logger.error("Couldn't set desired capacity", error);
 		throw error;
 	}
 };

--- a/packages/worker-capacity-manager/src/index.ts
+++ b/packages/worker-capacity-manager/src/index.ts
@@ -4,6 +4,7 @@ import {
 	getASGClient,
 	getConfig,
 	getSQSClient,
+	logger,
 } from '@guardian/transcription-service-backend-common';
 import { setDesiredCapacity } from './asg';
 import { getSQSQueueLengthIncludingInvisible } from './sqs';
@@ -22,7 +23,7 @@ const updateASGCapacity = async () => {
 		config.app.taskQueueUrl,
 	);
 
-	console.log(
+	logger.info(
 		`setting asg desired capacity to total messages in queue: ${totalMessagesInQueue}`,
 	);
 	await setDesiredCapacity(asgClient, asgGroupName, totalMessagesInQueue);

--- a/packages/worker-capacity-manager/src/sqs.ts
+++ b/packages/worker-capacity-manager/src/sqs.ts
@@ -1,4 +1,5 @@
 import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
+import { logger } from '@guardian/transcription-service-backend-common';
 
 export const getSQSQueueLengthIncludingInvisible = async (
 	sqsClient: SQSClient,
@@ -21,7 +22,7 @@ export const getSQSQueueLengthIncludingInvisible = async (
 			Number(attributes.ApproximateNumberOfMessagesNotVisible)
 		);
 	} catch (error) {
-		console.error("Couldn't get queue length", error);
+		logger.error("Couldn't get queue length", error);
 		throw error;
 	}
 };

--- a/packages/worker/src/asg.ts
+++ b/packages/worker/src/asg.ts
@@ -3,7 +3,7 @@ import {
 	readFile,
 	getASGClient,
 } from '@guardian/transcription-service-backend-common';
-import { logger } from '@guardian/transcription-service-backend-common/src/logging';
+import { logger } from '@guardian/transcription-service-backend-common';
 
 export const updateScaleInProtection = async (
 	region: string,
@@ -13,7 +13,7 @@ export const updateScaleInProtection = async (
 	try {
 		if (stage !== 'DEV') {
 			const instanceId = readFile('/var/lib/cloud/data/instance-id');
-			logger.info(`instanceId: ${instanceId}`);
+			logger.info(`instanceId retrieved from worker instance: ${instanceId}`);
 			const autoScalingClient = getASGClient(region);
 			const input = {
 				InstanceIds: [instanceId.trim()],

--- a/packages/worker/src/asg.ts
+++ b/packages/worker/src/asg.ts
@@ -3,6 +3,7 @@ import {
 	readFile,
 	getASGClient,
 } from '@guardian/transcription-service-backend-common';
+import { logger } from '@guardian/transcription-service-backend-common/src/logging';
 
 export const updateScaleInProtection = async (
 	region: string,
@@ -12,7 +13,7 @@ export const updateScaleInProtection = async (
 	try {
 		if (stage !== 'DEV') {
 			const instanceId = readFile('/var/lib/cloud/data/instance-id');
-			console.log(`instanceId: ${instanceId}`);
+			logger.info(`instanceId: ${instanceId}`);
 			const autoScalingClient = getASGClient(region);
 			const input = {
 				InstanceIds: [instanceId.trim()],
@@ -21,12 +22,12 @@ export const updateScaleInProtection = async (
 			};
 			const command = new SetInstanceProtectionCommand(input);
 			await autoScalingClient.send(command);
-			console.log(
+			logger.info(
 				`Updated scale-in protection to value ${value} for instance ${instanceId}`,
 			);
 		}
 	} catch (error) {
-		console.error(`Could not set scale-in protection`, error);
+		logger.error(`Could not set scale-in protection`, error);
 		throw error;
 	}
 };

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -122,12 +122,9 @@ const pollTranscriptionQueue = async (
 			return;
 		}
 
-		const { outputBucketUrls, inputSignedUrl, ...loggableJob } = job;
+		const { outputBucketUrls, inputSignedUrl } = job;
 
-		logger.info(
-			`Fetched transcription job with id ${taskMessage.MessageId}`,
-			loggableJob,
-		);
+		logger.info(`Fetched transcription job with id ${taskMessage.MessageId}`);
 
 		const destinationDirectory =
 			config.app.stage === 'DEV' ? `${__dirname}/sample` : '/tmp';
@@ -213,7 +210,7 @@ const pollTranscriptionQueue = async (
 			{
 				filename: transcriptionOutput.originalFilename,
 				useEmail: transcriptionOutput.userEmail,
-				fileDuration: ffmpegResult.duration,
+				fileDuration: ffmpegResult.duration?.toString() || '',
 			},
 		);
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -14,7 +14,7 @@ import {
 	OutputBucketKeys,
 	type TranscriptionOutput,
 } from '@guardian/transcription-service-common';
-import { getSNSClient, publishTranscriptionOutput } from './sns';
+import { getSNSClient, publishMessage } from './sns';
 import {
 	getTranscriptionText,
 	convertToWav,
@@ -202,7 +202,7 @@ const pollTranscriptionQueue = async (
 			outputBucketKeys,
 		};
 
-		await publishTranscriptionOutput(
+		await publishMessage(
 			snsClient,
 			config.app.destinationTopicArns.transcriptionService,
 			transcriptionOutput,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -206,7 +206,7 @@ const pollTranscriptionQueue = async (
 		);
 
 		logger.info(
-			'Successfully transcribed the file and sent notification to sns',
+			'Worker successfully transcribed the file and sent notification to sns',
 			{
 				id: transcriptionOutput.id,
 				filename: transcriptionOutput.originalFilename,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -122,6 +122,9 @@ const pollTranscriptionQueue = async (
 			return;
 		}
 
+		// from this point all worker logs will have id & userEmail in their fields
+		logger.setCommonMetadata(job.id, job.userEmail);
+
 		const { outputBucketUrls, inputSignedUrl } = job;
 
 		logger.info(`Fetched transcription job with id ${taskMessage.MessageId}`);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -9,6 +9,7 @@ import {
 	getObjectWithPresignedUrl,
 	TranscriptionConfig,
 	moveMessageToDeadLetterQueue,
+	logger,
 } from '@guardian/transcription-service-backend-common';
 import {
 	OutputBucketKeys,
@@ -31,7 +32,6 @@ import {
 import { SQSClient } from '@aws-sdk/client-sqs';
 import { SNSClient } from '@aws-sdk/client-sns';
 import { setTimeout } from 'timers/promises';
-import { logger } from '@guardian/transcription-service-backend-common/src/logging';
 
 const POLLING_INTERVAL_SECONDS = 30;
 
@@ -208,8 +208,9 @@ const pollTranscriptionQueue = async (
 		logger.info(
 			'Successfully transcribed the file and sent notification to sns',
 			{
+				id: transcriptionOutput.id,
 				filename: transcriptionOutput.originalFilename,
-				useEmail: transcriptionOutput.userEmail,
+				userEmail: transcriptionOutput.userEmail,
 				fileDuration: ffmpegResult.duration?.toString() || '',
 			},
 		);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -14,7 +14,7 @@ import {
 	OutputBucketKeys,
 	type TranscriptionOutput,
 } from '@guardian/transcription-service-common';
-import { getSNSClient, publishMessage } from './sns';
+import { getSNSClient, publishTranscriptionOutput } from './sns';
 import {
 	getTranscriptionText,
 	convertToWav,
@@ -202,10 +202,19 @@ const pollTranscriptionQueue = async (
 			outputBucketKeys,
 		};
 
-		await publishMessage(
+		await publishTranscriptionOutput(
 			snsClient,
 			config.app.destinationTopicArns.transcriptionService,
 			transcriptionOutput,
+		);
+
+		logger.info(
+			'Successfully transcribed the file and sent notification to sns',
+			{
+				filename: transcriptionOutput.originalFilename,
+				useEmail: transcriptionOutput.userEmail,
+				fileDuration: ffmpegResult.duration,
+			},
 		);
 
 		logger.info(`Deleting message ${taskMessage.MessageId}`);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -101,7 +101,7 @@ const pollTranscriptionQueue = async (
 
 	const taskMessage = message.message;
 	if (!taskMessage.Body) {
-		console.log('message missing body');
+		logger.error('message missing body');
 		await updateScaleInProtection(region, stage, false);
 		return;
 	}
@@ -148,7 +148,7 @@ const pollTranscriptionQueue = async (
 			// when ffmpeg fails to transcribe, move message to the dead letter
 			// queue
 			if (config.app.stage != 'DEV' && config.app.deadLetterQueueUrl) {
-				console.log(
+				logger.error(
 					`'ffmpeg failed, moving message with message id ${taskMessage.MessageId} to dead letter queue`,
 				);
 				await moveMessageToDeadLetterQueue(
@@ -158,11 +158,11 @@ const pollTranscriptionQueue = async (
 					taskMessage.Body,
 					receiptHandle,
 				);
-				console.log(
+				logger.info(
 					`moved message with message id ${taskMessage.MessageId} to dead letter queue.`,
 				);
 			} else {
-				console.log('skip moving message to dead letter queue in DEV');
+				logger.info('skip moving message to dead letter queue in DEV');
 			}
 			return;
 		}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -232,6 +232,7 @@ const pollTranscriptionQueue = async (
 			0,
 		);
 	} finally {
+		logger.resetCommonMetadata();
 		await updateScaleInProtection(region, stage, false);
 	}
 };

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -31,6 +31,7 @@ import {
 import { SQSClient } from '@aws-sdk/client-sqs';
 import { SNSClient } from '@aws-sdk/client-sns';
 import { setTimeout } from 'timers/promises';
+import { logger } from '@guardian/transcription-service-backend-common/src/logging';
 
 const POLLING_INTERVAL_SECONDS = 30;
 
@@ -93,7 +94,7 @@ const pollTranscriptionQueue = async (
 	}
 
 	if (!message.message) {
-		console.log('No messages available');
+		logger.info('No messages available');
 		await updateScaleInProtection(region, stage, false);
 		return;
 	}
@@ -123,7 +124,7 @@ const pollTranscriptionQueue = async (
 
 		const { outputBucketUrls, ...loggableJob } = job;
 
-		console.log(
+		logger.info(
 			`Fetched transcription job with id ${taskMessage.MessageId}`,
 			loggableJob,
 		);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -122,7 +122,7 @@ const pollTranscriptionQueue = async (
 			return;
 		}
 
-		const { outputBucketUrls, ...loggableJob } = job;
+		const { outputBucketUrls, inputSignedUrl, ...loggableJob } = job;
 
 		logger.info(
 			`Fetched transcription job with id ${taskMessage.MessageId}`,
@@ -133,7 +133,7 @@ const pollTranscriptionQueue = async (
 			config.app.stage === 'DEV' ? `${__dirname}/sample` : '/tmp';
 
 		const fileToTranscribe = await getObjectWithPresignedUrl(
-			job.inputSignedUrl,
+			inputSignedUrl,
 			job.id,
 			destinationDirectory,
 		);

--- a/packages/worker/src/sns.ts
+++ b/packages/worker/src/sns.ts
@@ -25,7 +25,9 @@ const publishMessage = async (
 				Message: message,
 			}),
 		);
-		logger.info('message sent');
+		logger.info(
+			`message sent with id ${resp.MessageId}, status: ${resp.$metadata.httpStatusCode}`,
+		);
 		return resp.MessageId;
 	} catch (e) {
 		logger.error('Error publishing message', e);

--- a/packages/worker/src/sns.ts
+++ b/packages/worker/src/sns.ts
@@ -1,4 +1,5 @@
 import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
+import { logger } from '@guardian/transcription-service-backend-common/src/logging';
 import { TranscriptionOutput } from '@guardian/transcription-service-common';
 
 export const getSNSClient = (region: string, localstackEndpoint?: string) => {
@@ -21,10 +22,10 @@ const publishMessage = async (
 		const resp = await client.send(
 			new PublishCommand({ TopicArn: topicArn, Message: message }),
 		);
-		console.log('message sent', resp);
+		logger.info('message sent', resp);
 		return resp.MessageId;
 	} catch (e) {
-		console.error('Error publishing message', e);
+		logger.error('Error publishing message', e);
 		throw e;
 	}
 };

--- a/packages/worker/src/sns.ts
+++ b/packages/worker/src/sns.ts
@@ -13,19 +13,19 @@ export const getSNSClient = (region: string, localstackEndpoint?: string) => {
 	return new SNSClient(clientConfig);
 };
 
-export const publishMessage = async (
+const publishMessage = async (
 	client: SNSClient,
 	topicArn: string,
-	output: TranscriptionOutput,
+	message: string,
 ): Promise<string | undefined> => {
 	try {
 		const resp = await client.send(
 			new PublishCommand({
 				TopicArn: topicArn,
-				Message: JSON.stringify(output),
+				Message: message,
 			}),
 		);
-		logger.info('message sent', output);
+		logger.info('message sent', resp);
 		return resp.MessageId;
 	} catch (e) {
 		logger.error('Error publishing message', e);
@@ -33,10 +33,10 @@ export const publishMessage = async (
 	}
 };
 
-// export const publishTranscriptionOutput = async (
-// 	client: SNSClient,
-// 	topicArn: string,
-// 	output: TranscriptionOutput,
-// ) => {
-// 	await publishMessage(client, topicArn, JSON.stringify(output));
-// };
+export const publishTranscriptionOutput = async (
+	client: SNSClient,
+	topicArn: string,
+	output: TranscriptionOutput,
+) => {
+	await publishMessage(client, topicArn, JSON.stringify(output));
+};

--- a/packages/worker/src/sns.ts
+++ b/packages/worker/src/sns.ts
@@ -13,16 +13,19 @@ export const getSNSClient = (region: string, localstackEndpoint?: string) => {
 	return new SNSClient(clientConfig);
 };
 
-const publishMessage = async (
+export const publishMessage = async (
 	client: SNSClient,
 	topicArn: string,
-	message: string,
+	output: TranscriptionOutput,
 ): Promise<string | undefined> => {
 	try {
 		const resp = await client.send(
-			new PublishCommand({ TopicArn: topicArn, Message: message }),
+			new PublishCommand({
+				TopicArn: topicArn,
+				Message: JSON.stringify(output),
+			}),
 		);
-		logger.info('message sent', resp);
+		logger.info('message sent', output);
 		return resp.MessageId;
 	} catch (e) {
 		logger.error('Error publishing message', e);
@@ -30,10 +33,10 @@ const publishMessage = async (
 	}
 };
 
-export const publishTranscriptionOutput = async (
-	client: SNSClient,
-	topicArn: string,
-	output: TranscriptionOutput,
-) => {
-	await publishMessage(client, topicArn, JSON.stringify(output));
-};
+// export const publishTranscriptionOutput = async (
+// 	client: SNSClient,
+// 	topicArn: string,
+// 	output: TranscriptionOutput,
+// ) => {
+// 	await publishMessage(client, topicArn, JSON.stringify(output));
+// };

--- a/packages/worker/src/sns.ts
+++ b/packages/worker/src/sns.ts
@@ -25,7 +25,7 @@ const publishMessage = async (
 				Message: message,
 			}),
 		);
-		logger.info('message sent', resp);
+		logger.info('message sent');
 		return resp.MessageId;
 	} catch (e) {
 		logger.error('Error publishing message', e);

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -50,8 +50,8 @@ const runSpawnCommand = (
 				stderr: stderr.join(''),
 				code: code || undefined,
 			};
-			logger.info(result.stdout);
-			logger.info(result.stderr);
+			logger.info(result.stdout.replace('\n', ' '));
+			logger.info(result.stderr.replace('\n', ' '));
 			if (code === 0) {
 				resolve(result);
 			} else {

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -33,12 +33,10 @@ const runSpawnCommand = (
 		const stdout: string[] = [];
 		const stderr: string[] = [];
 		cp.stdout.on('data', (data) => {
-			logger.info(data.toString());
 			stdout.push(data.toString());
 		});
 
 		cp.stderr.on('data', (data) => {
-			logger.info(data.toString());
 			stderr.push(data.toString());
 		});
 
@@ -52,6 +50,8 @@ const runSpawnCommand = (
 				stderr: stderr.join(''),
 				code: code || undefined,
 			};
+			logger.info(result.stdout);
+			logger.info(result.stderr);
 			if (code === 0) {
 				resolve(result);
 			} else {
@@ -100,8 +100,8 @@ export const convertToWav = async (
 	const filePath = `${CONTAINER_FOLDER}/${fileName}`;
 	const wavPath = `${CONTAINER_FOLDER}/${fileName}-converted.wav`;
 	logger.info(`containerId: ${containerId}`);
-	logger.info('file path: ', filePath);
-	logger.info('wav file path: ', wavPath);
+	logger.info(`file path: ${filePath}`);
+	logger.info(`wav file path: ${wavPath}`);
 
 	try {
 		const res = await runSpawnCommand('docker', [

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -4,36 +4,26 @@ import {
 	uploadToS3,
 	type OutputBucketUrls,
 } from '@guardian/transcription-service-common';
-import path from 'path';
 
 export const uploadAllTranscriptsToS3 = async (
 	destinationBucketUrls: OutputBucketUrls,
 	files: Transcripts,
 ) => {
 	const getBlob = (file: string) => new Blob([file as BlobPart]);
-	const getFileName = (file: string) => path.basename(file);
 	const blobs: [string, string, Blob][] = [
-		[getFileName(files.srt), destinationBucketUrls.srt.url, getBlob(files.srt)],
-		[
-			getFileName(files.json),
-			destinationBucketUrls.json.url,
-			getBlob(files.json),
-		],
-		[
-			getFileName(files.text),
-			destinationBucketUrls.text.url,
-			getBlob(files.text),
-		],
+		['srt', destinationBucketUrls.srt.url, getBlob(files.srt)],
+		['json', destinationBucketUrls.json.url, getBlob(files.json)],
+		['text', destinationBucketUrls.text.url, getBlob(files.text)],
 	];
 
 	for (const blobDetail of blobs) {
-		const [fileName, url, blob] = blobDetail;
+		const [fileFormat, url, blob] = blobDetail;
 		const response = await uploadToS3(url, blob);
 		if (!response.isSuccess) {
 			throw new Error(
-				`Could not upload file: ${fileName} to S3! ${response.errorMsg}`,
+				`Could not upload file format: ${fileFormat} to S3! ${response.errorMsg}`,
 			);
 		}
-		logger.info(`Successfully uploaded ${fileName} to S3`);
+		logger.info(`Successfully uploaded file format ${fileFormat} to S3`);
 	}
 };

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -1,3 +1,4 @@
+import { logger } from '@guardian/transcription-service-backend-common/src/logging';
 import { Transcripts } from './transcribe';
 import {
 	uploadToS3,
@@ -33,6 +34,6 @@ export const uploadAllTranscriptsToS3 = async (
 				`Could not upload file: ${fileName} to S3! ${response.errorMsg}`,
 			);
 		}
-		console.log(`Successfully uploaded ${fileName} to S3`);
+		logger.info(`Successfully uploaded ${fileName} to S3`);
 	}
 };

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -1,4 +1,4 @@
-import { logger } from '@guardian/transcription-service-backend-common/src/logging';
+import { logger } from '@guardian/transcription-service-backend-common';
 import { Transcripts } from './transcribe';
 import {
 	uploadToS3,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds `winston` logging library (only for serverside logging) in order to send structured data for logging and also improve the logging behaviour. 
The following improvements were done: 
- adds userEmail, fileName, message id to the API logging where the message is successfully pushed to SQS
- adds userEmail, fileName, file duration and message id to the WORKER logging where message is successfully sent to SNS
- adds userEmail, fileName, message id to the output handler logging where email is successfully sent
- adds message id and user email to all worker loggings (after sqs message is parsed up to when the processing is finished for that message)
- adds @timestamp to all messages - if this field doesn't exist in the log message, the DevEx tool that ships logs to ELK automatically generates timestamp but it seems that the  sametimestamp is generated for a batch of messages and place the messages out of order in kibana
- adds `level` to all logs - this make troubleshooting easier by filtering for error logs
- We had this issue where the logs were being seperated by new lines (`\n`) and it was hard to make sense of them in kibana. Using winston json format, fixed this issue. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Tested in CODE and locally