### PR TITLE
Use the transcription id to provide a uniqe MessageGroupId

### DIFF
--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -100,7 +100,7 @@ const sendMessage = async (
 			new SendMessageCommand({
 				QueueUrl: queueUrl,
 				MessageBody: messageBody,
-				MessageGroupId: 'api-transcribe-request',
+				MessageGroupId: id,
 			}),
 		);
 		console.log(`Message sent. Message id: ${result.MessageId}`);

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -86,13 +86,14 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		originalFilename,
 		outputBucketUrls: signedUrls,
 	};
-	return await sendMessage(client, queueUrl, JSON.stringify(job));
+	return await sendMessage(client, queueUrl, JSON.stringify(job), id);
 };
 
 const sendMessage = async (
 	client: SQSClient,
 	queueUrl: string,
 	messageBody: string,
+	id: string,
 ): Promise<SendResult> => {
 	try {
 		const result = await client.send(
@@ -219,11 +220,17 @@ export const moveMessageToDeadLetterQueue = async (
 	deadLetterQueueUrl: string,
 	messageBody: string,
 	receiptHandle: string,
+	id: string,
 ) => {
 	// SQS doesn't seem to offer an atomic way to move message from one queue to
 	// another. There is a chance that the write to the dead letter queue
 	// succeeds but the delete from the task queue fails
-	const sendResult = await sendMessage(client, deadLetterQueueUrl, messageBody);
+	const sendResult = await sendMessage(
+		client,
+		deadLetterQueueUrl,
+		messageBody,
+		id,
+	);
 	if (sendResult.status == SQSStatus.Failure) {
 		// rethrow exception, let another worker retry
 		throw Error('Failed to send message to dead letter queue');

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -156,6 +156,7 @@ const pollTranscriptionQueue = async (
 					config.app.deadLetterQueueUrl,
 					taskMessage.Body,
 					receiptHandle,
+					job.id,
 				);
 				console.log(
 					`moved message with message id ${taskMessage.MessageId} to dead letter queue.`,


### PR DESCRIPTION
## What does this change?
Another go at https://github.com/guardian/transcription-service/pull/50 - we need to set a unique MessageGroupId for each transcription job going to SQS - otherwise we can't process transcription jobs in parallel.

I decided to use the transcript ID for the MessageGroupId, seems as good as anything