### PR TITLE
Add alarms for failures and cost warnings

### DIFF
--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -30,6 +30,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       "GuSubnetListParameter",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuStringParameter",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -76,6 +77,10 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "InvestigationsAlarmTopicArn": {
+      "Default": "/TEST/investigations/alarmTopicArn",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "LoggingStreamName": {
@@ -305,6 +310,20 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
                 ],
               },
             },
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "transcriptionservicetaskdeadletterqueue8A13A1F1",
+                  "Arn",
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -359,7 +378,10 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "s3:PutObject",
+              "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+              ],
               "Effect": "Allow",
               "Resource": {
                 "Fn::Join": [
@@ -709,6 +731,11 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
         },
         "NewInstancesProtectedFromScaleIn": true,
         "Tags": [
+          {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "transcription-service-worker",
+          },
           {
             "Key": "gu:cdk:version",
             "PropagateAtLaunch": true,
@@ -2092,6 +2119,7 @@ service transcription-service-worker start",
     "transcriptionservicetaskdeadletterqueue8A13A1F1": {
       "DeletionPolicy": "Delete",
       "Properties": {
+        "ContentBasedDeduplication": true,
         "FifoQueue": true,
         "QueueName": "transcription-service-task-dead-letter-queue-TEST.fifo",
         "Tags": [

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -654,7 +654,7 @@ export class TranscriptionService extends GuStack {
 					threshold: 1,
 					comparisonOperator:
 						ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-					evaluationPeriods: 5 * 12, // 5 hours as metric has period of 5 minutes
+					evaluationPeriods: 2, // testing 5 * 12, // 5 hours as metric has period of 5 minutes
 					actionsEnabled: true,
 					alarmDescription:
 						'There has been more than 1 worker instance running for 5 hours - this will have significant cost implications. Please check that all running workers are doing something useful.',

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -642,7 +642,8 @@ export class TranscriptionService extends GuStack {
 					alarmDescription: 'A transcription service failure has occurred',
 					treatMissingData: TreatMissingData.IGNORE,
 				}),
-				// alarm when instances have been running in the worker asg for more than 5 hours
+				// alarm when at least one instance has been running in the worker asg during every 5 minute period for
+				// more than 5 hours
 				new Alarm(this, 'WorkerInstanceAlarm', {
 					alarmName: `transcription-service-worker-instances-${props.stage}`,
 					// this doesn't actually create the metric - just a reference to it

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -228,7 +228,6 @@ const pollTranscriptionQueue = async (
 	} catch (error) {
 		const msg = 'Worker failed to complete';
 		logger.error(msg, error);
-		await metrics.putMetric(FailureMetric);
 		// Terminate the message visibility timeout
 		await changeMessageVisibility(
 			sqsClient,


### PR DESCRIPTION
## What does this change?
This adds 3 cloudwatch alarms to the PROD transcription stack:
 - dead letter alarm - if a message goes into the dead letter queue it suggests a user upload has failed to process, so we alarm on that condition
 - transcription failure alarm - we already have a metric added in https://github.com/guardian/transcription-service/pull/32 to track failures. This adds an alarm to that metric
 - Long running instances alarm - this will alarm if we have more than 0 instances running for a period of 5 hours (this might need some tweaking to get it right)

Depends on https://github.com/guardian/investigations-platform/pull/480

## How to test
I've tested these alarms by:
 - manually publishing a message to the dead letter queue
 - killing docker part way through a transcription
 - running some transcriptions for a long time to check the long runnning instances alarm works

