### PR TITLE
Fix: raise worker visibility timeout

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -217,14 +217,14 @@ const pollTranscriptionQueue = async (
 
 		if (ffmpegResult.duration && ffmpegResult.duration !== 0) {
 			// Transcription time is usually slightly longer than file duration.
-			// Update visibility timeout to 25% more than file duration to avoid another
-			// worker picking up the task and to allow this worker to delete the
-			// message when it's finished.
+			// Update visibility timeout to 2x the file duration plus 10 minutes for the model to load.
+			// This should avoid another worker picking up the task and to allow
+			// this worker to delete the message when it's finished.
 			await changeMessageVisibility(
 				sqsClient,
 				config.app.taskQueueUrl,
 				receiptHandle,
-				ffmpegResult.duration * 1.25,
+				ffmpegResult.duration * 2 + 600,
 			);
 		}
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -216,13 +216,15 @@ const pollTranscriptionQueue = async (
 		}
 
 		if (ffmpegResult.duration && ffmpegResult.duration !== 0) {
-			// Adding 300 seconds (5 minutes) and the file duration
-			// to allow time to load the whisper model
+			// Transcription time is usually slightly longer than file duration.
+			// Update visibility timeout to 25% more than file duration to avoid another
+			// worker picking up the task and to allow this worker to delete the
+			// message when it's finished.
 			await changeMessageVisibility(
 				sqsClient,
 				config.app.taskQueueUrl,
 				receiptHandle,
-				ffmpegResult.duration + 300,
+				ffmpegResult.duration * 1.25,
 			);
 		}
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Raises SQS message visibility timeout from a constant `file duration + 5 minutes` to `file duration * 2 + 10 minutes`

## Why?
At the moment we've got a bug where we're setting SQS message visibility timeout to a value that is too low after having converted the corresponding file to wav and determining its duration. By the time transcription is finished, the visibility timeout has expired. We email the user with a success notification but fail to delete the message off of the queue because the message's receipt handle (with duration equal to message visibility) has expired. The worker then reattempts transcription twice with the same outcome, before the message is sent to the dead letter queue.

## How to test
Must be tested in prod since CODE use whisper's tiny model which is faster than prod's medium model, and usually finishes transcription within the current visibility timeout

## How can we measure success?
The sqs messages for @davidfurey 's TIF transcriptions will be deleted after transcription is finished and he won't get three success notifications.
