### PR TITLE
Add /tmp volume to media download task container

### DIFF
--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -1803,7 +1803,12 @@ service transcription-service-worker start",
               {
                 "ContainerPath": "/media-download",
                 "ReadOnly": false,
-                "SourceVolume": "media-download-volume",
+                "SourceVolume": "media-download-download-volume",
+              },
+              {
+                "ContainerPath": "/tmp",
+                "ReadOnly": false,
+                "SourceVolume": "media-download-temp-volume",
               },
             ],
             "Name": "media-download-task-TaskContainer",
@@ -1860,7 +1865,10 @@ service transcription-service-worker start",
         },
         "Volumes": [
           {
-            "Name": "media-download-volume",
+            "Name": "media-download-download-volume",
+          },
+          {
+            "Name": "media-download-temp-volume",
           },
         ],
       },

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -619,13 +619,22 @@ export class TranscriptionService extends GuStack {
 			],
 		});
 
-		const volume = {
-			name: `${mediaDownloadApp}-volume`,
+		const downloadVolume = {
+			name: `${mediaDownloadApp}-download-volume`,
 		};
-		mediaDownloadTask.taskDefinition.addVolume(volume);
+		const tempVolume = {
+			name: `${mediaDownloadApp}-temp-volume`,
+		};
+		mediaDownloadTask.taskDefinition.addVolume(downloadVolume);
+		mediaDownloadTask.taskDefinition.addVolume(tempVolume);
 		mediaDownloadTask.containerDefinition.addMountPoints({
-			sourceVolume: volume.name,
+			sourceVolume: downloadVolume.name,
 			containerPath: '/media-download', // needs to match DOWNLOAD_DIRECTORY in media-download index.ts
+			readOnly: false,
+		});
+		mediaDownloadTask.containerDefinition.addMountPoints({
+			sourceVolume: tempVolume.name,
+			containerPath: '/tmp', // needed by yt-dlp
 			readOnly: false,
 		});
 


### PR DESCRIPTION
## What does this change?
I've seen occasionaly failures in the media download service because yt-dlp yt-dlp needs to be able to write to the /tmp directory. In https://github.com/guardian/transcription-service/pull/114 I made the media export filesystem read only, allowing writes to a /media-download mounted volume. This PR adds an extra volume to support writing to /tmp.

## How to test
I've tested this on CODE. As it doesn't happen every time it's hard to test properly but I think it's a fairly harmless change.
