### PR TITLE
Calculate duration of input files in order to decide which engine to use

### DIFF
--- a/ffmpeg-lambda-layer/README.md
+++ b/ffmpeg-lambda-layer/README.md
@@ -1,0 +1,11 @@
+# ffmpeg lambda layer
+
+Ffmpeg (and ffprobe) are very useful tools for working with media files. In order to make use of them on AWS lambda,
+they need to be provided as a 'lambda layer' (essentially a zip file with the binaries in it).
+
+This folder contains a script to generate the zip file and push it to S3. If you are publishing a new version of the layer
+(e.g. to pull in some updates to ffmpeg) then you will need to run this script, and then update the FFMpegLayerZipKey
+parameter on the transcription-service stack.
+
+It probably would be possible to automate this process, but as we don't expect many updates to ffmpeg (I imagine it will
+only be necessary when we want to support new media codecs etc), I haven't bothered.

--- a/ffmpeg-lambda-layer/publish-ffmpeg-layer.sh
+++ b/ffmpeg-lambda-layer/publish-ffmpeg-layer.sh
@@ -3,6 +3,10 @@
 set +x
 set -e
 
+echo ""
+echo "Downloading ffmpeg release and bundling for lambda layer..."
+echo ""
+
 WORKING_DIRECTORY="ffmpeg-layer-build"
 mkdir -p $WORKING_DIRECTORY
 
@@ -16,14 +20,20 @@ tar -xf ffmpeg-release-amd64-static.tar.xz
 mkdir -p ffmpeg/bin
 mkdir -p ffprobe/bin
 
-cp ffmpeg-7.0.2-amd64-static/ffmpeg ffmpeg/bin/
-cp ffmpeg-7.0.2-amd64-static/ffprobe ffprobe/bin/
+mkdir -p bin
 
-zip -r ffmpeg_x86_64.zip ffmpeg ffprobe
+cp ffmpeg-7.0.2-amd64-static/ffmpeg bin/
+cp ffmpeg-7.0.2-amd64-static/ffprobe bin/
+
+zip -r ffmpeg_x86_64.zip bin
 
 HASH=$(md5sum ffmpeg_x86_64.zip | cut -d ' ' -f 1)
-mv ffmpeg_x86_64.zip ffmpeg_x86_64-$HASH.zip
+NAME_WITH_HASH="ffmpeg_x86_64-$HASH.zip"
+mv ffmpeg_x86_64.zip $NAME_WITH_HASH
 
-aws s3 cp ffmpeg_x86_64-$HASH.zip s3://transcription-service-lambda-layers/ffmpeg_x86_64-$HASH.zip
+aws s3 cp ffmpeg_x86_64-$HASH.zip "s3://transcription-service-lambda-layers/${NAME_WITH_HASH}"
 popd
 rm -rf $WORKING_DIRECTORY
+
+echo ""
+echo "Layer zip key: ${NAME_WITH_HASH} - to use this layer you will need to update the FFMpegLayerZipKey parameter in the transcription-service stack"

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -48,6 +48,7 @@ import {
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { invokeLambda } from './services/lambda';
 import { LambdaClient } from '@aws-sdk/client-lambda';
+import { exec } from 'node:child_process';
 
 const runningOnAws = process.env['AWS_EXECUTION_ENV'];
 const emulateProductionLocally =
@@ -386,6 +387,21 @@ const getApp = async () => {
 			res.set('Cache-Control', 'no-cache');
 			const responseBody: SignedUrlResponseBody = { presignedS3Url, s3Key };
 			res.send(responseBody);
+		}),
+	]);
+
+	apiRouter.get('/test-ffmpeg', [
+		// checkAuth,
+		asyncHandler(async (req, res) => {
+			exec('ffmpeg -version', (error, stdout, stderr) => {
+				console.log(stdout);
+				console.log(stderr);
+				if (error) {
+					console.error(`exec error: ${error}`);
+					return;
+				}
+				res.send('Ok');
+			});
 		}),
 	]);
 

