### PR TITLE
Support translation

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -125,6 +125,7 @@ const getApp = async () => {
 				body.data.fileName,
 				signedUrl,
 				body.data.languageCode,
+				body.data.translationRequested,
 			);
 			if (isSqsFailure(sendResult)) {
 				res.status(500).send(sendResult.errorMsg);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -233,7 +233,7 @@ const getApp = async () => {
 			}
 			const exportResult = await createTranscriptDocument(
 				config,
-				`${parsedItem.data.originalFilename} transcript`,
+				`${parsedItem.data.originalFilename} transcript${parsedItem.data.isTranslation ? ' translation' : ''}`,
 				exportRequest.data.oAuthTokenResponse,
 				transcriptText.text,
 			);

--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -38,6 +38,7 @@ export const TranscriptionDynamoItem = z.object({
 	transcriptKeys: TranscriptKeys,
 	userEmail: z.string(),
 	completedAt: z.optional(z.string()), // dynamodb can't handle dates so we need to use an ISO date
+	isTranslation: z.boolean(),
 });
 
 export type TranscriptionDynamoItem = z.infer<typeof TranscriptionDynamoItem>;

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -73,8 +73,8 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		region,
 		outputBucket,
 		userEmail,
-		originalFilename,
 		7,
+		translate,
 	);
 
 	const jobId = translate ? `${s3Key}-translation` : s3Key;
