### PR TITLE
 Bump CDK to support having readonlyRootFilesystem set to true #751 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,41 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/@aws-cdk/cloud-assembly-schema": {
+			"version": "38.0.1",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
+			"integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
+			"bundleDependencies": [
+				"jsonschema",
+				"semver"
+			],
+			"dev": true,
+			"dependencies": {
+				"jsonschema": "^1.4.1",
+				"semver": "^7.6.3"
+			}
+		},
+		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+			"version": "1.4.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+			"version": "7.6.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@aws-crypto/crc32": {
 			"version": "5.2.0",
 			"license": "Apache-2.0",
@@ -3057,6 +3092,33 @@
 			"version": "0.2.8",
 			"license": "MIT"
 		},
+		"node_modules/@guardian/cdk": {
+			"version": "61.1.0",
+			"resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-61.1.0.tgz",
+			"integrity": "sha512-4PEyzJuD3Us1XzEIO5wdWdnThK2rqv/8IJOdOc9+oqCoGaC4rvBVAOajHcGRJ2XBrD/YTnZDfSVFH4kIwb+7Tg==",
+			"dev": true,
+			"dependencies": {
+				"@oclif/core": "3.26.6",
+				"aws-sdk": "^2.1692.0",
+				"chalk": "^4.1.2",
+				"codemaker": "^1.106.0",
+				"git-url-parse": "^16.0.0",
+				"js-yaml": "^4.1.0",
+				"lodash.camelcase": "^4.3.0",
+				"lodash.kebabcase": "^4.1.1",
+				"lodash.upperfirst": "^4.3.1",
+				"read-pkg-up": "7.0.1",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"gu-cdk": "bin/gu-cdk"
+			},
+			"peerDependencies": {
+				"aws-cdk": "2.172.0",
+				"aws-cdk-lib": "2.172.0",
+				"constructs": "10.4.2"
+			}
+		},
 		"node_modules/@guardian/eslint-config": {
 			"version": "7.0.1",
 			"dev": true,
@@ -5459,6 +5521,396 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/aws-cdk": {
+			"version": "2.172.0",
+			"resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.172.0.tgz",
+			"integrity": "sha512-kacztcAl12F6zlBqKCuzCZmj4vrbMhzgDAxBB4T7fXR2amQyuu6W0nWcGWWvASXeBJcw2DJ6ulpfV4wuc9dksw==",
+			"dev": true,
+			"bin": {
+				"cdk": "bin/cdk"
+			},
+			"engines": {
+				"node": ">= 14.15.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/aws-cdk-lib": {
+			"version": "2.172.0",
+			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.172.0.tgz",
+			"integrity": "sha512-SbFn2FyKhsHQpS7M3qeMWnRKtBHELkY3rmejk07cPlJ/BCJk/af8eKyeiNEEB0AZSfIeP4ImZCLNy9JS34mlPw==",
+			"bundleDependencies": [
+				"@balena/dockerignore",
+				"case",
+				"fs-extra",
+				"ignore",
+				"jsonschema",
+				"minimatch",
+				"punycode",
+				"semver",
+				"table",
+				"yaml",
+				"mime-types"
+			],
+			"dev": true,
+			"dependencies": {
+				"@aws-cdk/asset-awscli-v1": "^2.2.208",
+				"@aws-cdk/asset-kubectl-v20": "^2.1.3",
+				"@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+				"@aws-cdk/cloud-assembly-schema": "^38.0.1",
+				"@balena/dockerignore": "^1.0.2",
+				"case": "1.6.3",
+				"fs-extra": "^11.2.0",
+				"ignore": "^5.3.2",
+				"jsonschema": "^1.4.1",
+				"mime-types": "^2.1.35",
+				"minimatch": "^3.1.2",
+				"punycode": "^2.3.1",
+				"semver": "^7.6.3",
+				"table": "^6.8.2",
+				"yaml": "1.10.2"
+			},
+			"engines": {
+				"node": ">= 14.15.0"
+			},
+			"peerDependencies": {
+				"constructs": "^10.0.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+			"version": "1.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/aws-cdk-lib/node_modules/ajv": {
+			"version": "8.17.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/astral-regex": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/case": {
+			"version": "1.6.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "(MIT OR GPL-3.0-or-later)",
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/color-convert": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/color-name": {
+			"version": "1.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/aws-cdk-lib/node_modules/concat-map": {
+			"version": "0.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/aws-cdk-lib/node_modules/fast-uri": {
+			"version": "3.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/aws-cdk-lib/node_modules/fs-extra": {
+			"version": "11.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/aws-cdk-lib/node_modules/ignore": {
+			"version": "5.3.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/aws-cdk-lib/node_modules/jsonfile": {
+			"version": "6.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/jsonschema": {
+			"version": "1.4.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+			"version": "4.4.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/aws-cdk-lib/node_modules/mime-db": {
+			"version": "1.52.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/mime-types": {
+			"version": "2.1.35",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/minimatch": {
+			"version": "3.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/punycode": {
+			"version": "2.3.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/require-from-string": {
+			"version": "2.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/semver": {
+			"version": "7.6.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/string-width": {
+			"version": "4.2.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/table": {
+			"version": "6.8.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"ajv": "^8.0.1",
+				"lodash.truncate": "^4.4.2",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/universalify": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/yaml": {
+			"version": "1.10.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/aws-lambda": {
 			"version": "1.0.7",
 			"license": "MIT",
@@ -6248,6 +6700,12 @@
 			"version": "0.0.1",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/constructs": {
+			"version": "10.4.2",
+			"resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
+			"integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
+			"dev": true
 		},
 		"node_modules/content-disposition": {
 			"version": "0.5.4",
@@ -7808,6 +8266,25 @@
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
+		"node_modules/git-up": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/git-up/-/git-up-8.0.0.tgz",
+			"integrity": "sha512-uBI8Zdt1OZlrYfGcSVroLJKgyNNXlgusYFzHk614lTasz35yg2PVpL1RMy0LOO2dcvF9msYW3pRfUSmafZNrjg==",
+			"dev": true,
+			"dependencies": {
+				"is-ssh": "^1.4.0",
+				"parse-url": "^9.2.0"
+			}
+		},
+		"node_modules/git-url-parse": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.0.0.tgz",
+			"integrity": "sha512-Y8iAF0AmCaqXc6a5GYgPQW9ESbncNLOL+CeQAJRhmWUOmnPkKpBYeWYp4mFd3LA5j53CdGDdslzX12yEBVHQQg==",
+			"dev": true,
+			"dependencies": {
+				"git-up": "^8.0.0"
+			}
+		},
 		"node_modules/glob": {
 			"version": "7.2.3",
 			"dev": true,
@@ -8507,8 +8984,9 @@
 		},
 		"node_modules/is-ssh": {
 			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
+			"integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"protocols": "^2.0.1"
 			}
@@ -10582,10 +11060,24 @@
 		},
 		"node_modules/parse-path": {
 			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
+			"integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"protocols": "^2.0.0"
+			}
+		},
+		"node_modules/parse-url": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
+			"integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/parse-path": "^7.0.0",
+				"parse-path": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.13.0"
 			}
 		},
 		"node_modules/parseurl": {
@@ -11020,8 +11512,9 @@
 		},
 		"node_modules/protocols": {
 			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
+			"integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
+			"dev": true
 		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
@@ -13106,7 +13599,7 @@
 				"@guardian/transcription-service-common": "1.0.0"
 			},
 			"devDependencies": {
-				"@guardian/cdk": "61.0.2",
+				"@guardian/cdk": "61.1.0",
 				"@guardian/eslint-config": "7.0.1",
 				"@guardian/eslint-config-typescript": "8.0.0",
 				"@guardian/prettier": "5.0.0",
@@ -13123,68 +13616,6 @@
 				"ts-jest": "^29.1.1",
 				"ts-node": "^10.9.2",
 				"typescript": "5.1.6"
-			}
-		},
-		"packages/cdk/node_modules/@aws-cdk/cloud-assembly-schema": {
-			"version": "38.0.1",
-			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
-			"integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
-			"bundleDependencies": [
-				"jsonschema",
-				"semver"
-			],
-			"dev": true,
-			"dependencies": {
-				"jsonschema": "^1.4.1",
-				"semver": "^7.6.3"
-			}
-		},
-		"packages/cdk/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-			"version": "1.4.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"packages/cdk/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-			"version": "7.6.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"packages/cdk/node_modules/@guardian/cdk": {
-			"version": "61.0.2",
-			"resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-61.0.2.tgz",
-			"integrity": "sha512-PSzi5kZ/aBZ1b2F5sIJW9KAuSzUlOcgThMDxFLpsA0sMK0CvWONRuSHeJAhvQqZx517iw68Qzz2BiuGliMijQg==",
-			"dev": true,
-			"dependencies": {
-				"@oclif/core": "3.26.6",
-				"aws-sdk": "^2.1692.0",
-				"chalk": "^4.1.2",
-				"codemaker": "^1.105.0",
-				"git-url-parse": "^16.0.0",
-				"js-yaml": "^4.1.0",
-				"lodash.camelcase": "^4.3.0",
-				"lodash.kebabcase": "^4.1.1",
-				"lodash.upperfirst": "^4.3.1",
-				"read-pkg-up": "7.0.1",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"gu-cdk": "bin/gu-cdk"
-			},
-			"peerDependencies": {
-				"aws-cdk": "2.172.0",
-				"aws-cdk-lib": "2.172.0",
-				"constructs": "10.4.2"
 			}
 		},
 		"packages/cdk/node_modules/@guardian/eslint-config-typescript": {
@@ -13416,396 +13847,6 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"packages/cdk/node_modules/aws-cdk": {
-			"version": "2.172.0",
-			"resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.172.0.tgz",
-			"integrity": "sha512-kacztcAl12F6zlBqKCuzCZmj4vrbMhzgDAxBB4T7fXR2amQyuu6W0nWcGWWvASXeBJcw2DJ6ulpfV4wuc9dksw==",
-			"dev": true,
-			"bin": {
-				"cdk": "bin/cdk"
-			},
-			"engines": {
-				"node": ">= 14.15.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib": {
-			"version": "2.172.0",
-			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.172.0.tgz",
-			"integrity": "sha512-SbFn2FyKhsHQpS7M3qeMWnRKtBHELkY3rmejk07cPlJ/BCJk/af8eKyeiNEEB0AZSfIeP4ImZCLNy9JS34mlPw==",
-			"bundleDependencies": [
-				"@balena/dockerignore",
-				"case",
-				"fs-extra",
-				"ignore",
-				"jsonschema",
-				"minimatch",
-				"punycode",
-				"semver",
-				"table",
-				"yaml",
-				"mime-types"
-			],
-			"dev": true,
-			"dependencies": {
-				"@aws-cdk/asset-awscli-v1": "^2.2.208",
-				"@aws-cdk/asset-kubectl-v20": "^2.1.3",
-				"@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-				"@aws-cdk/cloud-assembly-schema": "^38.0.1",
-				"@balena/dockerignore": "^1.0.2",
-				"case": "1.6.3",
-				"fs-extra": "^11.2.0",
-				"ignore": "^5.3.2",
-				"jsonschema": "^1.4.1",
-				"mime-types": "^2.1.35",
-				"minimatch": "^3.1.2",
-				"punycode": "^2.3.1",
-				"semver": "^7.6.3",
-				"table": "^6.8.2",
-				"yaml": "1.10.2"
-			},
-			"engines": {
-				"node": ">= 14.15.0"
-			},
-			"peerDependencies": {
-				"constructs": "^10.0.0"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
-			"version": "1.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0"
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/ajv": {
-			"version": "8.17.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/astral-regex": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/case": {
-			"version": "1.6.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "(MIT OR GPL-3.0-or-later)",
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/color-convert": {
-			"version": "2.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/color-name": {
-			"version": "1.1.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/concat-map": {
-			"version": "0.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
-			"version": "3.1.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/fast-uri": {
-			"version": "3.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-3-Clause"
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/fs-extra": {
-			"version": "11.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-			"version": "4.2.11",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/ignore": {
-			"version": "5.3.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonfile": {
-			"version": "6.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonschema": {
-			"version": "1.4.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
-			"version": "4.4.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/mime-db": {
-			"version": "1.52.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/mime-types": {
-			"version": "2.1.35",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/minimatch": {
-			"version": "3.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/punycode": {
-			"version": "2.3.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/require-from-string": {
-			"version": "2.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/semver": {
-			"version": "7.6.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/slice-ansi": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"astral-regex": "^2.0.0",
-				"is-fullwidth-code-point": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/string-width": {
-			"version": "4.2.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/table": {
-			"version": "6.8.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"ajv": "^8.0.1",
-				"lodash.truncate": "^4.4.2",
-				"slice-ansi": "^4.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/universalify": {
-			"version": "2.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"packages/cdk/node_modules/aws-cdk-lib/node_modules/yaml": {
-			"version": "1.10.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"packages/cdk/node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"dev": true,
@@ -13814,12 +13855,6 @@
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
-		},
-		"packages/cdk/node_modules/constructs": {
-			"version": "10.4.2",
-			"resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
-			"integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
-			"dev": true
 		},
 		"packages/cdk/node_modules/doctrine": {
 			"version": "2.1.0",
@@ -13878,25 +13913,6 @@
 				"semver": "bin/semver.js"
 			}
 		},
-		"packages/cdk/node_modules/git-up": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/git-up/-/git-up-8.0.0.tgz",
-			"integrity": "sha512-uBI8Zdt1OZlrYfGcSVroLJKgyNNXlgusYFzHk614lTasz35yg2PVpL1RMy0LOO2dcvF9msYW3pRfUSmafZNrjg==",
-			"dev": true,
-			"dependencies": {
-				"is-ssh": "^1.4.0",
-				"parse-url": "^9.2.0"
-			}
-		},
-		"packages/cdk/node_modules/git-url-parse": {
-			"version": "16.0.0",
-			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.0.0.tgz",
-			"integrity": "sha512-Y8iAF0AmCaqXc6a5GYgPQW9ESbncNLOL+CeQAJRhmWUOmnPkKpBYeWYp4mFd3LA5j53CdGDdslzX12yEBVHQQg==",
-			"dev": true,
-			"dependencies": {
-				"git-up": "^8.0.0"
-			}
-		},
 		"packages/cdk/node_modules/minimatch": {
 			"version": "3.1.2",
 			"dev": true,
@@ -13906,19 +13922,6 @@
 			},
 			"engines": {
 				"node": "*"
-			}
-		},
-		"packages/cdk/node_modules/parse-url": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
-			"integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/parse-path": "^7.0.0",
-				"parse-path": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=14.13.0"
 			}
 		},
 		"packages/cdk/node_modules/typescript": {

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -617,7 +617,7 @@ export class TranscriptionService extends GuStack {
 		mediaDownloadTask.taskDefinition.addVolume(volume);
 		mediaDownloadTask.containerDefinition.addMountPoints({
 			sourceVolume: volume.name,
-			containerPath: '/opt', // needs to match WORKDIR in media-download Dockerfile
+			containerPath: '/media-download', // needs to match DOWNLOAD_DIRECTORY in media-download index.ts
 			readOnly: false,
 		});
 

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -611,6 +611,16 @@ export class TranscriptionService extends GuStack {
 			],
 		});
 
+		const volume = {
+			name: `${mediaDownloadApp}-volume`,
+		};
+		mediaDownloadTask.taskDefinition.addVolume(volume);
+		mediaDownloadTask.containerDefinition.addMountPoints({
+			sourceVolume: volume.name,
+			containerPath: '/opt', // needs to match WORKDIR in media-download Dockerfile
+			readOnly: false,
+		});
+
 		const pipeRole = new Role(this, 'eventbridge-pipe-role', {
 			assumedBy: new ServicePrincipal('pipes.amazonaws.com'),
 		});

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -16,7 +16,7 @@
 		"@guardian/transcription-service-common": "1.0.0"
 	},
 	"devDependencies": {
-		"@guardian/cdk": "61.0.2",
+		"@guardian/cdk": "61.1.0",
 		"@guardian/eslint-config": "7.0.1",
 		"@guardian/eslint-config-typescript": "8.0.0",
 		"@guardian/prettier": "5.0.0",

--- a/packages/media-download/src/index.ts
+++ b/packages/media-download/src/index.ts
@@ -19,7 +19,7 @@ import {
 	MediaDownloadJob,
 } from '@guardian/transcription-service-common';
 
-const DOWNLOAD_DIRECTORY = '/media-download';
+export const MEDIA_DOWNLOAD_WORKING_DIRECTORY = '/media-download';
 
 const uploadToS3 = async (
 	s3Client: S3Client,
@@ -143,7 +143,7 @@ const main = async () => {
 
 	const metadata = await downloadMedia(
 		job.url,
-		DOWNLOAD_DIRECTORY,
+		MEDIA_DOWNLOAD_WORKING_DIRECTORY,
 		job.id,
 		proxyUrl,
 	);

--- a/packages/media-download/src/index.ts
+++ b/packages/media-download/src/index.ts
@@ -19,6 +19,8 @@ import {
 	MediaDownloadJob,
 } from '@guardian/transcription-service-common';
 
+const DOWNLOAD_DIRECTORY = '/media-download';
+
 const uploadToS3 = async (
 	s3Client: S3Client,
 	metadata: MediaMetadata,
@@ -139,7 +141,12 @@ const main = async () => {
 			)
 		: undefined;
 
-	const metadata = await downloadMedia(job.url, '/tmp', job.id, proxyUrl);
+	const metadata = await downloadMedia(
+		job.url,
+		DOWNLOAD_DIRECTORY,
+		job.id,
+		proxyUrl,
+	);
 	if (!metadata) {
 		await reportDownloadFailure(config, sqsClient, job);
 	} else {

--- a/packages/media-download/src/yt-dlp.ts
+++ b/packages/media-download/src/yt-dlp.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { runSpawnCommand } from '@guardian/transcription-service-backend-common/src/process';
 import { logger } from '@guardian/transcription-service-backend-common';
+import { MEDIA_DOWNLOAD_WORKING_DIRECTORY } from './index';
 
 export type MediaMetadata = {
 	title: string;
@@ -26,7 +27,11 @@ export const startProxyTunnel = async (
 	port: number,
 ): Promise<string> => {
 	try {
-		fs.writeFileSync('/tmp/media_download', key + '\n', { mode: 0o600 });
+		fs.writeFileSync(
+			`${MEDIA_DOWNLOAD_WORKING_DIRECTORY}/media_download`,
+			key + '\n',
+			{ mode: 0o600 },
+		);
 		const result = await runSpawnCommand(
 			'startProxyTunnel',
 			'ssh',
@@ -42,7 +47,7 @@ export const startProxyTunnel = async (
 				'-N',
 				'-f',
 				'-i',
-				'/tmp/media_download',
+				`${MEDIA_DOWNLOAD_WORKING_DIRECTORY}/media_download`,
 				`media_download@${ip}`,
 			],
 			true,


### PR DESCRIPTION
## What does this change?
Similar to https://github.com/guardian/lurch/pull/751, this PR disables write access to the root file system for ecs containers used in this project (just the media download service at the moment). This is achieved by bumping the version of GuCDK that the project uses to pull in https://github.com/guardian/cdk/pull/2545

With this in place, we then need to make sure that all file write operations happen inside a separate mounted volume - in this case mounted at /media-download

## How to test
Tested on CODE