### PR TITLE
Hotfix: set worker ASG `onDemandPercentageAboveBaseCapacity` to 10

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -395,7 +395,7 @@ export class TranscriptionService extends GuStack {
 						// 0 is the default, including this here just to make it more obvious what's happening
 						onDemandBaseCapacity: 0,
 						// if this value is set to 100, then we won't use spot instances at all, if it is 0 then we use 100% spot
-						onDemandPercentageAboveBaseCapacity: 50,
+						onDemandPercentageAboveBaseCapacity: 10,
 						spotAllocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
 						spotMaxPrice: '0.6202',
 					},

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -395,7 +395,7 @@ export class TranscriptionService extends GuStack {
 						// 0 is the default, including this here just to make it more obvious what's happening
 						onDemandBaseCapacity: 0,
 						// if this value is set to 100, then we won't use spot instances at all, if it is 0 then we use 100% spot
-						onDemandPercentageAboveBaseCapacity: 0,
+						onDemandPercentageAboveBaseCapacity: 50,
 						spotAllocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
 						spotMaxPrice: '0.6202',
 					},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Sets worker autoscaling group on-demand percentage to 10%

## Why
On-demand percentage of the worker ASG is currently 0% so when there are no spot instances available in our AWS region, the ASG is unable to scale with the transcription job queue. This happened over the weekend resulting in a backlog of 14 jobs and a few failed transcriptions. We should keep on-demand percentage at > 0% until we find a way to use 100% spot instances, unless there are none available, in which case we fall back to on-demand instances.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Deployed to prod