### PR TITLE
Add message id to failure notification

### DIFF
--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -36,11 +36,12 @@ const successMessageBody = (
 	`;
 };
 
-const failureMessageBody = (originalFilename: string): string => {
+const failureMessageBody = (originalFilename: string, id: string): string => {
 	return `
 		<h1>Transcription for ${originalFilename} has failed.</h1>
 		<p>Please make sure that the file is a valid audio or video file.</p>
 		<p>Contact the digital investigations team for support.</p>
+		<p>Transcription ID: ${id}</p>
 	`;
 };
 
@@ -106,7 +107,10 @@ const handleTranscriptionFailure = async (
 			config.app.emailNotificationFromAddress,
 			transcriptionOutput.userEmail,
 			`Transcription failed for ${transcriptionOutput.originalFilename}`,
-			failureMessageBody(transcriptionOutput.originalFilename),
+			failureMessageBody(
+				transcriptionOutput.originalFilename,
+				transcriptionOutput.id,
+			),
 		);
 
 		logger.info('Output handler successfully sent failure email notification', {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

Co-authored-by: Marjan Kalanaki <marjan.kalanaki@guardian.co.uk>

## What does this change?
Adds message id to the failure notification email we send to users when their transcription fails.
Debugging a recent issue based on a failure email forwarded to the team involved digging through logs and s3 in order to find job id based on original file name. This change should make debugging easier by surfacing this information.