@@ -281,13 +281,14 @@ const generateOutputSignedUrls = async (
 	region: string,
 	outputBucket: string,
 	userEmail: string,
-	originalFilename: string,
 	expiresInDays: number,
+	translate: boolean,
 ): Promise<OutputBucketUrls> => {
+	const fileName = `${id}${translate ? '-translation' : ''}`;
 	const expiresIn = expiresInDays * 24 * 60 * 60;
-	const srtKey = `srt/${id}.srt`;
-	const jsonKey = `json/${id}.json`;
-	const textKey = `text/${id}.txt`;
+	const srtKey = `srt/${fileName}.srt`;
+	const jsonKey = `json/${fileName}.json`;
+	const textKey = `text/${fileName}.txt`;
 	const srtSignedS3Url = await getSignedUploadUrl(
 		region,
 		outputBucket,

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -9,7 +9,7 @@ import {
 	TranscribeFileRequestBody,
 } from '@guardian/transcription-service-common';
 import { AuthContext } from '@/app/template';
-import { FileInput, Label, Select } from 'flowbite-react';
+import { Checkbox, FileInput, Label, Select } from 'flowbite-react';
 import { RequestStatus } from '@/types';
 import { iconForStatus, InfoMessage } from '@/components/InfoMessage';
 
@@ -17,6 +17,7 @@ const uploadFileAndTranscribe = async (
 	file: File,
 	token: string,
 	languageCode: LanguageCode,
+	translationRequested: boolean,
 ) => {
 	const blob = new Blob([file as BlobPart]);
 
@@ -42,6 +43,7 @@ const uploadFileAndTranscribe = async (
 		s3Key: body.data.s3Key,
 		fileName: file.name,
 		languageCode,
+		translationRequested,
 	};
 
 	const sendMessageResponse = await authFetch('/api/transcribe-file', token, {
@@ -83,6 +85,8 @@ export const UploadForm = () => {
 	const [languageCodeValid, setLanguageCodeValid] = useState<
 		boolean | undefined
 	>(undefined);
+	const [translationRequested, setTranslationRequested] =
+		useState<boolean>(false);
 	const { token } = useContext(AuthContext);
 
 	const reset = () => {
@@ -143,10 +147,18 @@ export const UploadForm = () => {
 							role="alert"
 						>
 							<span className="font-medium">Upload complete. </span>{' '}
-							Transcription in progress - check your email for the completed
-							transcript. The service can take a few minutes to start up, but
-							thereafter the transcription process is typically shorter than the
-							length of the media file.{' '}
+							<p>
+								Transcription in progress - check your email for the completed
+								transcript. The service can take a few minutes to start up, but
+								thereafter the transcription process is typically shorter than
+								the length of the media file.{' '}
+							</p>
+							<p>
+								If you have requested a translation, you will receive 2 emails -
+								one for the transcription in the original language, another for
+								the english translation. The emails will arrive at different
+								times
+							</p>
 							<button
 								onClick={() => reset()}
 								className="font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline"
@@ -191,6 +203,7 @@ export const UploadForm = () => {
 				file,
 				token,
 				mediaFileLanguageCode,
+				translationRequested,
 			);
 			if (!result) {
 				setUploads((prev) =>
@@ -261,6 +274,30 @@ export const UploadForm = () => {
 						))}
 					</Select>
 				</div>
+				{mediaFileLanguageCode !== 'en' && (
+					<div className="mb-6">
+						<div className="flex gap-2">
+							<div className="flex h-5 items-center">
+								<Checkbox
+									id="translation"
+									checked={translationRequested}
+									onChange={() =>
+										setTranslationRequested(!translationRequested)
+									}
+								/>
+							</div>
+							<div className="flex flex-col">
+								<Label htmlFor="shipping">Request English translation</Label>
+								<div className="text-gray-500 dark:text-gray-300">
+									<span className="text-xs font-normal">
+										You will receive two documents - a transcript in the
+										original language and a translation in English.
+									</span>
+								</div>
+							</div>
+						</div>
+					</div>
+				)}
 				<button
 					type="submit"
 					className="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -149,16 +149,22 @@ export const UploadForm = () => {
 							<span className="font-medium">Upload complete. </span>{' '}
 							<p>
 								Transcription in progress - check your email for the completed
-								transcript. The service can take a few minutes to start up, but
-								thereafter the transcription process is typically shorter than
-								the length of the media file.{' '}
+								transcript.{' '}
 							</p>
-							<p>
-								If you have requested a translation, you will receive 2 emails -
-								one for the transcription in the original language, another for
-								the english translation. The emails will arrive at different
-								times
-							</p>
+							<div className="font-medium">
+								<p>
+									{' '}
+									The service can take a few minutes to start up, but thereafter
+									the transcription process is typically shorter than the length
+									of the media file.{' '}
+								</p>
+								<p>
+									If you have requested a translation, you will receive 2 emails
+									- one for the transcription in the original language, another
+									for the english translation. The emails will arrive at
+									different times
+								</p>
+							</div>
 							<button
 								onClick={() => reset()}
 								className="font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline"

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -45,6 +45,7 @@ export const TranscriptionJob = z.object({
 	transcriptDestinationService: z.nativeEnum(DestinationService),
 	outputBucketUrls: OutputBucketUrls,
 	languageCode: zodLanguageCode,
+	translate: z.boolean(),
 });
 
 export type TranscriptionJob = z.infer<typeof TranscriptionJob>;
@@ -53,6 +54,7 @@ const TranscriptionOutputBase = z.object({
 	id: z.string(),
 	originalFilename: z.string(),
 	userEmail: z.string(),
+	isTranslation: z.boolean(),
 });
 
 export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
@@ -140,6 +142,7 @@ export const transcribeFileRequestBody = z.object({
 	s3Key: z.string(),
 	fileName: z.string(),
 	languageCode: zodLanguageCode,
+	translationRequested: z.boolean(),
 });
 export type TranscribeFileRequestBody = z.infer<
 	typeof transcribeFileRequestBody

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -66,6 +66,7 @@ const handleTranscriptionSuccess = async (
 		},
 		userEmail: transcriptionOutput.userEmail,
 		completedAt: new Date().toISOString(),
+		isTranslation: transcriptionOutput.isTranslation,
 	};
 
 	try {

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -27,18 +27,23 @@ const successMessageBody = (
 	transcriptId: string,
 	originalFilename: string,
 	rootUrl: string,
+	isTranslation: boolean,
 ): string => {
 	const exportUrl = `${rootUrl}/export?transcriptId=${transcriptId}`;
 	return `
-		<h1>Transcript for ${originalFilename} ready</h1>
+		<h1>Transcript ${isTranslation ? 'english translation ' : ''}for ${originalFilename} ready</h1>
 		<p>Click <a href="${exportUrl}">here</a> to export to a google doc.</p>
 		<p><b>Note:</b> transcripts will expire after 7 days. Export your transcript to a doc now if you want to keep it. </p>
 	`;
 };
 
-const failureMessageBody = (originalFilename: string, id: string): string => {
+const failureMessageBody = (
+	originalFilename: string,
+	id: string,
+	isTranslation: boolean,
+): string => {
 	return `
-		<h1>Transcription for ${originalFilename} has failed.</h1>
+		<h1>Transcription  ${isTranslation ? 'english translation ' : ''}for ${originalFilename} has failed.</h1>
 		<p>Please make sure that the file is a valid audio or video file.</p>
 		<p>Contact the digital investigations team for support.</p>
 		<p>Transcription ID: ${id}</p>
@@ -74,11 +79,12 @@ const handleTranscriptionSuccess = async (
 			sesClient,
 			config.app.emailNotificationFromAddress,
 			transcriptionOutput.userEmail,
-			`Transcription complete for ${transcriptionOutput.originalFilename}`,
+			`Transcription ${transcriptionOutput.isTranslation ? 'english translation ' : ''}complete for ${transcriptionOutput.originalFilename}`,
 			successMessageBody(
 				transcriptionOutput.id,
 				transcriptionOutput.originalFilename,
 				config.app.rootUrl,
+				transcriptionOutput.isTranslation,
 			),
 		);
 
@@ -107,10 +113,11 @@ const handleTranscriptionFailure = async (
 			sesClient,
 			config.app.emailNotificationFromAddress,
 			transcriptionOutput.userEmail,
-			`Transcription failed for ${transcriptionOutput.originalFilename}`,
+			`Transcription ${transcriptionOutput.isTranslation ? 'translation ' : ''}failed for ${transcriptionOutput.originalFilename}`,
 			failureMessageBody(
 				transcriptionOutput.originalFilename,
 				transcriptionOutput.id,
+				transcriptionOutput.isTranslation,
 			),
 		);
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -111,6 +111,7 @@ const publishTranscriptionOutputFailure = async (
 		status: 'FAILURE',
 		userEmail: job.userEmail,
 		originalFilename: job.originalFilename,
+		isTranslation: job.translate,
 	};
 	try {
 		await publishTranscriptionOutput(sqsClient, destination, failureMessage);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -251,6 +251,7 @@ const pollTranscriptionQueue = async (
 			numberOfThreads,
 			config.app.stage === 'PROD' ? 'medium' : 'tiny',
 			job.languageCode,
+			job.translate,
 		);
 
 		// if we've received an interrupt signal we don't want to perform a half-finished transcript upload/publish as
@@ -286,6 +287,7 @@ const pollTranscriptionQueue = async (
 			userEmail: job.userEmail,
 			originalFilename: job.originalFilename,
 			outputBucketKeys,
+			isTranslation: job.translate,
 		};
 
 		await publishTranscriptionOutput(

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -192,7 +192,7 @@ export const getTranscriptionText = async (
 
 		return { transcripts, metadata };
 	} catch (error) {
-		logger.error(`Could not read the transcripts result`);
+		logger.error(`Could not read the transcript result`);
 		throw error;
 	}
 };
@@ -254,7 +254,7 @@ export const transcribe = async (
 		const metadata = extractWhisperStderrData(result.stderr);
 		logger.info('Transcription finished successfully', metadata);
 		return {
-			fileName: `${fileName}${translate ? '-translation' : ''}`,
+			fileName: `${fileName}`,
 			metadata,
 		};
 	} catch (error) {

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -168,6 +168,7 @@ export const getTranscriptionText = async (
 	numberOfThreads: number,
 	model: WhisperModel,
 	languageCode: LanguageCode,
+	translate: boolean,
 ): Promise<TranscriptionResult> => {
 	try {
 		const { fileName, metadata } = await transcribe(
@@ -176,6 +177,7 @@ export const getTranscriptionText = async (
 			numberOfThreads,
 			model,
 			languageCode,
+			translate,
 		);
 
 		const srtPath = path.resolve(path.parse(file).dir, `${fileName}.srt`);
@@ -223,6 +225,7 @@ export const transcribe = async (
 	numberOfThreads: number,
 	model: WhisperModel,
 	languageCode: LanguageCode,
+	translate: boolean,
 ) => {
 	const fileName = path.parse(file).name;
 	const containerOutputFilePath = path.resolve(CONTAINER_FOLDER, fileName);
@@ -246,10 +249,14 @@ export const transcribe = async (
 			containerOutputFilePath,
 			'--language',
 			languageCode,
+			`${translate ? '--translate' : ''}`,
 		]);
 		const metadata = extractWhisperStderrData(result.stderr);
 		logger.info('Transcription finished successfully', metadata);
-		return { fileName, metadata };
+		return {
+			fileName: `${fileName}${translate ? '-translation' : ''}`,
+			metadata,
+		};
 	} catch (error) {
 		logger.error(`Transcription failed due to `, error);
 		throw error;


### PR DESCRIPTION
## What does this change?
The library we are using for transcription - [whisper.cpp](https://github.com/ggerganov/whisper.cpp) - supports translation to english.

This PR modifies the transcription tool to make use of this feature. A new checkbox is added to the submission form:

![Screenshot 2024-08-30 at 14 00 12](https://github.com/user-attachments/assets/849bee0d-10bc-48f8-aa6c-c94ed7f925ae)

This value is sent through to the API. If true, then the API will send 2 messages rather than 1 to the queue. The extra message will have the same id but with `-translation` appended. 

The worker then proceeds as normal, but when it finishes and uploads the output text, if it's a translation then `-translation` is appended to each of the json/srt/txt filenames.

The output handler modifies the email subject and message if it's a translation to indicate this:
![Screenshot 2024-08-30 at 14 03 11](https://github.com/user-attachments/assets/cfaab63a-9659-461c-b593-824cb7c23e1c)

The end result is that the user receives 2 emails. Whilst it would be nicer to have just one email with links to both docs, this approach means that they get the transcript as soon as possible, and we don't have to deal with any kind of state management of waiting for one or the other outputs.


## How to test
Tested on CODE
