### PR TITLE
Drop max spot price for gpu instances

### DIFF
--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -665,7 +665,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
             "OnDemandBaseCapacity": 0,
             "OnDemandPercentageAboveBaseCapacity": 10,
             "SpotAllocationStrategy": "capacity-optimized",
-            "SpotMaxPrice": "0.7520",
+            "SpotMaxPrice": "0.5260",
           },
           "LaunchTemplate": {
             "LaunchTemplateSpecification": {
@@ -2104,12 +2104,7 @@ service transcription-service-worker start",
               {
                 "ContainerPath": "/media-download",
                 "ReadOnly": false,
-                "SourceVolume": "media-download-download-volume",
-              },
-              {
-                "ContainerPath": "/tmp",
-                "ReadOnly": false,
-                "SourceVolume": "media-download-temp-volume",
+                "SourceVolume": "media-download-volume",
               },
             ],
             "Name": "media-download-task-TaskContainer",
@@ -2166,10 +2161,7 @@ service transcription-service-worker start",
         },
         "Volumes": [
           {
-            "Name": "media-download-download-volume",
-          },
-          {
-            "Name": "media-download-temp-volume",
+            "Name": "media-download-volume",
           },
         ],
       },

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -503,7 +503,7 @@ export class TranscriptionService extends GuStack {
 					launchTemplate: gpuWorkerLaunchTemplate,
 					instancesDistribution: {
 						...commonInstancesDistributionprops,
-						spotMaxPrice: '0.7520',
+						spotMaxPrice: '0.5260',
 					},
 					launchTemplateOverrides: gpuInstanceTypes.map(instanceTypeToOverride),
 				},


### PR DESCRIPTION
## What does this change?
I think I set the maxSpotPrice too high in https://github.com/guardian/transcription-service/pull/123 - I set it to the 'on demand' price of a g4dn.2xlarge, when whisperx seems to run fine on a g4dn.xlarge. With that in mind, I've dropped the max spot price.

Price details here https://instances.vantage.sh/?filter=g4dn.xlarge|g4dn.2xlarge&compare_on=true&selected=g4dn.xlarge,g4dn.2xlarge

## How to test
Deploy, check for cost savings...