### PR TITLE
Use original file name when downloading source media

### DIFF
--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -55,6 +55,12 @@ export const getSignedUploadUrl = (
 	);
 };
 
+const sanitizeFilename = (filename: string) => {
+	let sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, '_');
+	sanitized = sanitized.substring(0, 255);
+	return sanitized;
+};
+
 export const getSignedDownloadUrl = async (
 	region: string,
 	bucket: string,
@@ -63,7 +69,7 @@ export const getSignedDownloadUrl = async (
 	overrideFilename?: string,
 ) => {
 	const responseContentDisposition = overrideFilename
-		? `attachment; filename="${overrideFilename}"`
+		? `attachment; filename="${sanitizeFilename(overrideFilename)}"`
 		: undefined;
 	return await getSignedUrlSdk(
 		getS3Client(region),

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -60,15 +60,21 @@ export const getSignedDownloadUrl = async (
 	bucket: string,
 	key: string,
 	expiresIn: number,
-) =>
-	await getSignedUrlSdk(
+	overrideFilename?: string,
+) => {
+	const responseContentDisposition = overrideFilename
+		? `attachment; filename="${overrideFilename}"`
+		: undefined;
+	return await getSignedUrlSdk(
 		getS3Client(region),
 		new GetObjectCommand({
 			Bucket: bucket,
 			Key: key,
+			ResponseContentDisposition: responseContentDisposition,
 		}),
 		{ expiresIn }, // override default expiration time of 15 minutes
 	);
+};
 
 type GetObjectTextSuccess = {
 	status: AWSStatus.Success;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -98,6 +98,7 @@ export type MediaDownloadFailure = z.infer<typeof MediaDownloadFailure>;
 
 export const TranscriptionOutputFailure = TranscriptionOutputBase.extend({
 	status: z.literal('TRANSCRIPTION_FAILURE'),
+	id: z.string(),
 });
 
 export const TranscriptionOutput = z.union([
@@ -120,7 +121,7 @@ export const transcriptionOutputIsSuccess = (
 
 export const transcriptionOutputIsTranscriptionFailure = (
 	output: TranscriptionOutput,
-): output is TranscriptionOutputSuccess =>
+): output is TranscriptionOutputFailure =>
 	output.status === 'TRANSCRIPTION_FAILURE';
 
 export type TranscriptionOutput = z.infer<typeof TranscriptionOutput>;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -98,7 +98,6 @@ export type MediaDownloadFailure = z.infer<typeof MediaDownloadFailure>;
 
 export const TranscriptionOutputFailure = TranscriptionOutputBase.extend({
 	status: z.literal('TRANSCRIPTION_FAILURE'),
-	id: z.string(),
 });
 
 export const TranscriptionOutput = z.union([

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -190,6 +190,7 @@ const processMessage = async (event: unknown) => {
 				config.app.sourceMediaBucket,
 				transcriptionOutput.id,
 				7 * 24 * 60 * 60,
+				transcriptionOutput.originalFilename,
 			);
 			await handleTranscriptionFailure(
 				config,

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -165,14 +165,15 @@ const processMessage = async (event: unknown) => {
 
 	for (const record of parsedEvent.data.Records) {
 		const transcriptionOutput = record.body;
-		const sourceMediaDownloadUrl = await getSignedDownloadUrl(
-			config.aws.region,
-			config.app.sourceMediaBucket,
-			transcriptionOutput.id,
-			7 * 24 * 60 * 60,
-		);
 		if (transcriptionOutputIsSuccess(transcriptionOutput)) {
-			logger.info('handling transcription success');
+			const sourceMediaDownloadUrl = await getSignedDownloadUrl(
+				config.aws.region,
+				config.app.sourceMediaBucket,
+				transcriptionOutput.id,
+				7 * 24 * 60 * 60,
+				transcriptionOutput.originalFilename,
+			);
+			logger.info(`handling transcription success`);
 			await handleTranscriptionSuccess(
 				config,
 				transcriptionOutput,
@@ -181,7 +182,15 @@ const processMessage = async (event: unknown) => {
 				sourceMediaDownloadUrl,
 			);
 		} else if (transcriptionOutputIsTranscriptionFailure(transcriptionOutput)) {
-			logger.info('handling transcription failure');
+			logger.info(
+				`Handling transcription failure. Transcription output: ${JSON.stringify(transcriptionOutput)}`,
+			);
+			const sourceMediaDownloadUrl = await getSignedDownloadUrl(
+				config.aws.region,
+				config.app.sourceMediaBucket,
+				transcriptionOutput.id,
+				7 * 24 * 60 * 60,
+			);
 			await handleTranscriptionFailure(
 				config,
 				transcriptionOutput,


### PR DESCRIPTION
## What does this change?
Currently, when you get an output email from the transcription service and click the link to download source media, you get a file called UUID, which isn't very user friendly. This PR sets the filename to the original filename using the 'Content-Disposition' header https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition


## How to test
Tested on CODE