### PR TITLE
Use spot instances

### DIFF
--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -706,7 +706,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
         "MixedInstancesPolicy": {
           "InstancesDistribution": {
             "OnDemandBaseCapacity": 0,
-            "OnDemandPercentageAboveBaseCapacity": 100,
+            "OnDemandPercentageAboveBaseCapacity": 0,
             "SpotAllocationStrategy": "capacity-optimized",
             "SpotMaxPrice": "0.6202",
           },

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -54,6 +54,7 @@ import {
 	MachineImage,
 	Peer,
 	Port,
+	SpotInstanceInterruption,
 	UserData,
 } from 'aws-cdk-lib/aws-ec2';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
@@ -381,6 +382,9 @@ export class TranscriptionService extends GuStack {
 				userData,
 				role: workerRole,
 				securityGroup: workerSecurityGroup,
+				spotOptions: {
+					interruptionBehavior: SpotInstanceInterruption.TERMINATE,
+				},
 			},
 		);
 

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -382,9 +382,6 @@ export class TranscriptionService extends GuStack {
 				userData,
 				role: workerRole,
 				securityGroup: workerSecurityGroup,
-				spotOptions: {
-					interruptionBehavior: SpotInstanceInterruption.TERMINATE,
-				},
 			},
 		);
 
@@ -431,6 +428,9 @@ export class TranscriptionService extends GuStack {
 					launchTemplateOverrides: acceptableInstanceTypes.map(
 						(instanceType) => ({
 							instanceType,
+							spotOptions: {
+								interruptionBehavior: SpotInstanceInterruption.TERMINATE,
+							},
 						}),
 					),
 				},

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -420,7 +420,7 @@ export class TranscriptionService extends GuStack {
 						// 0 is the default, including this here just to make it more obvious what's happening
 						onDemandBaseCapacity: 0,
 						// if this value is set to 100, then we won't use spot instances at all, if it is 0 then we use 100% spot
-						onDemandPercentageAboveBaseCapacity: 100,
+						onDemandPercentageAboveBaseCapacity: 0,
 						spotAllocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
 						spotMaxPrice: '0.6202',
 					},

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -42,8 +42,6 @@ const POLLING_INTERVAL_SECONDS = 30;
 const main = async () => {
 	const config = await getConfig();
 
-	checkSpotInterrupt();
-
 	const metrics = new MetricsService(
 		config.app.stage,
 		config.aws.region,
@@ -54,6 +52,7 @@ const main = async () => {
 		config.aws.region,
 		config.aws.localstackEndpoint,
 	);
+
 	const snsClient = getSNSClient(
 		config.aws.region,
 		config.aws.localstackEndpoint,
@@ -152,6 +151,8 @@ const pollTranscriptionQueue = async (
 		await updateScaleInProtection(region, stage, false);
 		return;
 	}
+	// start job to regularly check the instance interruption
+	checkSpotInterrupt(sqsClient, config.app.taskQueueUrl, receiptHandle);
 
 	try {
 		// from this point all worker logs will have id & userEmail in their fields

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -35,11 +35,14 @@ import { SQSClient } from '@aws-sdk/client-sqs';
 import { SNSClient } from '@aws-sdk/client-sns';
 import { setTimeout } from 'timers/promises';
 import { MAX_RECEIVE_COUNT } from '@guardian/transcription-service-common';
+import { checkSpotInterrupt } from './spot-termination';
 
 const POLLING_INTERVAL_SECONDS = 30;
 
 const main = async () => {
 	const config = await getConfig();
+
+	checkSpotInterrupt();
 
 	const metrics = new MetricsService(
 		config.app.stage,

--- a/packages/worker/src/spot-termination.ts
+++ b/packages/worker/src/spot-termination.ts
@@ -12,21 +12,38 @@ export const checkSpotInterrupt = async (
 	queueUrl: string,
 ) => {
 	const url = 'http://169.254.169.254/latest/meta-data/spot/instance-action';
-	const result = await fetch(url);
-	if (result.status === 200) {
-		const json = await result.json();
-		if (json.action === 'terminate') {
-			setInterruptionTime(new Date(json.time));
-			logger.warn('Spot instance termination detected');
-			// Interrupt warning occurs 2 minutes before termination
-			const receiptHandle = getCurrentReceiptHandle();
-			if (!receiptHandle) {
+	try {
+		const result = await fetch(url);
+		if (result.status === 200) {
+			const json = await result.json();
+			if (json.action === 'terminate') {
+				const interruptionTime = new Date(json.time);
+				setInterruptionTime(interruptionTime);
+				logger.warn('Spot instance termination detected');
+				// Interrupt warning occurs 2 minutes before termination
+				const receiptHandle = getCurrentReceiptHandle();
+				if (!receiptHandle) {
+					return;
+				}
+				const secondsUntilTermination =
+					(interruptionTime.getTime() - new Date().getTime()) / 1000;
+				try {
+					await changeMessageVisibility(
+						client,
+						queueUrl,
+						receiptHandle,
+						secondsUntilTermination,
+					);
+				} catch (e) {
+					// we don't care if the visibility change fails - it will just delay the message being
+					// picked up by a new worker, so do nothing here
+				}
+				// once the interrupt warning has happened, we don't need to keep checking
 				return;
 			}
-			await changeMessageVisibility(client, queueUrl, receiptHandle, 110);
-			// once the interrupt warning has happened, we don't need to keep checking
-			return;
 		}
+	} catch (e) {
+		console.error('Error during spot termination check', e);
 	}
 	setTimeout(
 		() => checkSpotInterrupt(client, queueUrl),

--- a/packages/worker/src/spot-termination.ts
+++ b/packages/worker/src/spot-termination.ts
@@ -19,6 +19,8 @@ export const checkSpotInterrupt = async (
 			console.warn('Spot instance termination detected');
 			// Interrupt warning occurs 2 minutes before termination
 			await changeMessageVisibility(client, queueUrl, receiptHandle, 110);
+			// once the interrupt warning has happened, we don't need to keep checking
+			return;
 		}
 	}
 	setTimeout(

--- a/packages/worker/src/spot-termination.ts
+++ b/packages/worker/src/spot-termination.ts
@@ -1,13 +1,15 @@
-import { changeMessageVisibility } from '@guardian/transcription-service-backend-common';
+import {
+	changeMessageVisibility,
+	logger,
+} from '@guardian/transcription-service-backend-common';
 import { SQSClient } from '@aws-sdk/client-sqs';
-import { setInterruptionTime } from './index';
+import { getCurrentReceiptHandle, setInterruptionTime } from './index';
 
 const CHECK_FREQUENCY = 10;
 
 export const checkSpotInterrupt = async (
 	client: SQSClient,
 	queueUrl: string,
-	receiptHandle: string,
 ) => {
 	const url = 'http://169.254.169.254/latest/meta-data/spot/instance-action';
 	const result = await fetch(url);
@@ -15,15 +17,19 @@ export const checkSpotInterrupt = async (
 		const json = await result.json();
 		if (json.action === 'terminate') {
 			setInterruptionTime(new Date(json.time));
-			console.warn('Spot instance termination detected');
+			logger.warn('Spot instance termination detected');
 			// Interrupt warning occurs 2 minutes before termination
+			const receiptHandle = getCurrentReceiptHandle();
+			if (!receiptHandle) {
+				return;
+			}
 			await changeMessageVisibility(client, queueUrl, receiptHandle, 110);
 			// once the interrupt warning has happened, we don't need to keep checking
 			return;
 		}
 	}
 	setTimeout(
-		() => checkSpotInterrupt(client, queueUrl, receiptHandle),
+		() => checkSpotInterrupt(client, queueUrl),
 		1000 * CHECK_FREQUENCY,
 	);
 };

--- a/packages/worker/src/spot-termination.ts
+++ b/packages/worker/src/spot-termination.ts
@@ -25,5 +25,8 @@ export const checkSpotInterrupt = async (
 			return;
 		}
 	}
-	setTimeout(checkSpotInterrupt, 1000 * CHECK_FREQUENCY);
+	setTimeout(
+		() => checkSpotInterrupt(client, queueUrl, receiptHandle),
+		1000 * CHECK_FREQUENCY,
+	);
 };

--- a/packages/worker/src/spot-termination.ts
+++ b/packages/worker/src/spot-termination.ts
@@ -1,21 +1,29 @@
 import { changeMessageVisibility } from '@guardian/transcription-service-backend-common';
+import { SQSClient } from '@aws-sdk/client-sqs';
 
-export const checkSpotInterrupt = async () => {
+const CHECK_FREQUENCY = 10;
+
+export const checkSpotInterrupt = async (
+	client: SQSClient,
+	queueUrl: string,
+	receiptHandle: string,
+) => {
 	console.log('Checking for spot interruption');
 	const url = 'http://169.254.169.254/latest/meta-data/spot/instance-action';
 	const result = await fetch(url);
 	if (result.status === 200) {
 		const json = await result.json();
 		if (json.action === 'terminate') {
-			console.log('Spot instance termination detected');
+			console.warn('Spot instance termination detected');
+			// Interrupt warning occurs 2 minutes before termination
 			await changeMessageVisibility(
-				sqsClient,
-				config.app.taskQueueUrl,
+				client,
+				queueUrl,
 				receiptHandle,
-				0,
+				120 - CHECK_FREQUENCY,
 			);
 			return;
 		}
 	}
-	setTimeout(checkSpotInterrupt, 1000 * 10);
+	setTimeout(checkSpotInterrupt, 1000 * CHECK_FREQUENCY);
 };

--- a/packages/worker/src/spot-termination.ts
+++ b/packages/worker/src/spot-termination.ts
@@ -19,7 +19,9 @@ export const checkSpotInterrupt = async (
 			if (json.action === 'terminate') {
 				const interruptionTime = new Date(json.time);
 				setInterruptionTime(interruptionTime);
-				logger.warn('Spot instance termination detected');
+				logger.warn(
+					`Spot instance scheduled for termination at ${interruptionTime.toISOString()}`,
+				);
 				// Interrupt warning occurs 2 minutes before termination
 				const receiptHandle = getCurrentReceiptHandle();
 				if (!receiptHandle) {

--- a/packages/worker/src/spot-termination.ts
+++ b/packages/worker/src/spot-termination.ts
@@ -1,5 +1,6 @@
 import { changeMessageVisibility } from '@guardian/transcription-service-backend-common';
 import { SQSClient } from '@aws-sdk/client-sqs';
+import { setInterruptionTime } from './index';
 
 const CHECK_FREQUENCY = 10;
 
@@ -14,15 +15,10 @@ export const checkSpotInterrupt = async (
 	if (result.status === 200) {
 		const json = await result.json();
 		if (json.action === 'terminate') {
+			setInterruptionTime(new Date(json.time));
 			console.warn('Spot instance termination detected');
 			// Interrupt warning occurs 2 minutes before termination
-			await changeMessageVisibility(
-				client,
-				queueUrl,
-				receiptHandle,
-				120 - CHECK_FREQUENCY,
-			);
-			return;
+			await changeMessageVisibility(client, queueUrl, receiptHandle, 110);
 		}
 	}
 	setTimeout(

--- a/packages/worker/src/spot-termination.ts
+++ b/packages/worker/src/spot-termination.ts
@@ -1,0 +1,21 @@
+import { changeMessageVisibility } from '@guardian/transcription-service-backend-common';
+
+export const checkSpotInterrupt = async () => {
+	console.log('Checking for spot interruption');
+	const url = 'http://169.254.169.254/latest/meta-data/spot/instance-action';
+	const result = await fetch(url);
+	if (result.status === 200) {
+		const json = await result.json();
+		if (json.action === 'terminate') {
+			console.log('Spot instance termination detected');
+			await changeMessageVisibility(
+				sqsClient,
+				config.app.taskQueueUrl,
+				receiptHandle,
+				0,
+			);
+			return;
+		}
+	}
+	setTimeout(checkSpotInterrupt, 1000 * 10);
+};

--- a/packages/worker/src/spot-termination.ts
+++ b/packages/worker/src/spot-termination.ts
@@ -9,7 +9,6 @@ export const checkSpotInterrupt = async (
 	queueUrl: string,
 	receiptHandle: string,
 ) => {
-	console.log('Checking for spot interruption');
 	const url = 'http://169.254.169.254/latest/meta-data/spot/instance-action';
 	const result = await fetch(url);
 	if (result.status === 200) {


### PR DESCRIPTION
## What does this change?
In order to reduce the costs for our transcription service, let's use spot instances for the transcription workers.

A lot of the infrastructure for using spot instances was added in https://github.com/guardian/transcription-service/pull/4 - that PR has quite a bit of detail. What this change does is actually 'switch on' spot instances by setting `onDemandPercentageAboveBaseCapacity` to 0. With that change, all instances will be launched as spot instances. This means

 - instances may take a little longer to start up
 - instances may be terminated with 2 minutes notice - see [spot interruption notice](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-instance-termination-notices.html)

Regarding the startup time, we should monitor this (will be easier once we have more structured logs etc) but I don't anticipate this being a problem - in our tests so far instances took a few seconds longer than ondemand to start.

The termination is a bigger issue - which is addressed in this PR. We've added a job which polls the instance metadata service (using IMDSV1 - we should switch to IMDSV2 at some point) to check for a termination notice. If it finds one then we know that the instance will be terminated in the next 2 minutes.

The most likely scenario for this to happen is when we are mid transcription, likely with much more than 2 minutes left to go. For this scenario, we simply reduce the visibility timeout on the job currently being transcribed to 2 minutes, so that after our instance is terminated the job can be quickly picked up by another instance.

On the off chance that we are able to complete our transcription in less than 2 minutes then it would be nice to not throw away all the work. However, we don't want to 'half finish' a transcription - e.g. send a message to the ouput handler but not delete the transcription job from the task queue. To prevent this from happening we've got a nice `if` condition that checkes a new `INTERRUPT_TIME` variable to decide whether it's safe to start uploading a finished transcript (we allow 20s which should be more than enough to upload a few text files to S3 and notify SNS/SQS.

## How to test
You can test this by triggering a spot instance interruption as outlined here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/initiate-a-spot-instance-interruption.html 

Test cases tried on CODE:
 - Run a transcription, check it works
 - Run a transcription, immediately trigger an interrupt, verify that the work gets picked up by a new instance and the transcription still completes
 - Run a transcription, interrupt when transcription is almost complete, check that transcription finishes succesfully

## How can we measure success?
Money saving! 

![make it rain](https://static.wikia.nocookie.net/i-dont-feel-so-good-simulator/images/7/7a/Make_It_Rain.gif/revision/latest?cb=20210626090032)