### PR TITLE
Raise long-running worker alarm threshold to 12 hours

### DIFF
--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -482,30 +482,6 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "TranscriptDestinationTopic831E3125": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/transcription-service",
-          },
-          {
-            "Key": "Stack",
-            "Value": "investigations",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "TopicName": "transcription-service-destination-topic-TEST",
-      },
-      "Type": "AWS::SNS::Topic",
-    },
     "TranscriptTableA6F8B506": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -750,7 +726,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
         "MixedInstancesPolicy": {
           "InstancesDistribution": {
             "OnDemandBaseCapacity": 0,
-            "OnDemandPercentageAboveBaseCapacity": 0,
+            "OnDemandPercentageAboveBaseCapacity": 50,
             "SpotAllocationStrategy": "capacity-optimized",
             "SpotMaxPrice": "0.6202",
           },
@@ -773,7 +749,6 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
             ],
           },
         },
-        "NewInstancesProtectedFromScaleIn": true,
         "Tags": [
           {
             "Key": "App",
@@ -1022,10 +997,13 @@ service transcription-service-worker start",
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "sns:Publish",
+              "Action": "sqs:SendMessage",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "TranscriptDestinationTopic831E3125",
+                "Fn::GetAtt": [
+                  "transcriptionserviceoutputqueue2A0B1C70",
+                  "Arn",
+                ],
               },
             },
           ],
@@ -2106,59 +2084,6 @@ service transcription-service-worker start",
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
-    },
-    "transcriptionserviceoutputqueuePolicyF172243A": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sqs:SendMessage",
-              "Condition": {
-                "ArnEquals": {
-                  "aws:SourceArn": {
-                    "Ref": "TranscriptDestinationTopic831E3125",
-                  },
-                },
-              },
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "sns.amazonaws.com",
-              },
-              "Resource": {
-                "Fn::GetAtt": [
-                  "transcriptionserviceoutputqueue2A0B1C70",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Queues": [
-          {
-            "Ref": "transcriptionserviceoutputqueue2A0B1C70",
-          },
-        ],
-      },
-      "Type": "AWS::SQS::QueuePolicy",
-    },
-    "transcriptionserviceoutputqueueTranscriptionServiceTranscriptDestinationTopicB4E201A61D45605F": {
-      "DependsOn": [
-        "transcriptionserviceoutputqueuePolicyF172243A",
-      ],
-      "Properties": {
-        "Endpoint": {
-          "Fn::GetAtt": [
-            "transcriptionserviceoutputqueue2A0B1C70",
-            "Arn",
-          ],
-        },
-        "Protocol": "sqs",
-        "TopicArn": {
-          "Ref": "TranscriptDestinationTopic831E3125",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
     },
     "transcriptionservicetaskdeadletterqueue8A13A1F1": {
       "DeletionPolicy": "Delete",

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -610,7 +610,7 @@ export class TranscriptionService extends GuStack {
 					treatMissingData: TreatMissingData.IGNORE,
 				}),
 				// alarm when at least one instance has been running in the worker asg during every 5 minute period for
-				// more than 5 hours
+				// more than 12 hours
 				new Alarm(this, 'WorkerInstanceAlarm', {
 					alarmName: `transcription-service-worker-instances-${props.stage}`,
 					// this doesn't actually create the metric - just a reference to it
@@ -626,10 +626,11 @@ export class TranscriptionService extends GuStack {
 					threshold: 1,
 					comparisonOperator:
 						ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-					evaluationPeriods: 5 * 12, // 5 hours as metric has period of 5 minutes
+					evaluationPeriods: 12 * 12, // 12 hours as metric has period of 5 minutes
 					actionsEnabled: true,
-					alarmDescription:
-						'There has been more than 1 worker instance running for 5 hours - this will have significant cost implications. Please check that all running workers are doing something useful.',
+					alarmDescription: `There has been at least 1 worker instance running for 12 hours.
+						This could mean that a worker is failing to be scaled in, which could have significant cost implications.
+						Please check that all running workers are doing something useful.`,
 					treatMissingData: TreatMissingData.IGNORE,
 				}),
 			];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
When “transcription-service-worker-instances-PROD“ is in alarm, it is usually a false positive. The alarm is triggered when the capacity of the ASG is at least 1 for a period of 5 hours. Since the service is used so heavily, this is not an uncommon occurrence during business hours.

Now that the transcription service is stable, we're raising the threshold from at “least one instance running for 5 hours” to  “at least one instance running for 12 hours”?

We also considered a change to the worker-capacity-manager to describe all instances of the ASG, then find if any of them was older than x hours. This would be a more useful, descriptive alarm, but we've decided to forego this idea for the moment   in favor of other priorities.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- [ ] test in code
