### PR TITLE
Ensure cloudformation deploy succeeds before deploying worker artifact

### DIFF
--- a/packages/cdk/riff-raff.yaml
+++ b/packages/cdk/riff-raff.yaml
@@ -66,6 +66,8 @@ deployments:
       bucketSsmLookup: true
       cacheControl: public, max-age=60
       publicReadAcl: false
+    dependencies:
+      - cfn-eu-west-1-investigations-transcription-service
   lambda-upload-eu-west-1-investigations-transcription-service-output-handler:
     type: aws-lambda
     stacks:


### PR DESCRIPTION
## What does this change?
I spotted an issue recently on CODE where...

 - A [deploy failed](https://riffraff.gutools.co.uk/deployment/view/80ee3a10-db50-41e5-b829-0f8c3183b5aa) due to issues with the cloudformation, but the  transcription-service-worker [uploadStaticFiles] step completed
- Ran a transcription, which failed, because the worker fetched a version of the transcription worker application that was incompatible with the infrastructure it was running on (as the cloudformation step failed)

This change will prevent that from happening, by ensuring that if the cloudformation deploy fails, we don't replace the whisper worker code in s3.

## How to test
Tested on CODE by running a deploy and verifying that the worker deploy waited for the cfn deploy to finish before starting