### PR TITLE
remove the need for actions-read-private-repos action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,6 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: 'npm'
-      - uses: guardian/actions-read-private-repos@v0.1.1
-        with:
-          private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
       - name: Install dependencies
         run: |
           npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -5795,11 +5795,6 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@guardian/private-infrastructure-config": {
-			"version": "2.3.0",
-			"resolved": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#5242448b2aabea0e5d7c1729d49113709428f5b3",
-			"dev": true
-		},
 		"node_modules/@guardian/transcription-service-backend-common": {
 			"resolved": "packages/backend-common",
 			"link": true
@@ -22327,7 +22322,6 @@
 				"@guardian/cdk": "53.0.3",
 				"@guardian/eslint-config-typescript": "8.0.0",
 				"@guardian/prettier": "5.0.0",
-				"@guardian/private-infrastructure-config": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#5242448b2aabea0e5d7c1729d49113709428f5b3",
 				"@guardian/tsconfig": "^0.2.0",
 				"@types/jest": "^29.5.11",
 				"@types/node": "20.11.5",
@@ -27048,11 +27042,6 @@
 			"dev": true,
 			"requires": {}
 		},
-		"@guardian/private-infrastructure-config": {
-			"version": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#5242448b2aabea0e5d7c1729d49113709428f5b3",
-			"dev": true,
-			"from": "@guardian/private-infrastructure-config@github:guardian/private-infrastructure-config#v2.4.0"
-		},
 		"@guardian/transcription-service-backend-common": {
 			"version": "file:packages/backend-common",
 			"requires": {
@@ -29783,7 +29772,6 @@
 				"@guardian/cdk": "53.0.3",
 				"@guardian/eslint-config-typescript": "8.0.0",
 				"@guardian/prettier": "5.0.0",
-				"@guardian/private-infrastructure-config": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#5242448b2aabea0e5d7c1729d49113709428f5b3",
 				"@guardian/transcription-service-common": "1.0.0",
 				"@guardian/tsconfig": "^0.2.0",
 				"@types/jest": "^29.5.11",

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -21,7 +21,6 @@ import {
 } from '@guardian/cdk/lib/constructs/iam';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
-import { GuardianAwsAccounts } from '@guardian/private-infrastructure-config';
 import { MAX_RECEIVE_COUNT } from '@guardian/transcription-service-common';
 import {
 	type App,
@@ -91,7 +90,7 @@ export class TranscriptionService extends GuStack {
 			},
 		);
 
-		const ssmPrefix = `arn:aws:ssm:${props.env.region}:${GuardianAwsAccounts.Investigations}:parameter`;
+		const ssmPrefix = `arn:aws:ssm:${props.env.region}:${this.account}:parameter`;
 		const ssmPath = `${this.stage}/${this.stack}/${APP_NAME}`;
 		const domainName =
 			this.stage === 'PROD'
@@ -295,7 +294,7 @@ export class TranscriptionService extends GuStack {
 				new GuAllowPolicy(this, 'SetInstanceProtection', {
 					actions: ['autoscaling:SetInstanceProtection'],
 					resources: [
-						`arn:aws:autoscaling:${props.env.region}:${GuardianAwsAccounts.Investigations}:autoScalingGroup:*:autoScalingGroupName/${autoScalingGroupName}`,
+						`arn:aws:autoscaling:${props.env.region}:${this.account}:autoScalingGroup:*:autoScalingGroupName/${autoScalingGroupName}`,
 					],
 				}),
 				new GuAllowPolicy(this, 'WriteCloudwatch', {

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -19,7 +19,6 @@
 		"@guardian/cdk": "53.0.3",
 		"@guardian/eslint-config-typescript": "8.0.0",
 		"@guardian/prettier": "5.0.0",
-		"@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.4.0",
 		"@guardian/tsconfig": "^0.2.0",
 		"@types/jest": "^29.5.11",
 		"@types/node": "20.11.5",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR 
- removes `@guardian/private-infrastructure-config` dependancy. We were using this dependancy to retrieve the account id, now we are retrieving the account id from `this.account` instead. 
- removes the github action `guardian/actions-read-private-repos`. This action was only needed to access the `@guardian/private-infrastructure-config` dependancy

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Tested in code