### PR TITLE
Bump transcription file signed download url timeout to 7 days

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -113,7 +113,7 @@ const getApp = async () => {
 				config.aws.region,
 				config.app.sourceMediaBucket,
 				s3Key,
-				3600,
+				604800, // one week in seconds
 			);
 			const sendResult = await generateOutputSignedUrlAndSendMessage(
 				s3Key,


### PR DESCRIPTION
## What does this change?
If a transcription takes more than 2 hours and gets killed halfway through by e.g. spot instance rotation then it will need to be re-downloaded.

With that in mind, let's set a longer expiry for the s3 download url
