### PR TITLE
enabling transcription integration for giant

### DIFF
--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -271,7 +271,7 @@ export const parseTranscriptJobMessage = (
 		return job.data;
 	}
 	logger.error(
-		`Failed to parse message ${message.MessageId}, contents: ${message.Body}`,
+		`Failed to parse message ${message.MessageId}, contents: ${message.Body}, errors: ${JSON.stringify(job.error.errors, null, 2)}`,
 	);
 	return undefined;
 };

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -90,6 +90,15 @@ export class TranscriptionService extends GuStack {
 			},
 		);
 
+		const giantTranscriptionOutputQueueArn = new GuStringParameter(
+			this,
+			'GiantTranscriptionOutputQueueArn',
+			{
+				fromSSM: true,
+				default: `/${props.stage}/investigations/GiantTranscriptionOutputQueueArn`,
+			},
+		).valueAsString;
+
 		const ssmPrefix = `arn:aws:ssm:${props.env.region}:${this.account}:parameter`;
 		const ssmPath = `${this.stage}/${this.stack}/${APP_NAME}`;
 		const domainName =
@@ -281,7 +290,10 @@ export class TranscriptionService extends GuStack {
 				}),
 				new GuAllowPolicy(this, 'WriteToDestinationTopic', {
 					actions: ['sqs:SendMessage'],
-					resources: [transcriptionOutputQueue.queueArn],
+					resources: [
+						transcriptionOutputQueue.queueArn,
+						giantTranscriptionOutputQueueArn,
+					],
 				}),
 				new GuAllowPolicy(this, 'WriteToELK', {
 					actions: [

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -11,6 +11,7 @@ const zodLanguageCode = z.enum(getKeys(languageCodeToLanguage));
 
 export enum DestinationService {
 	TranscriptionService = 'TranscriptionService',
+	Giant = 'Giant',
 }
 
 const SignedUrl = z.object({

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -47,6 +47,8 @@ export const TranscriptionJob = z.object({
 	outputBucketUrls: OutputBucketUrls,
 	languageCode: zodLanguageCode,
 	translate: z.boolean(),
+	// we can get rid of this when we switch to using a zip
+	translationOutputBucketUrls: z.optional(OutputBucketUrls),
 });
 
 export type TranscriptionJob = z.infer<typeof TranscriptionJob>;
@@ -62,6 +64,8 @@ export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
 	status: z.literal('SUCCESS'),
 	languageCode: z.string(),
 	outputBucketKeys: OutputBucketKeys,
+	// we can get rid of this when we switch to using a zip
+	translationOutputBucketKeys: z.optional(OutputBucketKeys),
 });
 
 export const TranscriptionOutputFailure = TranscriptionOutputBase.extend({

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -315,11 +315,12 @@ const pollTranscriptionQueue = async (
 			userEmail: job.userEmail,
 			originalFilename: job.originalFilename,
 			outputBucketKeys,
-			translationOutputBucketKeys: job.translationOutputBucketUrls && {
-				srt: job.translationOutputBucketUrls.srt.key,
-				json: job.translationOutputBucketUrls.json.key,
-				text: job.translationOutputBucketUrls.text.key,
-			},
+			translationOutputBucketKeys: job.translationOutputBucketUrls &&
+				transcriptResult.transcriptTranslations && {
+					srt: job.translationOutputBucketUrls.srt.key,
+					json: job.translationOutputBucketUrls.json.key,
+					text: job.translationOutputBucketUrls.text.key,
+				},
 			isTranslation: job.translate,
 		};
 
@@ -330,7 +331,7 @@ const pollTranscriptionQueue = async (
 		);
 
 		logger.info(
-			'Worker successfully transcribed the file and sent notification to sns',
+			`Worker successfully transcribed the file and sent notification to ${job.transcriptDestinationService} output queue`,
 			{
 				id: transcriptionOutput.id,
 				filename: transcriptionOutput.originalFilename,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -226,7 +226,7 @@ const pollTranscriptionQueue = async (
 			}
 			await publishTranscriptionOutputFailure(
 				sqsClient,
-				config.app.destinationQueueUrls.transcriptionService,
+				config.app.destinationQueueUrls[job.transcriptDestinationService],
 				job,
 			);
 			return;
@@ -293,7 +293,7 @@ const pollTranscriptionQueue = async (
 
 		await publishTranscriptionOutput(
 			sqsClient,
-			config.app.destinationQueueUrls.transcriptionService,
+			config.app.destinationQueueUrls[job.transcriptDestinationService],
 			transcriptionOutput,
 		);
 
@@ -333,7 +333,7 @@ const pollTranscriptionQueue = async (
 		if (receiveCount >= MAX_RECEIVE_COUNT) {
 			await publishTranscriptionOutputFailure(
 				sqsClient,
-				config.app.destinationQueueUrls.transcriptionService,
+				config.app.destinationQueueUrls[job.transcriptDestinationService],
 				job,
 			);
 		}

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -229,6 +229,8 @@ const transcribeAndTranslate = async (
 			false,
 		);
 
+		// we only run language detection once,
+		// so need to override the detected language of future whisper runs
 		transcription.metadata.detectedLanguageCode = metadata.detectedLanguageCode;
 		const translation =
 			languageCode === 'en'

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -222,12 +222,14 @@ const transcribeAndTranslate = async (
 		const dlParams = whisperParams(true, whisperBaseParams.wavPath);
 		const { metadata } = await runWhisper(whisperBaseParams, dlParams);
 		const languageCode =
-			languageCodes.find((c) => c === metadata.detectedLanguageCode) || 'en';
+			languageCodes.find((c) => c === metadata.detectedLanguageCode) || 'auto';
 		const transcription = await runTranscription(
 			whisperBaseParams,
 			languageCode,
 			false,
 		);
+
+		transcription.metadata.detectedLanguageCode = metadata.detectedLanguageCode;
 		const translation =
 			languageCode === 'en'
 				? null

--- a/scripts/delete-local-queues.sh
+++ b/scripts/delete-local-queues.sh
@@ -1,0 +1,7 @@
+#!/bin/zsh
+
+aws sqs delete-queue --queue-url http://localhost:4566/000000000000/transcription-service-task-queue-DEV.fifo --endpoint-url http://localhost:4566
+aws sqs delete-queue --queue-url http://localhost:4566/000000000000/transcription-service-output-queue-DEV --endpoint-url http://localhost:4566
+aws sqs delete-queue --queue-url http://localhost:4566/000000000000/giant-output-dead-letter-queue-DEV.fifo --endpoint-url http://localhost:4566
+aws sqs delete-queue --queue-url http://localhost:4566/000000000000/transcription-service-task-dead-letter-queue-DEV.fifo --endpoint-url http://localhost:4566
+aws sqs delete-queue --queue-url http://localhost:4566/000000000000/giant-output-queue-DEV.fifo --endpoint-url http://localhost:4566

--- a/scripts/delete-local-queues.sh
+++ b/scripts/delete-local-queues.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#/usr/bin/env bash
 
 aws sqs delete-queue --queue-url http://localhost:4566/000000000000/transcription-service-task-queue-DEV.fifo --endpoint-url http://localhost:4566
 aws sqs delete-queue --queue-url http://localhost:4566/000000000000/transcription-service-output-queue-DEV --endpoint-url http://localhost:4566

--- a/scripts/purge-local-queue.sh
+++ b/scripts/purge-local-queue.sh
@@ -1,4 +1,0 @@
-#!/bin/zsh
-
-aws sqs purge-queue --queue-url http://localhost:4566/000000000000/transcription-service-task-queue-DEV.fifo --endpoint-url http://localhost:4566
-aws sqs purge-queue --queue-url http://localhost:4566/000000000000/giant-output-queue-DEV.fifo --endpoint-url http://localhost:4566

--- a/scripts/purge-local-queue.sh
+++ b/scripts/purge-local-queue.sh
@@ -1,4 +1,4 @@
 #!/bin/zsh
 
 aws sqs purge-queue --queue-url http://localhost:4566/000000000000/transcription-service-task-queue-DEV.fifo --endpoint-url http://localhost:4566
-aws sqs purge-queue --queue-url http://localhost:4566/000000000000/giant-output-queue-DEV --endpoint-url http://localhost:4566
+aws sqs purge-queue --queue-url http://localhost:4566/000000000000/giant-output-queue-DEV.fifo --endpoint-url http://localhost:4566

--- a/scripts/purge-local-queue.sh
+++ b/scripts/purge-local-queue.sh
@@ -1,3 +1,4 @@
 #!/bin/zsh
 
 aws sqs purge-queue --queue-url http://localhost:4566/000000000000/transcription-service-task-queue-DEV.fifo --endpoint-url http://localhost:4566
+aws sqs purge-queue --queue-url http://localhost:4566/000000000000/giant-output-queue-DEV --endpoint-url http://localhost:4566

--- a/scripts/purge-local-queues.sh
+++ b/scripts/purge-local-queues.sh
@@ -1,0 +1,7 @@
+#!/bin/zsh
+
+aws sqs purge-queue --queue-url http://localhost:4566/000000000000/transcription-service-task-queue-DEV.fifo --endpoint-url http://localhost:4566
+aws sqs purge-queue --queue-url http://localhost:4566/000000000000/transcription-service-output-queue-DEV --endpoint-url http://localhost:4566
+aws sqs purge-queue --queue-url http://localhost:4566/000000000000/giant-output-dead-letter-queue-DEV.fifo --endpoint-url http://localhost:4566
+aws sqs purge-queue --queue-url http://localhost:4566/000000000000/transcription-service-task-dead-letter-queue-DEV.fifo --endpoint-url http://localhost:4566
+aws sqs purge-queue --queue-url http://localhost:4566/000000000000/giant-output-queue-DEV.fifo --endpoint-url http://localhost:4566

--- a/scripts/purge-local-queues.sh
+++ b/scripts/purge-local-queues.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#/usr/bin/env bash
 
 aws sqs purge-queue --queue-url http://localhost:4566/000000000000/transcription-service-task-queue-DEV.fifo --endpoint-url http://localhost:4566
 aws sqs purge-queue --queue-url http://localhost:4566/000000000000/transcription-service-output-queue-DEV --endpoint-url http://localhost:4566

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -37,6 +37,20 @@ OUTPUT_QUEUE_URL_LOCALHOST=${OUTPUT_QUEUE_URL/sqs.eu-west-1.localhost.localstack
 
 echo "Created queue in localstack, url: ${OUTPUT_QUEUE_URL_LOCALHOST}"
 
+# ###########
+# Create output queue for Giant:
+# Giant is a service that uses transcription service to transcribe its audio/video files.
+# Giant pushes messages to the transcription input queue 'transcription-service-task-queue-DEV.fifo'
+# and transcription worker pushes the giant transcripts into the giant output queue 'giant-output-queue-DEV'.
+# Since creating multiple localstack containers could add complication, and localstack is
+# only needed for local running, the giant output queue is created in the localstack created for transcription service.
+# ###########
+OUTPUT_QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=giant-output-queue-DEV | jq .QueueUrl)
+# We don't install the localstack dns so need to replace the endpoint with localhost
+OUTPUT_QUEUE_URL_LOCALHOST=${OUTPUT_QUEUE_URL/sqs.eu-west-1.localhost.localstack.cloud/localhost}
+
+echo "Created queue in localstack, url: ${OUTPUT_QUEUE_URL_LOCALHOST}"
+
 DYNAMODB_ARN=$(aws --endpoint-url=http://localhost:4566 dynamodb create-table \
                                          --table-name ${APP_NAME}-DEV \
                                          --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -45,7 +45,7 @@ echo "Created queue in localstack, url: ${OUTPUT_QUEUE_URL_LOCALHOST}"
 # Since creating multiple localstack containers could add complication, and localstack is
 # only needed for local running, the giant output queue is created in the localstack created for transcription service.
 # ###########
-OUTPUT_QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=giant-output-queue-DEV | jq .QueueUrl)
+OUTPUT_QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=giant-output-queue-DEV.fifo --attributes "FifoQueue=true,ContentBasedDeduplication=true" | jq .QueueUrl)
 # We don't install the localstack dns so need to replace the endpoint with localhost
 OUTPUT_QUEUE_URL_LOCALHOST=${OUTPUT_QUEUE_URL/sqs.eu-west-1.localhost.localstack.cloud/localhost}
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -25,12 +25,33 @@ fi
 docker-compose up -d
 APP_NAME="transcription-service"
 # If the queue already exists this command appears to still work and returns the existing queue url
-QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=$APP_NAME-task-queue-DEV.fifo --attributes "FifoQueue=true,ContentBasedDeduplication=true" | jq .QueueUrl)
+
+#########
+##### task dead letter queue
+#########
+DEAD_LETTER_QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=$APP_NAME-task-dead-letter-queue-DEV.fifo --attributes "FifoQueue=true,ContentBasedDeduplication=true" | jq .QueueUrl)
+# We don't install the localstack dns so need to replace the endpoint with localhost
+DEAD_LETTER_QUEUE_URL_LOCALHOST=${DEAD_LETTER_QUEUE_URL/sqs.eu-west-1.localhost.localstack.cloud/localhost}
+
+echo "Created queue in localstack, url: ${DEAD_LETTER_QUEUE_URL_LOCALHOST}"
+
+#########
+##### task queue
+#########
+QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=$APP_NAME-task-queue-DEV.fifo \
+  --attributes '{
+  "FifoQueue": "true",
+  "ContentBasedDeduplication": "true",
+  "RedrivePolicy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:000000000000:transcription-service-task-dead-letter-queue-DEV.fifo\",\"maxReceiveCount\":\"3\"}"
+  }' | jq .QueueUrl)
 # We don't install the localstack dns so need to replace the endpoint with localhost
 QUEUE_URL_LOCALHOST=${QUEUE_URL/sqs.eu-west-1.localhost.localstack.cloud/localhost}
 
 echo "Created queue in localstack, url: ${QUEUE_URL_LOCALHOST}"
 
+#########
+##### output queue
+#########
 OUTPUT_QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=$APP_NAME-output-queue-DEV | jq .QueueUrl)
 # We don't install the localstack dns so need to replace the endpoint with localhost
 OUTPUT_QUEUE_URL_LOCALHOST=${OUTPUT_QUEUE_URL/sqs.eu-west-1.localhost.localstack.cloud/localhost}
@@ -38,18 +59,38 @@ OUTPUT_QUEUE_URL_LOCALHOST=${OUTPUT_QUEUE_URL/sqs.eu-west-1.localhost.localstack
 echo "Created queue in localstack, url: ${OUTPUT_QUEUE_URL_LOCALHOST}"
 
 # ###########
-# Create output queue for Giant:
+# Creating output queue for Giant:
 # Giant is a service that uses transcription service to transcribe its audio/video files.
 # Giant pushes messages to the transcription input queue 'transcription-service-task-queue-DEV.fifo'
-# and transcription worker pushes the giant transcripts into the giant output queue 'giant-output-queue-DEV'.
+# and transcription worker pushes the resulting transcripts into the giant output queue 'giant-output-queue-DEV.fifo'.
 # Since creating multiple localstack containers could add complication, and localstack is
-# only needed for local running, the giant output queue is created in the localstack created for transcription service.
+# only needed for local running, the giant output queue is created in the transcription service localstack.
 # ###########
-OUTPUT_QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=giant-output-queue-DEV.fifo --attributes "FifoQueue=true,ContentBasedDeduplication=true" | jq .QueueUrl)
-# We don't install the localstack dns so need to replace the endpoint with localhost
-OUTPUT_QUEUE_URL_LOCALHOST=${OUTPUT_QUEUE_URL/sqs.eu-west-1.localhost.localstack.cloud/localhost}
 
-echo "Created queue in localstack, url: ${OUTPUT_QUEUE_URL_LOCALHOST}"
+#########
+##### giant output dead letter queue
+#########
+GIANT_OUTPUT_DEAD_LETTER_QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=giant-output-dead-letter-queue-DEV.fifo --attributes "FifoQueue=true,ContentBasedDeduplication=true" | jq .QueueUrl)
+# We don't install the localstack dns so need to replace the endpoint with localhost
+GIANT_OUTPUT_DEAD_LETTER_QUEUE_URL_LOCALHOST=${GIANT_OUTPUT_DEAD_LETTER_QUEUE_URL/sqs.eu-west-1.localhost.localstack.cloud/localhost}
+
+echo "Created queue in localstack, url: ${GIANT_OUTPUT_DEAD_LETTER_QUEUE_URL_LOCALHOST}"
+
+#########
+##### giant output queue
+#########
+GIANT_OUTPUT_QUEUE_URL=$(aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name=giant-output-queue-DEV.fifo \
+  --attributes '{
+  "FifoQueue": "true",
+  "ContentBasedDeduplication": "true",
+  "RedrivePolicy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:000000000000:giant-output-dead-letter-queue-DEV.fifo\",\"maxReceiveCount\":\"3\"}"
+  }' | jq .QueueUrl)
+
+
+# We don't install the localstack dns so need to replace the endpoint with localhost
+GIANT_OUTPUT_QUEUE_URL_LOCALHOST=${GIANT_OUTPUT_QUEUE_URL/sqs.eu-west-1.localhost.localstack.cloud/localhost}
+
+echo "Created queue in localstack, url: ${GIANT_OUTPUT_QUEUE_URL_LOCALHOST}"
 
 DYNAMODB_ARN=$(aws --endpoint-url=http://localhost:4566 dynamodb create-table \
                                          --table-name ${APP_NAME}-DEV \


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR is enabling transcription service to process messages coming from third parties service (in particular 'Giant'). 
- The config model for `destinationQueueUrls` is updated so that we can now dynamically get the destination value based on if the message is coming from transcription or giant. 
- the worker message output is now published to the relevant service based on the value of `transcriptDestinationService` in the input message
- Added a local dead letter queue for the local task input queue to make it consistent with our code/prod environments
- Added a giant output queue and giant output dead letter queue. In code/prod these queues belong to giant, but in local setup, because adding 2 localstack would have add complication, we decided to have them created as part of the transcription service localstack. 
- Thanks to @philmcmahon for adding logic for translation if the message is coming from giant 🎉

The relevant PRs for this change and the order they need to be released are as followed:
1- https://github.com/guardian/investigations-platform/pull/521
2- current PR
3- https://github.com/guardian/giant/pull/239

The following SSM parameters were created for code but should also be created for prod:
- /CODE/investigations/GiantTranscriptionOutputQueueArn
- /CODE/investigations/transcription-service/destinationQueueUrls/giant
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Tested this both locally and in code