### PR TITLE
Handle media download failures 

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -696,6 +696,7 @@ export class TranscriptionService extends GuStack {
 					resources: [
 						transcriptionTaskQueue.queueArn,
 						transcriptionGpuTaskQueue.queueArn,
+						transcriptionOutputQueue.queueArn,
 					],
 				}),
 				new PolicyStatement({

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -73,10 +73,13 @@ export const TranscriptionJob = z.object({
 
 export type TranscriptionJob = z.infer<typeof TranscriptionJob>;
 
-const TranscriptionOutputBase = z.object({
+const OutputBase = z.object({
 	id: z.string(),
-	originalFilename: z.string(),
 	userEmail: z.string(),
+});
+
+const TranscriptionOutputBase = OutputBase.extend({
+	originalFilename: z.string(),
 	isTranslation: z.boolean(),
 });
 
@@ -88,7 +91,7 @@ export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
 	translationOutputBucketKeys: z.optional(OutputBucketKeys),
 });
 
-export const MediaDownloadFailure = z.object({
+export const MediaDownloadFailure = OutputBase.extend({
 	id: z.string(),
 	status: z.literal('MEDIA_DOWNLOAD_FAILURE'),
 	url: z.string(),
@@ -122,6 +125,10 @@ export const transcriptionOutputIsTranscriptionFailure = (
 	output: TranscriptionOutput,
 ): output is TranscriptionOutputSuccess =>
 	output.status === 'TRANSCRIPTION_FAILURE';
+
+export const transcriptionOutputIsMediaDownloadFailure = (
+	output: TranscriptionOutput,
+): output is MediaDownloadFailure => output.status === 'MEDIA_DOWNLOAD_FAILURE';
 
 export type TranscriptionOutput = z.infer<typeof TranscriptionOutput>;
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -92,7 +92,6 @@ export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
 });
 
 export const MediaDownloadFailure = OutputBase.extend({
-	id: z.string(),
 	status: z.literal('MEDIA_DOWNLOAD_FAILURE'),
 	url: z.string(),
 });

--- a/packages/media-download/src/index.ts
+++ b/packages/media-download/src/index.ts
@@ -64,6 +64,7 @@ const reportDownloadFailure = async (
 		id: job.id,
 		status: 'MEDIA_DOWNLOAD_FAILURE',
 		url: job.url,
+		userEmail: job.userEmail,
 	};
 	const result = await sendMessage(
 		sqsClient,

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -53,19 +53,19 @@ const transcriptionFailureMessageBody = (
 		<h1>${isTranslation ? 'English translation ' : 'Transcription'}for ${originalFilename} has failed.</h1>
 		<p>Please make sure that the file is a valid audio or video file.</p>
 		<p>Click <a href="${sourceMediaDownloadUrl}">here</a> to download the input media.</p>
-		<p>Contact digital.investigations@guardian.co.uk for support.</p>
+		<p>Contact digital.investigations@theguardian.com for support.</p>
 		<p>Transcription ID: ${id}</p>
 	`;
 };
 
 const mediaDownloadFailureMessageBody = (url: string) => {
 	return `
-		<h1>Media download of ${url} failed.</h1>
+		<h1>Media download failed for ${url}</h1>
 		<p>You recently requested a transcription of the media at this url ${url}. Unfortunately, the transcription service
         was unable to download the media for transcription.</p> 
         <p>This might be because the url is for an unsupported website. For a list of supported sites, see 
-        [here](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md).</p>
-        <p>Please contact digital.investigations@guardian.co.uk for further assistance.</p>
+        <a href="https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md">here</a>.</p>
+        <p>Please contact digital.investigations@theguardian.com for further assistance.</p>
         `;
 };
 


### PR DESCRIPTION
## What does this change?
I spotted that the media download serivice doesn't actually currently have permission to write to the transcription output queue, so if a media download fails it can't tell the user.

This fixes that, and adds a step to the output handler to send an email to the user explaining what might have happened. It looks like this:

<img width="1202" alt="Screenshot 2025-02-07 at 11 35 21" src="https://github.com/user-attachments/assets/d87a9c07-50cd-4731-913a-dbce1a221c64" />


## How to test
Tested on CODE