### PR TITLE
Fix serverless express deprecation notice

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -291,7 +291,7 @@ if (runningOnAws) {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let serverlessExpressHandler: any;
 	const serverlessHandler = getApp().then(
-		(app) => (serverlessExpressHandler = serverlessExpress({ app }).handler),
+		(app) => (serverlessExpressHandler = serverlessExpress({ app })),
 	);
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The api logs are full of this deprecation notice from serverless express
```
message | [DEPRECATION NOTICE] You're using the deprecated `serverlessExpress({...}).handler({...})` method. This will be removed in a future version of @codegenie/serverless-express. Instead, simply return `serverlessExpress({...})` as your handler.
```
This PR makes the recommended change so that logs are less noisy