### PR TITLE
Improve worker logs

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -188,6 +188,10 @@ const getApp = async () => {
 				config.app.sourceMediaBucket,
 				s3Key,
 				604800, // one week in seconds
+				// NOTE presigned urls will expire before a week has elapsed
+				// because of this issue
+				// https://repost.aws/knowledge-center/presigned-url-s3-bucket-expiration
+				// Can we just give workers read permission to the entire bucket?
 			);
 			const sendResult = await generateOutputSignedUrlAndSendMessage(
 				s3Key,

--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -10,7 +10,7 @@ export interface LoggerFunctions {
 }
 
 interface LogEvent {
-	level: 'debug' | 'info' | 'warn' | 'error';
+	level: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 	message: string;
 	stack_trace?: string;
 	meta?: Record<string, string | number>;
@@ -56,14 +56,14 @@ class ServerLogger {
 
 	debug(message: string): void {
 		this.log({
-			level: 'debug',
+			level: 'DEBUG',
 			message,
 		});
 	}
 
 	info(message: string, meta?: Record<string, string>): void {
 		this.log({
-			level: 'info',
+			level: 'INFO',
 			message,
 			meta: meta,
 		});
@@ -71,7 +71,7 @@ class ServerLogger {
 
 	warn(message: string, error?: Error): void {
 		this.log({
-			level: 'warn',
+			level: 'WARN',
 			message,
 			stack_trace: error instanceof Error ? error.stack : undefined,
 		});
@@ -79,7 +79,7 @@ class ServerLogger {
 
 	error(message: string, error?: Error | unknown): void {
 		this.log({
-			level: 'error',
+			level: 'ERROR',
 			message,
 			stack_trace: error instanceof Error ? error.stack : undefined,
 		});

--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -25,7 +25,13 @@ class ServerLogger {
 
 	constructor() {
 		const winstonConfig: winston.LoggerOptions = {
-			level: 'info',
+			levels: {
+				ERROR: 0,
+				WARN: 1,
+				INFO: 2,
+				DEBUG: 3,
+			},
+			level: 'INFO',
 			format: combine(timestamp({ alias: '@timestamp' }), json()),
 			transports: [new winston.transports.Console()],
 		};

--- a/packages/backend-common/src/process.ts
+++ b/packages/backend-common/src/process.ts
@@ -41,7 +41,8 @@ export const runSpawnCommand = (
 		cp.stderr.on('data', (data) => {
 			stderr.push(data.toString());
 			if (logImmediately) {
-				logger.error(data.toString());
+				// ffmpeg sends all text output to stderr even when it's successful
+				logger.info(data.toString());
 			}
 		});
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- changes server-side log levels from lower to uppercase to conform to all other services' log levels
- `runSpawnCommand` logs stderr at level `info`. ffmpeg directs all text output to stderr, even when its successful, so creating error logs for this output is misleading

## How to test
- [x] test in code
