### PR TITLE
Stop auto deleting containers tagged with 'main

### DIFF
--- a/packages/cdk/lib/repository.ts
+++ b/packages/cdk/lib/repository.ts
@@ -58,7 +58,7 @@ export class TranscriptionServiceRepository extends GuStack {
 						rulePriority: 1,
 					},
 					{
-						maxImageCount: 10,
+						maxImageCount: 20,
 						rulePriority: 2,
 					},
 				],

--- a/packages/cdk/lib/repository.ts
+++ b/packages/cdk/lib/repository.ts
@@ -35,14 +35,18 @@ export class TranscriptionServiceRepository extends GuStack {
 			'TranscriptionServiceRepository',
 			{
 				repositoryName: `transcription-service`,
+				// these are confusing - see https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html
 				lifecycleRules: [
+					// keep most recent 20 images tagged with 'main'
 					{
 						tagPrefixList: ['main'],
 						maxImageCount: 20,
 						rulePriority: 1,
 					},
+					// keep 10 most recent images not tagged with 'main'
 					{
 						maxImageCount: 10,
+						rulePriority: 2,
 					},
 				],
 				imageTagMutability: TagMutability.MUTABLE,
@@ -56,12 +60,15 @@ export class TranscriptionServiceRepository extends GuStack {
 			'MediaDownloadRepository',
 			{
 				repositoryName: `transcription-service-media-download`,
+				// these are confusing - see https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html
 				lifecycleRules: [
+					// keep most recent 20 images tagged with 'main'
 					{
 						tagPrefixList: ['main'],
 						maxImageCount: 20,
 						rulePriority: 1,
 					},
+					// keep 10 most recent images not tagged with 'main'
 					{
 						maxImageCount: 10,
 						rulePriority: 2,

--- a/packages/cdk/lib/repository.ts
+++ b/packages/cdk/lib/repository.ts
@@ -37,7 +37,12 @@ export class TranscriptionServiceRepository extends GuStack {
 				repositoryName: `transcription-service`,
 				lifecycleRules: [
 					{
-						maxImageCount: 5,
+						tagPrefixList: ['main'],
+						maxImageCount: undefined,
+						rulePriority: 1,
+					},
+					{
+						maxImageCount: 10,
 					},
 				],
 				imageTagMutability: TagMutability.MUTABLE,
@@ -58,7 +63,7 @@ export class TranscriptionServiceRepository extends GuStack {
 						rulePriority: 1,
 					},
 					{
-						maxImageCount: 20,
+						maxImageCount: 10,
 						rulePriority: 2,
 					},
 				],

--- a/packages/cdk/lib/repository.ts
+++ b/packages/cdk/lib/repository.ts
@@ -38,7 +38,7 @@ export class TranscriptionServiceRepository extends GuStack {
 				lifecycleRules: [
 					{
 						tagPrefixList: ['main'],
-						maxImageCount: undefined,
+						maxImageCount: 20,
 						rulePriority: 1,
 					},
 					{
@@ -59,7 +59,7 @@ export class TranscriptionServiceRepository extends GuStack {
 				lifecycleRules: [
 					{
 						tagPrefixList: ['main'],
-						maxImageCount: undefined,
+						maxImageCount: 20,
 						rulePriority: 1,
 					},
 					{

--- a/packages/cdk/lib/repository.ts
+++ b/packages/cdk/lib/repository.ts
@@ -53,7 +53,13 @@ export class TranscriptionServiceRepository extends GuStack {
 				repositoryName: `transcription-service-media-download`,
 				lifecycleRules: [
 					{
-						maxImageCount: 5,
+						tagPrefixList: ['main'],
+						maxImageCount: undefined,
+						rulePriority: 1,
+					},
+					{
+						maxImageCount: 10,
+						rulePriority: 2,
 					},
 				],
 				imageTagMutability: TagMutability.MUTABLE,


### PR DESCRIPTION
## What does this change?

We currently have a lifecycle rule for our ECR repositories that deletes all but the most recent 5 containers. This is causing problems on PROD, as if a development branch has more than 5 builds then the container tagged with `main` will end up being deleted.

This PR protects containers tagged with `main` from the lifecycle rule.

I've also bumped the number of containers from 5 to 10, 5 seemed a bit small because if you have 2 devs working on 2 branches then they could very quickly end up losing containers needed to test stuff.

## How to test
Deploy this, kick off a few builds, verify that `main` container isn't deleted