### PR TITLE
Set s3 expiry time in minutes not seconds

### DIFF
--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -266,7 +266,7 @@ const generateOutputSignedUrls = async (
 	originalFilename: string,
 	expiresInDays: number,
 ): Promise<OutputBucketUrls> => {
-	const expiresIn = expiresInDays * 24 * 60;
+	const expiresIn = expiresInDays * 24 * 60 * 60;
 	const srtKey = `srt/${id}.srt`;
 	const jsonKey = `json/${id}.json`;
 	const textKey = `text/${id}.txt`;


### PR DESCRIPTION
## What does this change?
This fixes small bug where we were setting the expiry time in minutes when the unit is actually seconds. Currently transcriptions will fail to upload after 168 minutes instead of 7 days

## How to test
I haven't tested this, but I've checked the docs and the unit is definitely seconds. 