### PR TITLE
Create media export function parameter in cdk

### DIFF
--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -188,6 +188,22 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "ExportFunctionName1C83D756": {
+      "Properties": {
+        "Name": "/TEST/investigations/transcription-service/app/mediaExportFunctionName",
+        "Tags": {
+          "Stack": "investigations",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/transcription-service",
+        },
+        "Type": "String",
+        "Value": {
+          "Ref": "transcriptionservicemediaexport2E32D5D8",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "GetDistributablePolicyTranscriptionserviceworker2DFD604E": {
       "Properties": {
         "PolicyDocument": {

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -75,6 +75,7 @@ import { HttpMethods } from 'aws-cdk-lib/aws-s3';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { JsonPath } from 'aws-cdk-lib/aws-stepfunctions';
 
 const topicArnToName = (topicArn: string) => {
@@ -762,6 +763,11 @@ export class TranscriptionService extends GuStack {
 						: undefined,
 			},
 		);
+
+		new StringParameter(this, 'ExportFunctionName', {
+			parameterName: `/${ssmPath}/app/mediaExportFunctionName`,
+			stringValue: mediaExportLambda.functionName,
+		});
 
 		mediaExportLambda.addToRolePolicy(getParametersPolicy);
 		mediaExportLambda.addToRolePolicy(


### PR DESCRIPTION
## What does this change?

When deploying https://github.com/guardian/transcription-service/pull/115 it didn't work because I left a whitespace character at the end of the mediaExportFunctionName parameter. Since this param just refers to something created in cdk we should create it in cdk.

## How to test
Tested on CODE - need to delete the existing param before deploying this change
