### PR TITLE
Improve url form validation

### DIFF
--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -121,26 +121,26 @@ const updateFileStatus = (
 	};
 };
 
-const checkUrlInputValid = (input: MediaUrlInput): MediaUrlInput => {
+const checkUrlValid = (url_input: string): MediaUrlInput => {
 	try {
-		if (input.value === '') {
-			return { value: input.value, status: 'empty' };
+		if (url_input === '') {
+			return { value: url_input, status: 'empty' };
 		}
-		const url = new URL(input.value);
+		const url = new URL(url_input);
 		// we don't want people providing search results pages as yt-dlp will try and fetch every video
 		if (
 			url.pathname.includes('results') &&
 			url.search.includes('search_query')
 		) {
 			return {
-				value: input.value,
+				value: url_input,
 				reason: 'URL is a link to search results. Please link to a video page',
 				status: 'invalid',
 			};
 		}
-		return { value: input.value, status: 'valid' };
+		return { value: url_input, status: 'valid' };
 	} catch {
-		return { ...input, reason: 'Invalid URL', status: 'invalid' };
+		return { value: url_input, reason: 'Invalid URL', status: 'invalid' };
 	}
 };
 
@@ -335,12 +335,7 @@ export const UploadForm = () => {
 											onChange={(e) => {
 												setMediaUrlInputs(
 													mediaUrlInputs.map((input, i) =>
-														i === index
-															? checkUrlInputValid({
-																	...input,
-																	value: e.target.value,
-																})
-															: input,
+														i === index ? checkUrlValid(e.target.value) : input,
 													),
 												);
 											}}

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -323,25 +323,30 @@ export const UploadForm = () => {
 							</div>
 							<div className={'ml-3'}>
 								{mediaUrlInputs.map((input, index) => (
-									<TextInput
-										id={`media-url-${index}`}
-										placeholder="e.g. https://www.youtube.com?v=abc123"
-										className={'mt-1 mb-1'}
-										color={getStatusColor(input)}
-										helperText={input.status === 'invalid' ? input.reason : ''}
-										onChange={(e) => {
-											setMediaUrlInputs(
-												mediaUrlInputs.map((input, i) =>
-													i === index
-														? checkUrlInputValid({
-																...input,
-																value: e.target.value,
-															})
-														: input,
-												),
-											);
-										}}
-									/>
+									<>
+										<TextInput
+											id={`media-url-${index}`}
+											placeholder="e.g. https://www.youtube.com?v=abc123"
+											className={'mt-1 mb-1'}
+											color={getStatusColor(input)}
+											helperText={
+												input.status === 'invalid' ? input.reason : ''
+											}
+											onChange={(e) => {
+												setMediaUrlInputs(
+													mediaUrlInputs.map((input, i) =>
+														i === index
+															? checkUrlInputValid({
+																	...input,
+																	value: e.target.value,
+																})
+															: input,
+													),
+												);
+											}}
+										/>
+										<hr className="h-0.5 my-2 bg-gray-200 border-0 dark:bg-gray-700" />
+									</>
 								))}
 								<Button
 									size={'sm'}

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -55,7 +55,7 @@ const submitMediaUrl = async (
 	});
 	const success = response.status === 200;
 	if (!success) {
-		console.error('Failed to submit urls for transcription');
+		console.error('Failed to submit URLs for transcription');
 		return false;
 	}
 	return true;
@@ -318,7 +318,7 @@ export const UploadForm = () => {
 								<Label
 									className="text-base"
 									htmlFor="media-url"
-									value="Url(s) for transcription"
+									value="URL(s) for transcription"
 								/>
 							</div>
 							<div className={'ml-3'}>
@@ -355,7 +355,7 @@ export const UploadForm = () => {
 									color={'light'}
 								>
 									<PlusIcon className="mr-2 h-5 w-5" />
-									Add url
+									Add URL
 								</Button>
 							</div>
 						</div>

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -333,11 +333,9 @@ export const UploadForm = () => {
 												input.status === 'invalid' ? input.reason : ''
 											}
 											onChange={(e) => {
-												setMediaUrlInputs(
-													mediaUrlInputs.map((input, i) =>
-														i === index ? checkUrlValid(e.target.value) : input,
-													),
-												);
+												const newInputs = [...mediaUrlInputs];
+												newInputs[index] = checkUrlValid(e.target.value);
+												setMediaUrlInputs(newInputs);
 											}}
 										/>
 										<hr className="h-0.5 my-2 bg-gray-200 border-0 dark:bg-gray-700" />

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -15,3 +15,21 @@ export enum RequestStatus {
 	Success = 'Success',
 	Failed = 'Failed',
 }
+
+type MediaUrlInvalid = {
+	status: 'invalid';
+	value: string;
+	reason: string;
+};
+
+type MediaUrlValid = {
+	status: 'valid';
+	value: string;
+};
+
+type MediaUrlEmpty = {
+	status: 'empty';
+	value: string;
+};
+
+export type MediaUrlInput = MediaUrlInvalid | MediaUrlValid | MediaUrlEmpty;


### PR DESCRIPTION
## What does this change?
It would be helpful to perform some client side validation on urls being added to the upload form so that we can, e.g. prevent people submitting invalid urls, or urls to youtube search results (as yt-dlp will then try download everything on the page). 

This PR introduces this, by breaking up the existing 'textarea' into individual input elements, as suggested by @zekehuntergreen ages ago. 

Before:
<img width="1269" alt="Screenshot 2025-01-10 at 16 43 30" src="https://github.com/user-attachments/assets/0c0825e1-d0c7-43a9-81d7-c6037ab71002" />

After:

<img width="1279" alt="Screenshot 2025-01-10 at 16 44 24" src="https://github.com/user-attachments/assets/a772ddf1-83ea-4767-a1ef-e1c6bc7ce800" />

## How to test
You can run just the API and the client locally to test this - though hopefully screenshots make it fairly clear what's going on. I've not tested on CODE yet as I'm waiting for https://github.com/guardian/transcription-service/pull/115 to go out. 