### PR TITLE
Extract timing and language data from transcript output

### DIFF
--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -4,7 +4,7 @@ export interface LoggerFunctions {
 	setCommonMetadata(id: string, userEmail: string): void;
 	resetCommonMetadata(): void;
 	debug(message: string): void;
-	info(message: string, meta?: Record<string, string>): void;
+	info(message: string, meta?: Record<string, string | number>): void;
 	warn(message: string, error?: Error | unknown): void;
 	error(message: string, error?: Error | unknown): void;
 }
@@ -13,7 +13,7 @@ interface LogEvent {
 	level: 'debug' | 'info' | 'warn' | 'error';
 	message: string;
 	stack_trace?: string;
-	meta?: Record<string, string>;
+	meta?: Record<string, string | number>;
 }
 
 const { combine, timestamp, json } = winston.format;

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -197,7 +197,7 @@ const regexExtract = (text: string, regex: RegExp): string | undefined => {
 	return regexResult ? regexResult[1] : undefined;
 };
 
-const extractStdErrInfo = (stderr: string): TranscriptionMetadata => {
+const extractWhisperStderrData = (stderr: string): TranscriptionMetadata => {
 	const languageRegex = /auto-detected\slanguage: ([a-zA-Z]{2})/;
 	const detectedLanguageCode = regexExtract(stderr, languageRegex);
 
@@ -243,7 +243,7 @@ export const transcribe = async (
 			'--language',
 			'auto',
 		]);
-		const metadata = extractStdErrInfo(result.stderr);
+		const metadata = extractWhisperStderrData(result.stderr);
 		logger.info('Transcription finished successfully', metadata);
 		return { fileName, metadata };
 	} catch (error) {


### PR DESCRIPTION
## What does this change?
This pr uses some regular expressions to extract useful information out of the whisper.cpp output. Currently, we extract language code, total time and load time (time taken to load the model).

## How to test
I've tested this on CODE - here's an example log line https://logs.gutools.co.uk/s/investigations/app/discover#/doc/3501e690-a763-11eb-882c-5b432fbcaa69/logstash-investigations-2024.02.29?id=Acc69Y0BLE-XvQ1FY3Mn
