### PR TITLE
Make sure file extension doesn't get truncated for s3 downloads

### DIFF
--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -56,9 +56,14 @@ export const getSignedUploadUrl = (
 };
 
 const sanitizeFilename = (filename: string) => {
-	let sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, '_');
-	sanitized = sanitized.substring(0, 255);
-	return sanitized;
+	const extension = path.extname(filename);
+	if (!extension) {
+		return filename.substring(0, 250);
+	}
+	const truncatedExtension = extension.substring(0, 20);
+	const nameNoExtension = path.basename(filename, extension);
+	const truncatedName = nameNoExtension.substring(0, 220);
+	return `${truncatedName}.${truncatedExtension}`;
 };
 
 export const getSignedDownloadUrl = async (

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -56,12 +56,16 @@ export const getSignedUploadUrl = (
 };
 
 const sanitizeFilename = (filename: string) => {
-	const extension = path.extname(filename);
+	const sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, '_');
+	const extension = path.extname(sanitized);
 	if (!extension) {
-		return filename.substring(0, 250);
+		// no extension - just return the filename truncated to 250 characters (max macos is 255, but the user may
+		// manually add an extension so let's give them some headroom)
+		return sanitized.substring(0, 250);
 	}
+	// file has an extension - truncate that to 20 chars and the filename to 220 chars
 	const truncatedExtension = extension.substring(0, 20);
-	const nameNoExtension = path.basename(filename, extension);
+	const nameNoExtension = path.basename(sanitized, extension);
 	const truncatedName = nameNoExtension.substring(0, 220);
 	return `${truncatedName}.${truncatedExtension}`;
 };

--- a/packages/media-download/src/index.ts
+++ b/packages/media-download/src/index.ts
@@ -97,7 +97,7 @@ const requestTranscription = async (
 		sqsClient,
 		config,
 		job.userEmail,
-		metadata.title,
+		`${metadata.title}.${metadata.extension}`,
 		signedUrl,
 		job.languageCode,
 		job.translationRequested,


### PR DESCRIPTION
## What does this change?
The filename limit on macos/windows is 255/257 chars. We were already truncating to 255 chars, but that resulted in the file extension being lost for long filenames. For url transcripts, the media download worker was only providiing the video title to the  worker/output handler, which meant that the output handler had no chance of generating a download link with the correct extension. This resolved that, by providing  the full title/extension from the media download service to the worker.

A downside of this is that the emails now all say "your download for blah.mp4" instead of "your download for blah" - but to do it properly I'd need to pass through the file extension/name as separate fields all the way through to the output handler, this seems a pragmatic approach for now and brings the url route in line with the file route (which already says "your download for voicenote.mp3")


## How to test
I've tested this with this video https://www.tiktok.com/@bbcnews/video/7474294980090088726