### PR TITLE
Enforce selection of media file language

### DIFF
--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -64,7 +64,7 @@ export const generateOutputSignedUrlAndSendMessage = async (
 	userEmail: string,
 	originalFilename: string,
 	inputSignedUrl: string,
-	languageCode: LanguageCode | null,
+	languageCode: LanguageCode,
 ): Promise<SendResult> => {
 	const signedUrls = await generateOutputSignedUrls(
 		id,

--- a/packages/client/src/app/page.tsx
+++ b/packages/client/src/app/page.tsx
@@ -6,8 +6,7 @@ const Home = () => {
 		<>
 			<p className={' pb-3 font-light'}>
 				Use the form below to upload your files for transcription. You will
-				receive an email when the transcription process is complete. Choosing
-				audio language may improve accuracy.
+				receive an email when the transcription process is complete.
 			</p>
 			<UploadForm></UploadForm>
 		</>

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -75,7 +75,6 @@ const updateFileStatus = (
 
 export const UploadForm = () => {
 	const [status, setStatus] = useState<RequestStatus>(RequestStatus.Ready);
-	const [errorMessage, setErrorMessage] = useState<string | undefined>();
 	const [files, setFiles] = useState<FileList | null>(null);
 	const [uploads, setUploads] = useState<Record<string, RequestStatus>>({});
 	const [mediaFileLanguageCode, setMediaFileLanguageCode] = useState<
@@ -88,7 +87,6 @@ export const UploadForm = () => {
 
 	const reset = () => {
 		setStatus(RequestStatus.Ready);
-		setErrorMessage(undefined);
 		setUploads({});
 		setFiles(null);
 		setMediaFileLanguageCode(undefined);
@@ -127,9 +125,7 @@ export const UploadForm = () => {
 						className="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400"
 						role="alert"
 					>
-						<span className="font-medium">
-							{errorMessage ?? 'One or more uploads failed'}
-						</span>{' '}
+						<span className="font-medium">One or more uploads failed</span>{' '}
 						<button
 							onClick={() => reset()}
 							className="font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline"
@@ -175,11 +171,11 @@ export const UploadForm = () => {
 			return;
 		}
 
+		// the required property on the file input should prevent the form from
+		// being submitted without any files selected. Need to confirm this in
+		// order to narrow the type of files
 		if (files === null || files.length === 0) {
-			setErrorMessage(
-				'Invalid file input - did you select a file to transcribe?',
-			);
-			setStatus(RequestStatus.Failed);
+			console.error('form submitted without any files');
 			return;
 		}
 

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -8,7 +8,7 @@ import {
 	languageCodes,
 } from '@guardian/transcription-service-common';
 import { AuthContext } from '@/app/template';
-import { FileInput, Label } from 'flowbite-react';
+import { Alert, FileInput, Label } from 'flowbite-react';
 import { RequestStatus } from '@/types';
 import { iconForStatus, InfoMessage } from '@/components/InfoMessage';
 import { Dropdown } from 'flowbite-react';
@@ -75,8 +75,12 @@ export const UploadForm = () => {
 	const [status, setStatus] = useState<RequestStatus>(RequestStatus.Ready);
 	const [errorMessage, setErrorMessage] = useState<string | undefined>();
 	const [uploads, setUploads] = useState<Record<string, RequestStatus>>({});
-	const [mediaFileLanguageCode, setMediaFileLanguageCode] =
-		useState<LanguageCode | null>(null);
+	const [mediaFileLanguageCode, setMediaFileLanguageCode] = useState<
+		LanguageCode | undefined
+	>(undefined);
+	const [languageCodeValid, setLanguageCodeValid] = useState<
+		boolean | undefined
+	>(undefined);
 	const { token } = useContext(AuthContext);
 
 	const reset = () => {
@@ -138,9 +142,9 @@ export const UploadForm = () => {
 						>
 							<span className="font-medium">Upload complete. </span>{' '}
 							Transcription in progress - check your email for the completed
-							transcript. The service can take a few minutes to start up, but 
-							thereafter the transcription process is typically shorter than
-							the length of the media file.{' '}
+							transcript. The service can take a few minutes to start up, but
+							thereafter the transcription process is typically shorter than the
+							length of the media file.{' '}
 							<button
 								onClick={() => reset()}
 								className="font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline"
@@ -160,6 +164,13 @@ export const UploadForm = () => {
 		const maybeFileInput = document.querySelector(
 			'input[id=files]',
 		) as HTMLInputElement;
+
+		// form validation
+		if (mediaFileLanguageCode === undefined) {
+			setLanguageCodeValid(false);
+			return;
+		}
+
 		if (
 			!maybeFileInput ||
 			!maybeFileInput.files ||
@@ -171,6 +182,7 @@ export const UploadForm = () => {
 			setStatus(RequestStatus.Failed);
 			return;
 		}
+
 		setStatus(RequestStatus.InProgress);
 		const fileArray = Array.from(maybeFileInput.files);
 		const fileIds = fileArray.map((f, index) => [
@@ -201,7 +213,7 @@ export const UploadForm = () => {
 		maybeFileInput.value = '';
 	};
 
-	const detectLanguageLabel = 'Auto detect language';
+	const detectLanguageLabel = 'Choose a transcription language';
 
 	return (
 		<>
@@ -226,24 +238,15 @@ export const UploadForm = () => {
 								: detectLanguageLabel
 						}
 						dismissOnClick={true}
-						color="gray"
+						color={languageCodeValid === false ? 'red' : 'gray'}
 					>
-						<Dropdown.Item
-							key={undefined}
-							value={undefined}
-							onClick={() => {
-								setMediaFileLanguageCode(null);
-							}}
-						>
-							{detectLanguageLabel}
-						</Dropdown.Item>
-						<Dropdown.Divider />
 						{languageCodes.map((languageCode: LanguageCode) => (
 							<Dropdown.Item
 								key={languageCode}
 								value={languageCode}
 								onClick={() => {
 									setMediaFileLanguageCode(languageCode);
+									setLanguageCodeValid(true);
 								}}
 							>
 								{languageCodeToLanguage[languageCode]}
@@ -251,6 +254,15 @@ export const UploadForm = () => {
 						))}
 					</Dropdown>
 				</div>
+				{languageCodeValid === false ? (
+					<div className="mb-6">
+						<Alert color="failure">
+							Please choose the language of the file or 'Auto-detect language'
+						</Alert>
+					</div>
+				) : (
+					<></>
+				)}
 				<button
 					type="submit"
 					className="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -231,9 +231,6 @@ export const UploadForm = () => {
 					<FileInput id="files" multiple />
 				</div>
 				<div className="mb-6">
-					<div>
-						<Label htmlFor="language-selector" value="Audio language" />
-					</div>
 					<Dropdown
 						label={
 							mediaFileLanguageCode

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -90,6 +90,9 @@ export const UploadForm = () => {
 		setStatus(RequestStatus.Ready);
 		setErrorMessage(undefined);
 		setUploads({});
+		setFiles(null);
+		setMediaFileLanguageCode(undefined);
+		setLanguageCodeValid(undefined);
 	};
 
 	if (!token) {

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -6,6 +6,7 @@ import {
 	languageCodeToLanguage,
 	type LanguageCode,
 	languageCodes,
+	TranscribeFileRequestBody,
 } from '@guardian/transcription-service-common';
 import { AuthContext } from '@/app/template';
 import { Alert, FileInput, Label } from 'flowbite-react';
@@ -16,7 +17,7 @@ import { Dropdown } from 'flowbite-react';
 const uploadFileAndTranscribe = async (
 	file: File,
 	token: string,
-	languageCode: LanguageCode | null,
+	languageCode: LanguageCode,
 ) => {
 	const blob = new Blob([file as BlobPart]);
 
@@ -38,16 +39,18 @@ const uploadFileAndTranscribe = async (
 		return false;
 	}
 
+	const transcribeFileBody: TranscribeFileRequestBody = {
+		s3Key: body.data.s3Key,
+		fileName: file.name,
+		languageCode,
+	};
+
 	const sendMessageResponse = await authFetch('/api/transcribe-file', token, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 		},
-		body: JSON.stringify({
-			s3Key: body.data.s3Key,
-			fileName: file.name,
-			languageCode,
-		}),
+		body: JSON.stringify(transcribeFileBody),
 	});
 	const sendMessageSuccess = sendMessageResponse.status === 200;
 	if (!sendMessageSuccess) {

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -175,7 +175,6 @@ export const UploadForm = () => {
 		// being submitted without any files selected. Need to confirm this in
 		// order to narrow the type of files
 		if (files === null || files.length === 0) {
-			console.error('form submitted without any files');
 			return;
 		}
 

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -215,6 +215,7 @@ export const UploadForm = () => {
 				<div className="mb-6">
 					<div>
 						<Label
+							className="text-base"
 							htmlFor="multiple-file-upload"
 							value="File(s) for transcription"
 						/>
@@ -230,8 +231,15 @@ export const UploadForm = () => {
 				</div>
 				<div className="mb-6">
 					<div>
-						<Label htmlFor="language-selector" value="Audio language" />
+						<Label
+							className="text-base"
+							htmlFor="language-selector"
+							value="Audio language"
+						/>
 					</div>
+					<p className="font-light">
+						Choosing a specific language may give you more accurate results.
+					</p>
 					<Select
 						id="language-selector"
 						style={{

--- a/packages/common/src/languages.ts
+++ b/packages/common/src/languages.ts
@@ -3,7 +3,7 @@
 // https://github.com/ggerganov/whisper.cpp/blob/25d313b38b1f562200f915cd5952555613cd0110/whisper.cpp#L251
 // and values transformed to title case
 export const languageCodeToLanguage = Object.freeze({
-	auto: 'Auto-detect language',
+	auto: 'Auto-detect language (not yet recommended)',
 	en: 'English',
 	zh: 'Chinese',
 	de: 'German',

--- a/packages/common/src/languages.ts
+++ b/packages/common/src/languages.ts
@@ -3,7 +3,7 @@
 // https://github.com/ggerganov/whisper.cpp/blob/25d313b38b1f562200f915cd5952555613cd0110/whisper.cpp#L251
 // and values transformed to title case
 export const languageCodeToLanguage = Object.freeze({
-	auto: 'Auto Detect Language (best for multi-language files)',
+	auto: 'Auto-detect language',
 	en: 'English',
 	zh: 'Chinese',
 	de: 'German',

--- a/packages/common/src/languages.ts
+++ b/packages/common/src/languages.ts
@@ -3,6 +3,7 @@
 // https://github.com/ggerganov/whisper.cpp/blob/25d313b38b1f562200f915cd5952555613cd0110/whisper.cpp#L251
 // and values transformed to title case
 export const languageCodeToLanguage = Object.freeze({
+	auto: 'Auto Detect Language (best for multi-language files)',
 	en: 'English',
 	zh: 'Chinese',
 	de: 'German',
@@ -106,6 +107,7 @@ export const languageCodeToLanguage = Object.freeze({
 });
 
 type LanguageCodeToLanguage = typeof languageCodeToLanguage;
+
 export type LanguageCode = keyof LanguageCodeToLanguage;
 
 // There doesn't seem to be a way to get the object keys that has a type which

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -7,7 +7,7 @@ export function getKeys<T extends Record<string, any>>(obj: T) {
 	return Object.keys(obj) as [keyof typeof obj];
 }
 
-const zodLanguageCode = z.enum(getKeys(languageCodeToLanguage)).nullable();
+const zodLanguageCode = z.enum(getKeys(languageCodeToLanguage));
 
 export enum DestinationService {
 	TranscriptionService = 'TranscriptionService',

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -167,7 +167,7 @@ export const getTranscriptionText = async (
 	file: string,
 	numberOfThreads: number,
 	model: WhisperModel,
-	languageCode: LanguageCode | null,
+	languageCode: LanguageCode,
 ): Promise<TranscriptionResult> => {
 	try {
 		const { fileName, metadata } = await transcribe(
@@ -222,12 +222,11 @@ export const transcribe = async (
 	file: string,
 	numberOfThreads: number,
 	model: WhisperModel,
-	languageCode: LanguageCode | null,
+	languageCode: LanguageCode,
 ) => {
 	const fileName = path.parse(file).name;
 	const containerOutputFilePath = path.resolve(CONTAINER_FOLDER, fileName);
 	logger.info(`Transcription output file path: ${containerOutputFilePath}`);
-	const language = languageCode ? languageCode : 'auto';
 
 	try {
 		const result = await runSpawnCommand('transcribe', 'docker', [
@@ -246,7 +245,7 @@ export const transcribe = async (
 			'--output-file',
 			containerOutputFilePath,
 			'--language',
-			language,
+			languageCode,
 		]);
 		const metadata = extractWhisperStderrData(result.stderr);
 		logger.info('Transcription finished successfully', metadata);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- changes transcription form so that there is no default language chosen, and the user must either select a language or 'Auto-detect language'.
- fixes the form on mobile by changing the language picker from a flowbite-react `Dropdown` element to a react `Select` element. The former didn't work on some mobile devices. When it was selected, the dropdown opened upward (regardless of `placement` property) and couldn't be navigated by swiping or scrolling.
- improves handling of form state by moving from a query selector to get files on form submission, to keeping track of that state with a `useState` hook

## Before
auto-detect language is the default, language picker doesn't work

https://github.com/guardian/transcription-service/assets/17057932/ec16286c-5e80-40b0-9744-260ffc4aaf8e

## after 
no default language, language picker does work


https://github.com/guardian/transcription-service/assets/17057932/b05d5c25-62fb-405c-a10f-50673aaf765a




<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- [x] tested in CODE

## How can we measure success?
- fewer mistakenly detected transcriptions
- users can use language picker on mobile