### PR TITLE
Make completedAt optional

### DIFF
--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -37,7 +37,7 @@ export const TranscriptionDynamoItem = z.object({
 	originalFilename: z.string(),
 	transcriptKeys: TranscriptKeys,
 	userEmail: z.string(),
-	completedAt: z.string(), // dynamodb can't handle dates so we need to use an ISO date
+	completedAt: z.optional(z.string()), // dynamodb can't handle dates so we need to use an ISO date
 });
 
 export type TranscriptionDynamoItem = z.infer<typeof TranscriptionDynamoItem>;


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/transcription-service/pull/78 - the new completedAt field needs to be optional to allow for any transcriptions completed in the past 7 days. After 7 days we can revert this PR.  

