### PR TITLE
Create footer with link to docs

### DIFF
--- a/packages/client/src/app/layout.tsx
+++ b/packages/client/src/app/layout.tsx
@@ -34,10 +34,7 @@ export default function RootLayout({
 						{children}
 					</div>
 				</main>
-				<Footer
-					container
-					className="fixed bottom-0 sm:justify-end md:justify-end"
-				>
+				<Footer container className="fixed bottom-0 md:justify-end">
 					<Footer.LinkGroup>
 						<Footer.Link
 							target="_blank"

--- a/packages/client/src/app/layout.tsx
+++ b/packages/client/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Footer } from 'flowbite-react';
 import './globals.css';
 import React from 'react';
 export default function RootLayout({
@@ -33,6 +34,19 @@ export default function RootLayout({
 						{children}
 					</div>
 				</main>
+				<Footer
+					container
+					className="fixed bottom-0 sm:justify-end md:justify-end"
+				>
+					<Footer.LinkGroup>
+						<Footer.Link
+							target="_blank"
+							href="https://docs.google.com/document/d/1e224Fe5tJJNeLBNvYLVJ4FWd_O-1nwrJcqKyEXI03lA"
+						>
+							About this tool
+						</Footer.Link>
+					</Footer.LinkGroup>
+				</Footer>
 			</body>
 		</html>
 	);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds a footer component to the page with a link to our [user-facing docs](https://docs.google.com/document/d/1e224Fe5tJJNeLBNvYLVJ4FWd_O-1nwrJcqKyEXI03lA/edit#heading=h.faz67d5pl5mg).

<img width="894" alt="Screenshot 2024-04-04 at 10 56 27" src="https://github.com/guardian/transcription-service/assets/17057932/09c134ee-d135-4a67-b846-f703317347de">