--- a/packages/backend-common/src/ffmpeg.ts
+++ b/packages/backend-common/src/ffmpeg.ts
@@ -1,0 +1,19 @@
+import { exec } from 'node:child_process';
+import { logger } from '@guardian/transcription-service-backend-common';
+import { promisify } from 'node:util';
+
+const execPromise = promisify(exec);
+
+export const getFileDuration = async (filePath: string): Promise<number> => {
+	const command = `ffprobe -i ${filePath} -show_entries format=duration -v quiet -of csv="p=0"`;
+	try {
+		const { stdout, stderr } = await execPromise(command);
+		if (stderr) {
+			logger.error(` ffprobe stderr: `, stderr);
+		}
+		return parseFloat(stdout);
+	} catch (error) {
+		logger.error(`Error during ffprobe file duration detection`, error);
+		throw error;
+	}
+};

--- a/packages/backend-common/src/ffmpeg.ts
+++ b/packages/backend-common/src/ffmpeg.ts
@@ -4,16 +4,18 @@ import { promisify } from 'node:util';
 
 const execPromise = promisify(exec);
 
-export const getFileDuration = async (filePath: string): Promise<number> => {
+export const getFileDuration = async (
+	filePath: string,
+): Promise<number | undefined> => {
 	const command = `ffprobe -i ${filePath} -show_entries format=duration -v quiet -of csv="p=0"`;
 	try {
 		const { stdout, stderr } = await execPromise(command);
 		if (stderr) {
-			logger.error(` ffprobe stderr: `, stderr);
+			logger.error(`ffprobe stderr: `, stderr);
 		}
 		return parseFloat(stdout);
 	} catch (error) {
 		logger.error(`Error during ffprobe file duration detection`, error);
-		throw error;
+		return undefined;
 	}
 };

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -81,7 +81,7 @@ export const generateOutputSignedUrlAndSendMessage = async (
 	);
 
 	const engine =
-		config.app.useWhisperx && (duration > 900 || diarizationRequested)
+		config.app.useWhisperx && (duration > 600 || diarizationRequested)
 			? TranscriptionEngine.WHISPER_X
 			: TranscriptionEngine.WHISPER_CPP;
 

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -80,6 +80,8 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		7,
 	);
 
+	// user whisperX if whisperX enabled and...
+	// duration is either unknown or greater than 10 minutes or  diarization has been requested
 	const engine =
 		config.app.useWhisperx &&
 		(!duration || duration > 600 || diarizationRequested)
@@ -103,7 +105,6 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		translate: false,
 		diarize: diarizationRequested,
 		engine,
