### PR TITLE
Set an output template for media download filename

### DIFF
--- a/packages/media-download/src/yt-dlp.ts
+++ b/packages/media-download/src/yt-dlp.ts
@@ -76,7 +76,7 @@ export const downloadMedia = async (
 				'--no-clean-info-json',
 				'--newline',
 				'-o',
-				`${destinationDirectoryPath}/${id}`,
+				`${destinationDirectoryPath}/${id}.%(ext)s`,
 				...proxyParams,
 				url,
 			],

--- a/packages/media-download/src/yt-dlp.ts
+++ b/packages/media-download/src/yt-dlp.ts
@@ -17,7 +17,7 @@ const extractInfoJson = (infoJsonPath: string): MediaMetadata => {
 		title: json.title,
 		extension: json.ext,
 		filename: json.filename,
-		mediaPath: `${json.filename}.${json.ext}`,
+		mediaPath: `${json.filename}`,
 	};
 };
 


### PR DESCRIPTION
## What does this change?
I found an issue where the filename of the file downloaded by yt-dlp isn't consistent - for videos from some services it included the file extension whereas for others (in this case bluesky) it didn't, which resulted in the upload to s3 step failing as it had the wrong filename. This PR fixes that by explicitly including the file extension in the downloaded filename using an [output template](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#output-template).

## How to test
Tested on CODE - it works