### PR TITLE
Use different ID, output urls for translation and transcript

### DIFF
--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -71,7 +71,6 @@ export const generateOutputSignedUrlAndSendMessage = async (
 	translationRequested: boolean,
 	diarizationRequested: boolean,
 ): Promise<SendResult> => {
-	const translationId = `${s3Key}-translation`;
 	const signedUrls = await generateOutputSignedUrls(
 		s3Key,
 		config.aws.region,
@@ -112,6 +111,7 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		return messageResult;
 	}
 	if (!isSqsFailure(messageResult) && translationRequested) {
+		const translationId = `${s3Key}-translation`;
 		const signedUrlsTranslation = await generateOutputSignedUrls(
 			translationId,
 			config.aws.region,
@@ -124,11 +124,11 @@ export const generateOutputSignedUrlAndSendMessage = async (
 			queue,
 			JSON.stringify({
 				...job,
-				id: `${s3Key}-translation`,
+				id: translationId,
 				translate: true,
 				outputBucketUrls: signedUrlsTranslation,
 			}),
-			s3Key,
+			translationId,
 		);
 	}
 	return messageResult;

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -77,7 +77,15 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		config.app.transcriptionOutputBucket,
 		userEmail,
 		7,
-		translationRequested,
+		false,
+	);
+	const signedUrlsTranslation = await generateOutputSignedUrls(
+		s3Key,
+		config.aws.region,
+		config.app.transcriptionOutputBucket,
+		userEmail,
+		7,
+		true,
 	);
 
 	const queue = config.app.useWhisperx
@@ -115,8 +123,12 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		return await sendMessage(
 			client,
 			queue,
-			JSON.stringify({ ...job, id: `${s3Key}-translation`, translate: true }),
-
+			JSON.stringify({
+				...job,
+				id: `${s3Key}-translation`,
+				translate: true,
+				outputBucketUrls: signedUrlsTranslation,
+			}),
 			s3Key,
 		);
 	}

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -84,9 +84,8 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		? config.app.gpuTaskQueueUrl
 		: config.app.taskQueueUrl;
 
-	const jobId = translationRequested ? `${s3Key}-translation` : s3Key;
 	const job: TranscriptionJob = {
-		id: jobId, // id of the source file
+		id: s3Key, // id of the source file
 		inputSignedUrl,
 		sentTimestamp: new Date().toISOString(),
 		userEmail,
@@ -116,7 +115,8 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		return await sendMessage(
 			client,
 			queue,
-			JSON.stringify({ ...job, translate: true }),
+			JSON.stringify({ ...job, id: `${s3Key}-translation`, translate: true }),
+
 			s3Key,
 		);
 	}


### PR DESCRIPTION
## What does this change?
There's a bug in the transcription tool at the moment where both the transcription and the translation end up with the same id, resulting in whichever one finishes last overwriting the other! This fixes that.
