### PR TITLE
Email notification on worker failure

### DIFF
--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -159,6 +159,7 @@ export const getNextMessage = async (
 				MaxNumberOfMessages: 1,
 				// Not sure we need to set this here - could just rely on the queue default
 				VisibilityTimeout: timeoutOverride ?? 300,
+				AttributeNames: ['All'],
 			}),
 		);
 		const messages = message.Messages;

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -159,6 +159,7 @@ export const getNextMessage = async (
 				MaxNumberOfMessages: 1,
 				// Not sure we need to set this here - could just rely on the queue default
 				VisibilityTimeout: timeoutOverride ?? 300,
+				// we need to get message attributes so that we can use ApproximateReceiveCount
 				AttributeNames: ['All'],
 			}),
 		);

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -22,6 +22,7 @@ import {
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import { GuardianAwsAccounts } from '@guardian/private-infrastructure-config';
+import { MAX_RECEIVE_COUNT } from '@guardian/transcription-service-common';
 import {
 	type App,
 	aws_events_targets,
@@ -464,7 +465,7 @@ export class TranscriptionService extends GuStack {
 			contentBasedDeduplication: true,
 			deadLetterQueue: {
 				queue: transcriptionDeadLetterQueue,
-				maxReceiveCount: 3,
+				maxReceiveCount: MAX_RECEIVE_COUNT,
 			},
 		});
 

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -1,74 +1,77 @@
 {
-  "name": "cdk",
-  "version": "0.0.0",
-  "private": true,
-  "scripts": {
-    "build": "tsc",
-    "test": "jest",
-    "test-update": "jest -u",
-    "format": "prettier --write \"{lib,bin}/**/*.ts\"",
-    "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
-    "lint-fix": "eslint --fix lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
-    "synth": "cdk synth --path-metadata false --version-reporting false",
-    "diff": "cdk diff --path-metadata false --version-reporting false"
-  },
-  "devDependencies": {
-    "@guardian/cdk": "53.0.3",
-    "@guardian/eslint-config-typescript": "8.0.0",
-    "@guardian/prettier": "5.0.0",
-    "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.4.0",
-    "@guardian/tsconfig": "^0.2.0",
-    "@types/jest": "^29.5.11",
-    "@types/node": "20.11.5",
-    "aws-cdk": "2.121.1",
-    "aws-cdk-lib": "2.121.1",
-    "constructs": "10.3.0",
-    "eslint": "^8.56.0",
-    "jest": "^29.7.0",
-    "prettier": "^3.2.4",
-    "source-map-support": "^0.5.20",
-    "ts-jest": "^29.1.1",
-    "ts-node": "^10.9.2",
-    "typescript": "5.1.6"
-  },
-  "prettier": "@guardian/prettier",
-  "jest": {
-    "testMatch": [
-      "<rootDir>/lib/**/*.test.ts"
-    ],
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest"
-    },
-    "setupFilesAfterEnv": [
-      "./jest.setup.js"
-    ]
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true,
-      "jest": true
-    },
-    "extends": [
-      "@guardian/eslint-config-typescript"
-    ],
-    "parserOptions": {
-      "ecmaVersion": 2020,
-      "sourceType": "module"
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "rules": {
-      "@typescript-eslint/no-inferrable-types": 0,
-      "import/no-namespace": 2
-    },
-    "ignorePatterns": [
-      "**/*.js",
-      "node_modules",
-      "cdk.out",
-      ".eslintrc.js",
-      "jest.config.js"
-    ]
-  }
+	"name": "cdk",
+	"version": "0.0.0",
+	"private": true,
+	"scripts": {
+		"build": "tsc",
+		"test": "jest",
+		"test-update": "jest -u",
+		"format": "prettier --write \"{lib,bin}/**/*.ts\"",
+		"lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
+		"lint-fix": "eslint --fix lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
+		"synth": "cdk synth --path-metadata false --version-reporting false",
+		"diff": "cdk diff --path-metadata false --version-reporting false"
+	},
+	"dependencies": {
+		"@guardian/transcription-service-common": "1.0.0"
+	},
+	"devDependencies": {
+		"@guardian/cdk": "53.0.3",
+		"@guardian/eslint-config-typescript": "8.0.0",
+		"@guardian/prettier": "5.0.0",
+		"@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.4.0",
+		"@guardian/tsconfig": "^0.2.0",
+		"@types/jest": "^29.5.11",
+		"@types/node": "20.11.5",
+		"aws-cdk": "2.121.1",
+		"aws-cdk-lib": "2.121.1",
+		"constructs": "10.3.0",
+		"eslint": "^8.56.0",
+		"jest": "^29.7.0",
+		"prettier": "^3.2.4",
+		"source-map-support": "^0.5.20",
+		"ts-jest": "^29.1.1",
+		"ts-node": "^10.9.2",
+		"typescript": "5.1.6"
+	},
+	"prettier": "@guardian/prettier",
+	"jest": {
+		"testMatch": [
+			"<rootDir>/lib/**/*.test.ts"
+		],
+		"transform": {
+			"^.+\\.tsx?$": "ts-jest"
+		},
+		"setupFilesAfterEnv": [
+			"./jest.setup.js"
+		]
+	},
+	"eslintConfig": {
+		"root": true,
+		"env": {
+			"node": true,
+			"jest": true
+		},
+		"extends": [
+			"@guardian/eslint-config-typescript"
+		],
+		"parserOptions": {
+			"ecmaVersion": 2020,
+			"sourceType": "module"
+		},
+		"plugins": [
+			"@typescript-eslint"
+		],
+		"rules": {
+			"@typescript-eslint/no-inferrable-types": 0,
+			"import/no-namespace": 2
+		},
+		"ignorePatterns": [
+			"**/*.js",
+			"node_modules",
+			"cdk.out",
+			".eslintrc.js",
+			"jest.config.js"
+		]
+	}
 }

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_RECEIVE_COUNT = 3;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './utils';
+export * from './constants';

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -40,13 +40,38 @@ export const TranscriptionJob = z.object({
 
 export type TranscriptionJob = z.infer<typeof TranscriptionJob>;
 
-export const TranscriptionOutput = z.object({
+const TranscriptionOutputBase = z.object({
 	id: z.string(),
 	originalFilename: z.string(),
 	languageCode: z.string(),
 	userEmail: z.string(),
+});
+
+export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
+	status: z.literal('SUCCESS'),
 	outputBucketKeys: OutputBucketKeys,
 });
+
+export const TranscriptionOutputFailure = TranscriptionOutputBase.extend({
+	status: z.literal('FAILURE'),
+});
+
+export const TranscriptionOutput = z.union([
+	TranscriptionOutputSuccess,
+	TranscriptionOutputFailure,
+]);
+
+export type TranscriptionOutputSuccess = z.infer<
+	typeof TranscriptionOutputSuccess
+>;
+
+export type TranscriptionOutputFailure = z.infer<
+	typeof TranscriptionOutputFailure
+>;
+
+export const transcriptionOutputIsSuccess = (
+	output: TranscriptionOutput,
+): output is TranscriptionOutputSuccess => output.status === 'SUCCESS';
 
 export type TranscriptionOutput = z.infer<typeof TranscriptionOutput>;
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -43,12 +43,12 @@ export type TranscriptionJob = z.infer<typeof TranscriptionJob>;
 const TranscriptionOutputBase = z.object({
 	id: z.string(),
 	originalFilename: z.string(),
-	languageCode: z.string(),
 	userEmail: z.string(),
 });
 
 export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
 	status: z.literal('SUCCESS'),
+	languageCode: z.string(),
 	outputBucketKeys: OutputBucketKeys,
 });
 

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -38,7 +38,7 @@ const successMessageBody = (
 
 const failureMessageBody = (originalFilename: string): string => {
 	return `
-		<h1>Transcription for ${originalFilename} has failed 😢</h1>
+		<h1>Transcription for ${originalFilename} has failed.</h1>
 		<p>Please make sure that the file is a valid audio or video file.</p>
 		<p>Contact the digital investigations team for support.</p>
 	`;

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -72,7 +72,7 @@ const handleTranscriptionSuccess = async (
 			sesClient,
 			config.app.emailNotificationFromAddress,
 			transcriptionOutput.userEmail,
-			transcriptionOutput.originalFilename,
+			`Transcription complete for ${transcriptionOutput.originalFilename}`,
 			successMessageBody(
 				transcriptionOutput.id,
 				transcriptionOutput.originalFilename,
@@ -105,7 +105,7 @@ const handleTranscriptionFailure = async (
 			sesClient,
 			config.app.emailNotificationFromAddress,
 			transcriptionOutput.userEmail,
-			transcriptionOutput.originalFilename,
+			`Transcription failed for ${transcriptionOutput.originalFilename}`,
 			failureMessageBody(transcriptionOutput.originalFilename),
 		);
 

--- a/packages/output-handler/src/ses.ts
+++ b/packages/output-handler/src/ses.ts
@@ -9,7 +9,7 @@ export const sendEmail = async (
 	client: SESClient,
 	fromAddress: string,
 	recipientEmail: string,
-	originalFilename: string,
+	subject: string,
 	body: string,
 ) => {
 	logger.info(`Sending email from ${fromAddress} to ${recipientEmail}`);
@@ -21,7 +21,7 @@ export const sendEmail = async (
 		Message: {
 			Subject: {
 				Charset: 'UTF-8',
-				Data: `Transcription complete for ${originalFilename}`,
+				Data: subject,
 			},
 			Body: {
 				Html: {

--- a/packages/output-handler/test/testMessage.ts
+++ b/packages/output-handler/test/testMessage.ts
@@ -2,6 +2,7 @@ export const testMessage = {
 	Records: [
 		{
 			messageId: 'e60db2e5-b671-4832-abd4-c3fd40fe1c92',
+			status: 'SUCCESS',
 			receiptHandle: 'handle123',
 			body:
 				'{\n' +

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -147,6 +147,7 @@ const pollTranscriptionQueue = async (
 	if (!job) {
 		await metrics.putMetric(FailureMetric);
 		logger.error('Failed to parse job message', message);
+		await updateScaleInProtection(region, stage, false);
 		return;
 	}
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -80,7 +80,6 @@ const publishTranscriptionOutputFailure = async (
 	const failureMessage: TranscriptionOutputFailure = {
 		id: job.id,
 		status: 'FAILURE',
-		languageCode: 'en',
 		userEmail: job.userEmail,
 		originalFilename: job.originalFilename,
 	};

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -13,7 +13,7 @@ import {
 } from '@guardian/transcription-service-backend-common';
 import {
 	OutputBucketKeys,
-	type TranscriptionOutput,
+	type TranscriptionOutputSuccess,
 } from '@guardian/transcription-service-common';
 import { getSNSClient, publishTranscriptionOutput } from './sns';
 import {
@@ -198,8 +198,9 @@ const pollTranscriptionQueue = async (
 			text: outputBucketUrls.text.key,
 		};
 
-		const transcriptionOutput: TranscriptionOutput = {
+		const transcriptionOutput: TranscriptionOutputSuccess = {
 			id: job.id,
+			status: 'SUCCESS',
 			languageCode: transcriptResult.metadata.detectedLanguageCode || 'en',
 			userEmail: job.userEmail,
 			originalFilename: job.originalFilename,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- updates the types of the messages the worker pushes to SNS so that they can include failure messages as well as success messages
- workers post a failure message to SNS in two situations 
  - when ffmpeg fails to convert a file to a wav
  - when an exception is thrown after the SQS task message is parsed on the third retry
- the output handler processes worker failures by sending an email to the user

<img width="629" alt="Screenshot 2024-03-01 at 15 35 42" src="https://github.com/guardian/transcription-service/assets/17057932/f906f6d6-6285-4fca-bf74-4e948f78d154">


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- tested in CODE
