### PR TITLE
Store language code in database

### DIFF
--- a/packages/api/src/export.ts
+++ b/packages/api/src/export.ts
@@ -3,13 +3,13 @@ import {
 	isS3Failure,
 	logger,
 	TranscriptionConfig,
-	TranscriptionDynamoItem,
 } from '@guardian/transcription-service-backend-common';
 import {
 	ExportItems,
 	ExportStatus,
 	ExportStatuses,
 	ExportType,
+	TranscriptionDynamoItem,
 } from '@guardian/transcription-service-common';
 import { uploadToGoogleDocs } from './services/googleDrive';
 import { S3Client } from '@aws-sdk/client-s3';

--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -5,9 +5,8 @@ import {
 	GetCommand,
 } from '@aws-sdk/lib-dynamodb';
 
-import { z } from 'zod';
 import { logger } from '@guardian/transcription-service-backend-common';
-import { ExportStatuses } from '@guardian/transcription-service-common';
+import { TranscriptionDynamoItem } from '@guardian/transcription-service-common';
 
 export const getDynamoClient = (
 	region: string,
@@ -24,27 +23,6 @@ export const getDynamoClient = (
 	const client = new DynamoDBClient(clientConfig);
 	return DynamoDBDocumentClient.from(client);
 };
-
-export const TranscriptKeys = z.object({
-	srt: z.string(),
-	text: z.string(),
-	json: z.string(),
-});
-
-export type TranscriptKeys = z.infer<typeof TranscriptKeys>;
-
-export const TranscriptionDynamoItem = z.object({
-	id: z.string(),
-	originalFilename: z.string(),
-	transcriptKeys: TranscriptKeys,
-	userEmail: z.string(),
-	completedAt: z.optional(z.string()), // dynamodb can't handle dates so we need to use an ISO date
-	isTranslation: z.boolean(),
-	exportStatuses: z.optional(ExportStatuses),
-	languageCode: z.optional(z.string()),
-});
-
-export type TranscriptionDynamoItem = z.infer<typeof TranscriptionDynamoItem>;
 
 export const writeTranscriptionItem = async (
 	client: DynamoDBDocumentClient,

--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -41,6 +41,7 @@ export const TranscriptionDynamoItem = z.object({
 	completedAt: z.optional(z.string()), // dynamodb can't handle dates so we need to use an ISO date
 	isTranslation: z.boolean(),
 	exportStatuses: z.optional(ExportStatuses),
+	languageCode: z.optional(z.string()),
 });
 
 export type TranscriptionDynamoItem = z.infer<typeof TranscriptionDynamoItem>;

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -10,9 +10,9 @@ import {
 	OutputBucketUrls,
 	DestinationService,
 	TranscriptionJob,
-	LanguageCode,
 	TranscriptionOutput,
 	TranscriptionEngine,
+	InputLanguageCode,
 } from '@guardian/transcription-service-common';
 import {
 	getSignedUploadUrl,
@@ -67,7 +67,7 @@ export const generateOutputSignedUrlAndSendMessage = async (
 	userEmail: string,
 	originalFilename: string,
 	inputSignedUrl: string,
-	languageCode: LanguageCode,
+	languageCode: InputLanguageCode,
 	translationRequested: boolean,
 	diarizationRequested: boolean,
 ): Promise<SendResult> => {

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -3,11 +3,11 @@ import React, { useContext, useState } from 'react';
 import {
 	SignedUrlResponseBody,
 	uploadToS3,
-	languageCodeToLanguage,
-	type LanguageCode,
 	languageCodes,
 	TranscribeFileRequestBody,
 	MediaSourceType,
+	InputLanguageCode,
+	languageCodeToLanguageWithAuto,
 } from '@guardian/transcription-service-common';
 import { AuthContext } from '@/app/template';
 import {
@@ -39,7 +39,7 @@ const getStatusColor = (input: MediaUrlInput) => {
 const submitMediaUrl = async (
 	url: string,
 	token: string,
-	languageCode: LanguageCode,
+	languageCode: InputLanguageCode,
 	translationRequested: boolean,
 	diarizationRequested: boolean,
 ) => {
@@ -66,7 +66,7 @@ const submitMediaUrl = async (
 const uploadFileAndTranscribe = async (
 	file: File,
 	token: string,
-	languageCode: LanguageCode,
+	languageCode: InputLanguageCode,
 	translationRequested: boolean,
 	diarizationRequested: boolean,
 ) => {
@@ -161,7 +161,7 @@ export const UploadForm = () => {
 	const [files, setFiles] = useState<FileList | null>(null);
 	const [uploads, setUploads] = useState<Record<string, RequestStatus>>({});
 	const [mediaFileLanguageCode, setMediaFileLanguageCode] = useState<
-		LanguageCode | undefined
+		InputLanguageCode | undefined
 	>(undefined);
 	const [languageCodeValid, setLanguageCodeValid] = useState<
 		boolean | undefined
@@ -308,8 +308,8 @@ export const UploadForm = () => {
 	return (
 		<>
 			<p className={' pb-3 font-light'}>
-				This tool can transcribe both audio and video. You will receive an
-				email when the transcription is ready.
+				This tool can transcribe both audio and video. You will receive an email
+				when the transcription is ready.
 			</p>
 			<form id="media-upload-form" onSubmit={handleSubmit}>
 				<div className={'mb-1'}>
@@ -425,16 +425,16 @@ export const UploadForm = () => {
 								borderColor: languageSelectColor,
 							}}
 							onChange={(e) => {
-								setMediaFileLanguageCode(e.target.value as LanguageCode);
+								setMediaFileLanguageCode(e.target.value as InputLanguageCode);
 								setLanguageCodeValid(true);
 							}}
 						>
 							<option disabled selected>
 								Select a language
 							</option>
-							{languageCodes.map((languageCode: LanguageCode) => (
+							{languageCodes.map((languageCode: InputLanguageCode) => (
 								<option key={languageCode} value={languageCode}>
-									{languageCodeToLanguage[languageCode]}
+									{languageCodeToLanguageWithAuto[languageCode]}
 								</option>
 							))}
 						</Select>

--- a/packages/common/src/languages.ts
+++ b/packages/common/src/languages.ts
@@ -1,10 +1,8 @@
-import { z } from 'zod';
 // languages supported by whisper.cpp
 // copied from
 // https://github.com/ggerganov/whisper.cpp/blob/25d313b38b1f562200f915cd5952555613cd0110/whisper.cpp#L251
 // and values transformed to title case
-export const languageCodeToLanguage = Object.freeze({
-	auto: 'Auto-detect language (not yet recommended)',
+const languageCodeToLanguage = {
 	en: 'English',
 	zh: 'Chinese',
 	de: 'German',
@@ -105,16 +103,24 @@ export const languageCodeToLanguage = Object.freeze({
 	jw: 'Javanese',
 	su: 'Sundanese',
 	yue: 'Cantonese',
+};
+
+export const languageCodeToLanguageWithAuto = Object.freeze({
+	auto: 'Auto-detect language (not yet recommended)',
+	...languageCodeToLanguage,
 });
 
-type LanguageCodeToLanguage = typeof languageCodeToLanguage;
+export const languageCodeToLanguageWithUnknown = Object.freeze({
+	UNKNOWN: 'Detected language not recognised',
+	...languageCodeToLanguage,
+});
 
-// There doesn't seem to be a way to get the object keys that has a type which
-// is an array of a union of string literals rather than an array of strings.
-// https://www.charpeni.com/blog/properly-type-object-keys-and-object-entries
-export const languageCodes = Object.keys(languageCodeToLanguage) as [
-	keyof LanguageCodeToLanguage,
-];
+// thanks https://github.com/colinhacks/zod/discussions/2125#discussioncomment-7452235
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getKeys<T extends Record<string, any>>(obj: T) {
+	return Object.keys(obj) as [keyof typeof obj];
+}
 
-export const LanguageCode = z.enum(languageCodes);
-export type LanguageCode = z.infer<typeof LanguageCode>;
+export const languageCodes = getKeys(languageCodeToLanguage);
+export const inputLanguageCodes = getKeys(languageCodeToLanguageWithAuto);
+export const outputLanguageCodes = getKeys(languageCodeToLanguageWithUnknown);

--- a/packages/common/src/languages.ts
+++ b/packages/common/src/languages.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 // languages supported by whisper.cpp
 // copied from
 // https://github.com/ggerganov/whisper.cpp/blob/25d313b38b1f562200f915cd5952555613cd0110/whisper.cpp#L251
@@ -108,11 +109,12 @@ export const languageCodeToLanguage = Object.freeze({
 
 type LanguageCodeToLanguage = typeof languageCodeToLanguage;
 
-export type LanguageCode = keyof LanguageCodeToLanguage;
-
 // There doesn't seem to be a way to get the object keys that has a type which
 // is an array of a union of string literals rather than an array of strings.
 // https://www.charpeni.com/blog/properly-type-object-keys-and-object-entries
-export const languageCodes = Object.keys(
-	languageCodeToLanguage,
-) as unknown as LanguageCode[];
+export const languageCodes = Object.keys(languageCodeToLanguage) as [
+	keyof LanguageCodeToLanguage,
+];
+
+export const LanguageCode = z.enum(languageCodes);
+export type LanguageCode = z.infer<typeof LanguageCode>;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { languageCodeToLanguage } from './languages';
+import { LanguageCode, languageCodeToLanguage } from './languages';
 
 // thanks https://github.com/colinhacks/zod/discussions/2125#discussioncomment-7452235
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -247,3 +247,24 @@ export type InputBucketObjectMetadata = z.infer<
 >;
 
 export type MediaSourceType = 'file' | 'url';
+
+export const TranscriptKeys = z.object({
+	srt: z.string(),
+	text: z.string(),
+	json: z.string(),
+});
+
+export type TranscriptKeys = z.infer<typeof TranscriptKeys>;
+
+export const TranscriptionDynamoItem = z.object({
+	id: z.string(),
+	originalFilename: z.string(),
+	transcriptKeys: TranscriptKeys,
+	userEmail: z.string(),
+	completedAt: z.optional(z.string()), // dynamodb can't handle dates so we need to use an ISO date
+	isTranslation: z.boolean(),
+	languageCode: z.optional(LanguageCode),
+	exportStatuses: z.optional(ExportStatuses),
+});
+
+export type TranscriptionDynamoItem = z.infer<typeof TranscriptionDynamoItem>;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,13 +1,15 @@
 import { z } from 'zod';
-import { LanguageCode, languageCodeToLanguage } from './languages';
+import { inputLanguageCodes, outputLanguageCodes } from './languages';
 
-// thanks https://github.com/colinhacks/zod/discussions/2125#discussioncomment-7452235
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function getKeys<T extends Record<string, any>>(obj: T) {
-	return Object.keys(obj) as [keyof typeof obj];
-}
+export const InputLanguageCode = z.enum(inputLanguageCodes);
+export type InputLanguageCode = z.infer<typeof InputLanguageCode>;
 
-const zodLanguageCode = z.enum(getKeys(languageCodeToLanguage));
+export const OutputLanguageCode = z.enum(outputLanguageCodes);
+export type OutputLanguageCode = z.infer<typeof OutputLanguageCode>;
+
+export const inputToOutputLanguageCode = (
+	c: InputLanguageCode,
+): OutputLanguageCode => (c === 'auto' ? 'UNKNOWN' : c);
 
 export enum DestinationService {
 	TranscriptionService = 'TranscriptionService',
@@ -41,7 +43,7 @@ export const MediaDownloadJob = z.object({
 	id: z.string(),
 	url: z.string(),
 	userEmail: z.string(),
-	languageCode: zodLanguageCode,
+	languageCode: InputLanguageCode,
 	translationRequested: z.boolean(),
 	diarizationRequested: z.boolean(),
 });
@@ -61,7 +63,7 @@ export const TranscriptionJob = z.object({
 	userEmail: z.string(),
 	transcriptDestinationService: z.nativeEnum(DestinationService),
 	outputBucketUrls: OutputBucketUrls,
-	languageCode: zodLanguageCode,
+	languageCode: InputLanguageCode,
 	translate: z.boolean(),
 	diarize: z.boolean(),
 	engine: z.nativeEnum(TranscriptionEngine),
@@ -80,7 +82,7 @@ const TranscriptionOutputBase = z.object({
 
 export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
 	status: z.literal('SUCCESS'),
-	languageCode: z.string(),
+	languageCode: OutputLanguageCode,
 	outputBucketKeys: OutputBucketKeys,
 	// we can get rid of this when we switch to using a zip
 	translationOutputBucketKeys: z.optional(OutputBucketKeys),
@@ -215,7 +217,7 @@ export type CreateFolderRequest = z.infer<typeof CreateFolderRequest>;
 
 export const transcribeUrlRequestBody = z.object({
 	url: z.string(),
-	languageCode: zodLanguageCode,
+	languageCode: InputLanguageCode,
 	translationRequested: z.boolean(),
 	diarizationRequested: z.boolean(),
 });
@@ -225,7 +227,7 @@ export type TranscribeUrlRequestBody = z.infer<typeof transcribeUrlRequestBody>;
 export const transcribeFileRequestBody = z.object({
 	s3Key: z.string(),
 	fileName: z.string(),
-	languageCode: zodLanguageCode,
+	languageCode: InputLanguageCode,
 	translationRequested: z.boolean(),
 	diarizationRequested: z.boolean(),
 });
@@ -263,7 +265,7 @@ export const TranscriptionDynamoItem = z.object({
 	userEmail: z.string(),
 	completedAt: z.optional(z.string()), // dynamodb can't handle dates so we need to use an ISO date
 	isTranslation: z.boolean(),
-	languageCode: z.optional(LanguageCode),
+	languageCode: z.optional(OutputLanguageCode),
 	exportStatuses: z.optional(ExportStatuses),
 });
 

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -18,7 +18,6 @@ import {
 	TranscriptionOutputFailure,
 	transcriptionOutputIsTranscriptionFailure,
 	TranscriptionDynamoItem,
-	LanguageCode,
 } from '@guardian/transcription-service-common';
 import {
 	MetricsService,
@@ -64,14 +63,6 @@ const handleTranscriptionSuccess = async (
 	metrics: MetricsService,
 	sourceMediaDownloadUrl: string,
 ) => {
-	const languageCode = LanguageCode.safeParse(transcriptionOutput.languageCode);
-	if (!languageCode.success) {
-		logger.error('Failed to parse language code', {
-			languageCode: transcriptionOutput.languageCode,
-		});
-		await metrics.putMetric(FailureMetric);
-		return;
-	}
 	const dynamoItem: TranscriptionDynamoItem = {
 		id: transcriptionOutput.id,
 		originalFilename: transcriptionOutput.originalFilename,
@@ -83,7 +74,7 @@ const handleTranscriptionSuccess = async (
 		userEmail: transcriptionOutput.userEmail,
 		completedAt: new Date().toISOString(),
 		isTranslation: transcriptionOutput.isTranslation,
-		languageCode: languageCode.data,
+		languageCode: transcriptionOutput.languageCode,
 	};
 
 	try {

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -74,6 +74,7 @@ const handleTranscriptionSuccess = async (
 		userEmail: transcriptionOutput.userEmail,
 		completedAt: new Date().toISOString(),
 		isTranslation: transcriptionOutput.isTranslation,
+		languageCode: transcriptionOutput.languageCode,
 	};
 
 	try {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -17,6 +17,7 @@ import {
 import {
 	DestinationService,
 	OutputBucketKeys,
+	OutputLanguageCode,
 	TranscriptionJob,
 	TranscriptionOutputFailure,
 	type TranscriptionOutputSuccess,
@@ -348,6 +349,11 @@ const pollTranscriptionQueue = async (
 			job.engine === 'whisperx',
 		);
 
+		const languageCode: OutputLanguageCode =
+			job.languageCode === 'auto'
+				? transcriptResult.metadata.detectedLanguageCode
+				: job.languageCode;
+
 		// if we've received an interrupt signal we don't want to perform a half-finished transcript upload/publish as
 		// this may, for example, result in duplicate emails to the user. Here we assume that we can upload some text
 		// files to s3 and make a single request to SNS and SQS within 20 seconds
@@ -385,10 +391,7 @@ const pollTranscriptionQueue = async (
 		const transcriptionOutput: TranscriptionOutputSuccess = {
 			id: job.id,
 			status: 'SUCCESS',
-			languageCode:
-				job.languageCode === 'auto'
-					? transcriptResult.metadata.detectedLanguageCode || 'UNKNOWN'
-					: job.languageCode,
+			languageCode,
 			userEmail: job.userEmail,
 			originalFilename: job.originalFilename,
 			outputBucketKeys,


### PR DESCRIPTION
## What does this change?
I'm currently experimenting with https://github.com/m-bain/whisperX. WhisperX appears to [support fewer languages](https://github.com/m-bain/whisperX?tab=readme-ov-file#other-languages) than whisper.cpp. To understand the impact of moving to whisperX this PR sets the transcription service to record the language code of the transcription in the dynamo database.

I made the new field optional in the zod type to avoid breaking existing transcriptions. In a few weeks we could make it compulsory.

## How to test
Tested on CODE