### PR TITLE
Remove g6.xlarge instance type

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -440,7 +440,6 @@ export class TranscriptionService extends GuStack {
 					InstanceType.of(InstanceClass.G4DN, InstanceSize.XLARGE),
 					InstanceType.of(InstanceClass.G4DN, InstanceSize.XLARGE2),
 					InstanceType.of(InstanceClass.G5, InstanceSize.XLARGE),
-					InstanceType.of(InstanceClass.G6, InstanceSize.XLARGE),
 				]
 			: [InstanceType.of(InstanceClass.G4DN, InstanceSize.XLARGE)];
 


### PR DESCRIPTION
## What does this change?
When I tried to deploy the whisperx stuff to PROD I got the cloudformation error "The specified instance type g6.xlarge is not valid"

I think this might just be because we need to enable it for our account (this is sometimes necessary for rarer, expensive instance types) because g6.xlarge definitely is a realy instance type, but for now let's just remove it


This change is already live on PROD