-		duration,
 	};
 	const messageResult = await sendMessage(
 		client,

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -70,7 +70,7 @@ export const generateOutputSignedUrlAndSendMessage = async (
 	languageCode: InputLanguageCode,
 	translationRequested: boolean,
 	diarizationRequested: boolean,
-	duration: number,
+	duration?: number,
 ): Promise<SendResult> => {
 	const signedUrls = await generateOutputSignedUrls(
 		s3Key,
@@ -81,7 +81,8 @@ export const generateOutputSignedUrlAndSendMessage = async (
 	);
 
 	const engine =
-		config.app.useWhisperx && (duration > 600 || diarizationRequested)
+		config.app.useWhisperx &&
+		(!duration || duration > 600 || diarizationRequested)
 			? TranscriptionEngine.WHISPER_X
 			: TranscriptionEngine.WHISPER_CPP;
 

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -70,6 +70,7 @@ export const generateOutputSignedUrlAndSendMessage = async (
 	languageCode: InputLanguageCode,
 	translationRequested: boolean,
 	diarizationRequested: boolean,
+	duration: number,
 ): Promise<SendResult> => {
 	const signedUrls = await generateOutputSignedUrls(
 		s3Key,
@@ -79,9 +80,15 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		7,
 	);
 
-	const queue = config.app.useWhisperx
-		? config.app.gpuTaskQueueUrl
-		: config.app.taskQueueUrl;
+	const engine =
+		config.app.useWhisperx && (duration > 900 || diarizationRequested)
+			? TranscriptionEngine.WHISPER_X
+			: TranscriptionEngine.WHISPER_CPP;
+
+	const queue =
+		engine === TranscriptionEngine.WHISPER_X
+			? config.app.gpuTaskQueueUrl
+			: config.app.taskQueueUrl;
 
 	const job: TranscriptionJob = {
 		id: s3Key, // id of the source file
@@ -94,9 +101,8 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		languageCode,
 		translate: false,
 		diarize: diarizationRequested,
-		engine: config.app.useWhisperx
-			? TranscriptionEngine.WHISPER_X
-			: TranscriptionEngine.WHISPER_CPP,
+		engine,
+		duration,
 	};
 	const messageResult = await sendMessage(
 		client,

--- a/packages/cdk/README.md
+++ b/packages/cdk/README.md
@@ -3,3 +3,18 @@
 This directory defines the components to be deployed to AWS.
 
 See [`package.json`](./package.json) for a list of available scripts.
+
+## Stacks
+
+### Transcription-Service
+
+This is the main stack with the vast majority of the infrastructure.
+
+### Repository
+
+This stack could probably be merged with universal-infra (it isn't for historical reasons). It contains all the relevant
+infra and IAM permissions to support publishing docker images from github actions to ECR.
+
+### Universal-Infra
+
+This stack was created to contain resources shared across all stages.

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -2,6 +2,7 @@ import 'source-map-support/register';
 import { GuRoot } from '@guardian/cdk/lib/constructs/root';
 import { TranscriptionServiceRepository } from '../lib/repository';
 import { TranscriptionService } from '../lib/transcription-service';
+import { TranscriptionServiceUniversalInfra } from '../lib/universal-infra';
 
 const app = new GuRoot();
 new TranscriptionService(app, 'TranscriptionService-CODE', {
@@ -21,3 +22,15 @@ new TranscriptionServiceRepository(app, 'TranscriptionServiceRepository', {
 	stage: 'PROD',
 	env: { region: 'eu-west-1' },
 });
+
+// This is another stack which is used for both code/prod - but as repository already existed I made a new stack to avoid
+// having to delete the whole repository stack (including all containers) in order to give it a less specific name
+new TranscriptionServiceUniversalInfra(
+	app,
+	'TranscriptionServiceUniversalInfra',
+	{
+		stack: 'investigations',
+		stage: 'PROD',
+		env: { region: 'eu-west-1' },
+	},
+);

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -11,6 +11,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       "GuCertificate",
       "GuS3Bucket",
       "GuS3Bucket",
+      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuApiLambda",
       "GuPolicy",
@@ -103,6 +104,10 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
     },
     "InvestigationsAlarmTopicArn": {
       "Default": "/TEST/investigations/alarmTopicArn",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "LayerBucketArn": {
+      "Default": "/investigations/transcription-service/lambdaLayerBucketArn",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "LoggingStreamName": {
@@ -208,6 +213,48 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::SSM::Parameter",
+    },
+    "FFMpegLayerx8664TEST3F325D39": {
+      "Properties": {
+        "CompatibleArchitectures": [
+          "x86_64",
+        ],
+        "CompatibleRuntimes": [
+          "nodejs18.x",
+          "nodejs22.x",
+          "nodejs20.x",
+          "nodejs18.x",
+        ],
+        "Content": {
+          "S3Bucket": {
+            "Fn::Select": [
+              0,
+              {
+                "Fn::Split": [
+                  "/",
+                  {
+                    "Fn::Select": [
+                      5,
+                      {
+                        "Fn::Split": [
+                          ":",
+                          {
+                            "Ref": "LayerBucketArn",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          "S3Key": "ffmpeg_x86_64-1998ca7c6bd4313262b49cd9a66bc690.zip",
+        },
+        "Description": "FFMpeg Layer",
+        "LayerName": "FFMpegLayer",
+      },
+      "Type": "AWS::Lambda::LayerVersion",
     },
     "GPUTaskQueueUrlParameter64941E19": {
       "Properties": {
@@ -2442,7 +2489,15 @@ service transcription-service-worker start",
             "STAGE": "TEST",
           },
         },
+        "EphemeralStorage": {
+          "Size": 10240,
+        },
         "Handler": "index.api",
+        "Layers": [
+          {
+            "Ref": "FFMpegLayerx8664TEST3F325D39",
+          },
+        ],
         "LoggingConfig": {
           "LogFormat": "JSON",
         },

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -215,6 +215,11 @@ export class TranscriptionService extends GuStack {
 			default: '/investigations/transcription-service/lambdaLayerBucketArn',
 		});
 
+		const ffmpegHash = new GuStringParameter(this, 'FFMpegLayerZipKey', {
+			description:
+				"Key for the ffmpeg layer's zip file (pushed to layerBucket by publish-ffmpeg-layer.sh script)",
+		});
+
 		const ffmpegLayer = new LayerVersion(
 			this,
 			`FFMpegLayer_x86_64-${this.stage}`,
@@ -225,7 +230,7 @@ export class TranscriptionService extends GuStack {
 						'LambdaLayerBucket',
 						layerBucket.valueAsString,
 					),
-					'ffmpeg_x86_64-ba72e86a4234ae0f807fe035f89eeecf.zip',
+					ffmpegHash.valueAsString,
 				),
 				description: 'FFMpeg Layer',
 				layerVersionName: 'FFMpegLayer',

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -248,6 +248,7 @@ export class TranscriptionService extends GuStack {
 			},
 			app: `${APP_NAME}-api`,
 			layers: [ffmpegLayer],
+			ephemeralStorageSize: Size.gibibytes(10), // needed so api can download source files to get the duration
 			api: {
 				id: apiId,
 				description: 'API for transcription service frontend',

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -225,7 +225,7 @@ export class TranscriptionService extends GuStack {
 						'LambdaLayerBucket',
 						layerBucket.valueAsString,
 					),
-					'ffmpeg_x86_64.zip',
+					'ffmpeg_x86_64-ba72e86a4234ae0f807fe035f89eeecf.zip',
 				),
 				description: 'FFMpeg Layer',
 				layerVersionName: 'FFMpegLayer',

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -67,11 +67,16 @@ import {
 	Role,
 	ServicePrincipal,
 } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import {
+	Architecture,
+	Code,
+	LayerVersion,
+	Runtime,
+} from 'aws-cdk-lib/aws-lambda';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import { CfnPipe } from 'aws-cdk-lib/aws-pipes';
-import { HttpMethods } from 'aws-cdk-lib/aws-s3';
+import { Bucket, HttpMethods } from 'aws-cdk-lib/aws-s3';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
@@ -205,6 +210,35 @@ export class TranscriptionService extends GuStack {
 			});
 		}
 
+		const layerBucket = new GuStringParameter(this, 'LayerBucketArn', {
+			fromSSM: true,
+			default: '/investigations/transcription-service/lambdaLayerBucketArn',
+		});
+
+		const ffmpegLayer = new LayerVersion(
+			this,
+			`FFMpegLayer_x86_64-${this.stage}`,
+			{
+				code: Code.fromBucket(
+					Bucket.fromBucketArn(
+						this,
+						'LambdaLayerBucket',
+						layerBucket.valueAsString,
+					),
+					'ffmpeg_x86_64.zip',
+				),
+				description: 'FFMpeg Layer',
+				layerVersionName: 'FFMpegLayer',
+				compatibleArchitectures: [Architecture.X86_64],
+				compatibleRuntimes: [
+					Runtime.NODEJS_LATEST,
+					Runtime.NODEJS_22_X,
+					Runtime.NODEJS_20_X,
+					Runtime.NODEJS_18_X,
+				],
+			},
+		);
+
 		const apiLambda = new GuApiLambda(this, 'transcription-service-api', {
 			fileName: 'api.zip',
 			handler: 'index.api',
@@ -213,6 +247,7 @@ export class TranscriptionService extends GuStack {
 				noMonitoring: true,
 			},
 			app: `${APP_NAME}-api`,
+			layers: [ffmpegLayer],
 			api: {
 				id: apiId,
 				description: 'API for transcription service frontend',

--- a/packages/cdk/lib/universal-infra.ts
+++ b/packages/cdk/lib/universal-infra.ts
@@ -1,0 +1,26 @@
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
+import type { App } from 'aws-cdk-lib';
+import { CfnOutput } from 'aws-cdk-lib';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+
+export class TranscriptionServiceUniversalInfra extends GuStack {
+	constructor(scope: App, id: string, props: GuStackProps) {
+		super(scope, id, props);
+
+		const layerBucket = new GuS3Bucket(this, 'LayerBucket', {
+			bucketName: 'transcription-service-lambda-layers',
+			app: 'transcription-service-universal-infra',
+		});
+
+		new StringParameter(this, 'ExportFunctionName', {
+			parameterName: `/investigations/transcription-service/lambdaLayerBucketArn`,
+			stringValue: layerBucket.bucketArn,
+		});
+
+		new CfnOutput(this, 'LayerBucket', {
+			value: layerBucket.bucketArn,
+		});
+	}
+}

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -69,8 +69,6 @@ export const TranscriptionJob = z.object({
 	engine: z.nativeEnum(TranscriptionEngine),
 	// we can get rid of this when we switch to using a zip
 	translationOutputBucketUrls: z.optional(OutputBucketUrls),
-	// this is optional because giant currently doesn't know file duration
-	duration: z.optional(z.number()),
 });
 
 export type TranscriptionJob = z.infer<typeof TranscriptionJob>;
@@ -83,7 +81,6 @@ const OutputBase = z.object({
 const TranscriptionOutputBase = OutputBase.extend({
 	originalFilename: z.string(),
 	isTranslation: z.boolean(),
-	duration: z.optional(z.number()),
 });
 
 export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
@@ -92,6 +89,7 @@ export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
 	outputBucketKeys: OutputBucketKeys,
 	// we can get rid of this when we switch to using a zip
 	translationOutputBucketKeys: z.optional(OutputBucketKeys),
+	duration: z.optional(z.number()),
 });
 
 export const MediaDownloadFailure = OutputBase.extend({

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -69,6 +69,8 @@ export const TranscriptionJob = z.object({
 	engine: z.nativeEnum(TranscriptionEngine),
 	// we can get rid of this when we switch to using a zip
 	translationOutputBucketUrls: z.optional(OutputBucketUrls),
+	// this is optional because giant currently doesn't know file duration
+	duration: z.optional(z.number()),
 });
 
 export type TranscriptionJob = z.infer<typeof TranscriptionJob>;
@@ -81,6 +83,7 @@ const OutputBase = z.object({
 const TranscriptionOutputBase = OutputBase.extend({
 	originalFilename: z.string(),
 	isTranslation: z.boolean(),
+	duration: z.optional(z.number()),
 });
 
 export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({

--- a/packages/media-download/src/index.ts
+++ b/packages/media-download/src/index.ts
@@ -101,6 +101,7 @@ const requestTranscription = async (
 		job.languageCode,
 		job.translationRequested,
 		job.diarizationRequested,
+		metadata.duration,
 	);
 	if (isSqsFailure(sendResult)) {
 		throw new Error('Failed to send transcription job');

--- a/packages/media-download/src/yt-dlp.ts
+++ b/packages/media-download/src/yt-dlp.ts
@@ -8,6 +8,7 @@ export type MediaMetadata = {
 	extension: string;
 	filename: string;
 	mediaPath: string;
+	duration: number;
 };
 
 const extractInfoJson = (infoJsonPath: string): MediaMetadata => {
@@ -18,6 +19,7 @@ const extractInfoJson = (infoJsonPath: string): MediaMetadata => {
 		extension: json.ext,
 		filename: json.filename,
 		mediaPath: `${json.filename}`,
+		duration: parseInt(json.duration),
 	};
 };
 

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -111,10 +111,12 @@ const handleTranscriptionSuccess = async (
 			),
 		);
 
-		logger.info('Output handler successfully sent success email notification', {
+		logger.info('Output handler sent success email notification', {
 			id: transcriptionOutput.id,
 			filename: transcriptionOutput.originalFilename,
 			userEmail: transcriptionOutput.userEmail,
+			duration: transcriptionOutput.duration || '',
+			languageCode: transcriptionOutput.languageCode,
 		});
 	} catch (error) {
 		logger.error(

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -126,7 +126,6 @@ const publishTranscriptionOutputFailure = async (
 		userEmail: job.userEmail,
 		originalFilename: job.originalFilename,
 		isTranslation: job.translate,
-		duration: job.duration,
 	};
 	try {
 		await publishTranscriptionOutput(sqsClient, destination, failureMessage);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -126,6 +126,7 @@ const publishTranscriptionOutputFailure = async (
 		userEmail: job.userEmail,
 		originalFilename: job.originalFilename,
 		isTranslation: job.translate,
+		duration: job.duration,
 	};
 	try {
 		await publishTranscriptionOutput(sqsClient, destination, failureMessage);
@@ -402,6 +403,7 @@ const pollTranscriptionQueue = async (
 					text: job.translationOutputBucketUrls.text.key,
 				},
 			isTranslation: job.translate,
+			duration: ffmpegResult.duration,
 		};
 
 		await publishTranscriptionOutput(

--- a/scripts/publish-ffmpeg-layer.sh
+++ b/scripts/publish-ffmpeg-layer.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set +x
+set -e
+
+WORKING_DIRECTORY="ffmpeg-layer-build"
+mkdir -p $WORKING_DIRECTORY
+
+pushd $WORKING_DIRECTORY
+curl -0L https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz > ffmpeg-release-amd64-static.tar.xz
+curl -0L https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz.md5 > ffmpeg-release-amd64-static.tar.xz.md5
+md5sum -c ffmpeg-release-amd64-static.tar.xz.md5
+
+tar -xf ffmpeg-release-amd64-static.tar.xz
+
+mkdir -p ffmpeg/bin
+mkdir -p ffprobe/bin
+
+cp ffmpeg-7.0.2-amd64-static/ffmpeg ffmpeg/bin/
+cp ffmpeg-7.0.2-amd64-static/ffprobe ffprobe/bin/
+
+zip -r ffmpeg_x86_64.zip ffmpeg ffprobe
+
+HASH=$(md5sum ffmpeg_x86_64.zip | cut -d ' ' -f 1)
+mv ffmpeg_x86_64.zip ffmpeg_x86_64-$HASH.zip
+
+aws s3 cp ffmpeg_x86_64-$HASH.zip s3://transcription-service-lambda-layers/ffmpeg_x86_64-$HASH.zip
+popd
+rm -rf $WORKING_DIRECTORY


### PR DESCRIPTION
## What does this change?
Currently we have two available 'engines' for transcription:
 - whisperx - supports diarization, is very fast once it gets started, better output formatting, very slow startup (~10mins)
 - whisper.cpp - fast(er) startup, less pretty output formatting, no diarization

It seems a shame to wait to spin up whisperx for a file that is only a few minutes long. This PR gets the API to make a decision on which engine to use based on the duration of the file - any files under 10 minutes long where the user hasn't requested diarization will be sent to whisper.cpp, everything else goes to whisperX

To get ffprobe running on lambda I had to create a lambda layer - this is basically just a zip file that gets added to the disk of the lambda vm. 

## How to test
Tested on CODE