### PR TITLE
Make file duration a number in logs

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -218,7 +218,7 @@ const pollTranscriptionQueue = async (
 				id: transcriptionOutput.id,
 				filename: transcriptionOutput.originalFilename,
 				userEmail: transcriptionOutput.userEmail,
-				fileDuration: ffmpegResult.duration?.toString() || '',
+				fileDuration: ffmpegResult.duration || 0,
 				...transcriptResult.metadata,
 			},
 		);


### PR DESCRIPTION
## What does this change?
Tiny change - this would allow us to have a table visualisation in our ELK cluster of e.g. average file length, max file length etc