### PR TITLE
Block outbound traffic from worker instances

### DIFF
--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -660,9 +660,24 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
         "GroupDescription": "TranscriptionService/TranscriptionServiceWorkerSGTranscriptionserviceworker",
         "SecurityGroupEgress": [
           {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
+            "Description": {
+              "Fn::Join": [
+                "",
+                [
+                  "from ",
+                  {
+                    "Fn::ImportValue": "internet-enabled-vpc-AWSEndpointSecurityGroup",
+                  },
+                  ":443",
+                ],
+              ],
+            },
+            "DestinationSecurityGroupId": {
+              "Fn::ImportValue": "internet-enabled-vpc-AWSEndpointSecurityGroup",
+            },
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
           },
         ],
         "Tags": [
@@ -692,6 +707,35 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "TranscriptionServiceWorkerSGTranscriptionserviceworkertoIndirectPeer44380412F57": {
+      "Properties": {
+        "Description": {
+          "Fn::Join": [
+            "",
+            [
+              "to ",
+              {
+                "Ref": "S3PrefixListIdParameter",
+              },
+              ":443",
+            ],
+          ],
+        },
+        "DestinationPrefixListId": {
+          "Ref": "S3PrefixListIdParameter",
+        },
+        "FromPort": 443,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "TranscriptionServiceWorkerSGTranscriptionserviceworker6EE23C91",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 443,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "TranscriptionWorkerASGCAE69A98": {
       "Properties": {

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -341,7 +341,7 @@ export class TranscriptionService extends GuStack {
 			{
 				app: workerApp,
 				vpc,
-				allowAllOutbound: true,
+				allowAllOutbound: false,
 			},
 		);
 


### PR DESCRIPTION
## What does this change?
This re-implements changes initially introduced in https://github.com/guardian/transcription-service/pull/34, after they were removed for debugging in https://github.com/guardian/transcription-service/pull/42 and https://github.com/guardian/transcription-service/pull/44

With this change, worker instances will only have egress access to a limited number of AWS services 

## How to test
I deployed this change to CODE and verified
- Transcription works (this should test communication with s3, sqs, sns, parameter store)
- logs work (tests kinesis)