### PR TITLE
Rename file duration field to mediaDurationSeconds

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -252,7 +252,7 @@ const pollTranscriptionQueue = async (
 				id: transcriptionOutput.id,
 				filename: transcriptionOutput.originalFilename,
 				userEmail: transcriptionOutput.userEmail,
-				fileDuration: ffmpegResult.duration || 0,
+				mediaDurationSeconds: ffmpegResult.duration || 0,
 				...transcriptResult.metadata,
 			},
 		);


### PR DESCRIPTION
## What does this change?
In https://github.com/guardian/transcription-service/pull/59 I converted fileDuration from being a string to a number. Unfortunately once data has been added to an elasticsearch mapping you can't change the format without doing a reindex. Having a mix of numberic and text data prevents from using the field in any formulas/visualisations, and shows an error:
<img width="454" alt="Screenshot 2024-03-04 at 14 30 58" src="https://github.com/guardian/transcription-service/assets/3606555/048ecefa-6bfe-479d-bbd9-052932ddd5f8">

With that in mind, I'm just making a new field to store this data, with a slightly improved name.
