### PR TITLE
Worker logs file language, output handler records completion date

### DIFF
--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -37,6 +37,7 @@ export const TranscriptionDynamoItem = z.object({
 	originalFilename: z.string(),
 	transcriptKeys: TranscriptKeys,
 	userEmail: z.string(),
+	completedAt: z.date(),
 });
 
 export type TranscriptionDynamoItem = z.infer<typeof TranscriptionDynamoItem>;

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -59,6 +59,7 @@ const handleTranscriptionSuccess = async (
 			json: transcriptionOutput.outputBucketKeys.json,
 		},
 		userEmail: transcriptionOutput.userEmail,
+		completedAt: new Date(),
 	};
 
 	try {
@@ -142,6 +143,7 @@ const processMessage = async (event: unknown) => {
 	for (const record of parsedEvent.data.Records) {
 		const transcriptionOutput = record.body;
 		if (transcriptionOutputIsSuccess(transcriptionOutput)) {
+			logger.info('handling transcription success');
 			await handleTranscriptionSuccess(
 				config,
 				transcriptionOutput,
@@ -149,6 +151,7 @@ const processMessage = async (event: unknown) => {
 				metrics,
 			);
 		} else {
+			logger.info('handling transcription failure');
 			await handleTranscriptionFailure(
 				config,
 				transcriptionOutput,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -298,6 +298,7 @@ const pollTranscriptionQueue = async (
 				filename: transcriptionOutput.originalFilename,
 				userEmail: transcriptionOutput.userEmail,
 				mediaDurationSeconds: ffmpegResult.duration || 0,
+				specifiedLanguageCode: job.languageCode,
 				...transcriptResult.metadata,
 			},
 		);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -279,7 +279,10 @@ const pollTranscriptionQueue = async (
 		const transcriptionOutput: TranscriptionOutputSuccess = {
 			id: job.id,
 			status: 'SUCCESS',
-			languageCode: transcriptResult.metadata.detectedLanguageCode || 'en',
+			languageCode:
+				job.languageCode === 'auto'
+					? transcriptResult.metadata.detectedLanguageCode || 'UNKNOWN'
+					: job.languageCode,
 			userEmail: job.userEmail,
 			originalFilename: job.originalFilename,
 			outputBucketKeys,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- our tools usage dashboard is broken since switching from autodetected transcription language to user-specified languages in https://github.com/guardian/transcription-service/pull/71 since it relied on autodetected language. This change logs the user-specified language as well as the autodetected one so that the dashboard can be fixed.
- the output handler records completion date of transcription in dynamodb so that we have more specific reporting on usage numbers