### PR TITLE
Add a note pointing out that the email will always take at least a few minutes

### DIFF
--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -138,7 +138,8 @@ export const UploadForm = () => {
 						>
 							<span className="font-medium">Upload complete. </span>{' '}
 							Transcription in progress - check your email for the completed
-							transcript. The transcription process is typically shorter than
+							transcript. The service can take a few minutes to start up, but 
+							thereafter the transcription process is typically shorter than
 							the length of the media file.{' '}
 							<button
 								onClick={() => reset()}


### PR DESCRIPTION
A user noted that the message saying 'The transcription process is typically shorter than the length of the media file' led them to think the service had failed when they tried an extremely short recording. So I thought it might help to suggest that there is always a minimum turnaround time of a few minutes, even if the transcription worker itself is typically faster than the recording's duration.

Edit made in a text editor so may need prettifying