### PR TITLE
Add padding under main div to ensure space for footer

### DIFF
--- a/packages/client/src/app/layout.tsx
+++ b/packages/client/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
 					</div>
 				</header>
 				<main>
-					<div className="mx-auto max-w-7xl py-6 sm:px-6 lg:px-8 px-4">
+					<div className="mx-auto max-w-7xl py-6 sm:px-6 lg:px-8 px-4 pb-20">
 						{children}
 					</div>
 				</main>


### PR DESCRIPTION

## What does this change?
This PR resolves a bug where on certain phone screens you can't click the submit button because the 'about this tool' footer thing gets in the way. As the footer is absolutely positioned it will go on top of the submit button. We resolve this by adding some padding 🥳 


## How to test
Use a 'short and wide' phone layout to reproduce the bug