### PR TITLE
Tidy up UI - don't flash 'login required' message

### DIFF
--- a/packages/client/src/app/template.tsx
+++ b/packages/client/src/app/template.tsx
@@ -12,7 +12,6 @@ export const AuthContext: React.Context<AuthState> = createContext({});
 
 export default function Template({ children }: { children: React.ReactNode }) {
 	const [authLoading, setAuthLoading] = useState(true);
-	const browserHistory = createBrowserHistory();
 	const [auth, setAuth] = useState<AuthState>(initialState);
 
 	useEffect(() => {
@@ -25,20 +24,21 @@ export default function Template({ children }: { children: React.ReactNode }) {
 	}, [auth]);
 
 	useEffect(() => {
+		const browserHistory = createBrowserHistory();
 		setAuthLoading(true);
 		const newAuth = initAuth(browserHistory);
 		setAuth(newAuth);
 		setAuthLoading(false);
 	}, []);
 
-	if (authLoading) {
-		return (
-			<div>
-				<Spinner className={'w-6 h-6'} />
-			</div>
-		);
-	}
 	if (!auth.token) {
+		if (authLoading) {
+			return (
+				<div>
+					<Spinner className={'w-6 h-6'} />
+				</div>
+			);
+		}
 		return (
 			<div>
 				<h2 className="text-4xl font-extrabold dark:text-white">

--- a/packages/client/src/app/template.tsx
+++ b/packages/client/src/app/template.tsx
@@ -5,7 +5,6 @@ import { AuthRequired } from '@/components/AuthRequired';
 import { initAuth, initialState, logOutIfLoginExpired } from '@/services/auth';
 import { AuthState } from '@/types';
 import { createContext } from 'react';
-import { Spinner } from 'flowbite-react';
 
 export const authExpiryCheckPeriodInSeconds = 30;
 export const AuthContext: React.Context<AuthState> = createContext({});
@@ -33,11 +32,7 @@ export default function Template({ children }: { children: React.ReactNode }) {
 
 	if (!auth.token) {
 		if (authLoading) {
-			return (
-				<div>
-					<Spinner className={'w-6 h-6'} />
-				</div>
-			);
+			return <div>Loading...</div>;
 		}
 		return (
 			<div>

--- a/packages/client/src/app/template.tsx
+++ b/packages/client/src/app/template.tsx
@@ -5,11 +5,14 @@ import { AuthRequired } from '@/components/AuthRequired';
 import { initAuth, initialState, logOutIfLoginExpired } from '@/services/auth';
 import { AuthState } from '@/types';
 import { createContext } from 'react';
+import { Spinner } from 'flowbite-react';
 
 export const authExpiryCheckPeriodInSeconds = 30;
 export const AuthContext: React.Context<AuthState> = createContext({});
 
 export default function Template({ children }: { children: React.ReactNode }) {
+	const [authLoading, setAuthLoading] = useState(true);
+	const browserHistory = createBrowserHistory();
 	const [auth, setAuth] = useState<AuthState>(initialState);
 
 	useEffect(() => {
@@ -22,12 +25,19 @@ export default function Template({ children }: { children: React.ReactNode }) {
 	}, [auth]);
 
 	useEffect(() => {
-		const browserHistory = createBrowserHistory();
-
+		setAuthLoading(true);
 		const newAuth = initAuth(browserHistory);
 		setAuth(newAuth);
+		setAuthLoading(false);
 	}, []);
 
+	if (authLoading) {
+		return (
+			<div>
+				<Spinner className={'w-6 h-6'} />
+			</div>
+		);
+	}
 	if (!auth.token) {
 		return (
 			<div>


### PR DESCRIPTION
## What does this change?
I noticed we flash a 'login required' message on most pages even when the user is logged in. This change adds a loading spinner when we're reading the value from local storage, and pulls the call to createBrowserHistory to the top of the component - which appears to speed things up a bit though would be good to check with @marjisound if you think this will work.

Before:

https://github.com/guardian/transcription-service/assets/3606555/5e930c3f-3319-47b8-b354-6a86d6731879


After:


https://github.com/guardian/transcription-service/assets/3606555/d939b2a7-92d7-40fa-b844-8e57c2a91b32