### PR TITLE
Hotfix worker capacity manager

### DIFF
--- a/packages/worker-capacity-manager/src/index.ts
+++ b/packages/worker-capacity-manager/src/index.ts
@@ -22,10 +22,14 @@ const updateASGCapacity = async (
 		queueUrl,
 	);
 
+	// TODO get max capacity from ASG and replace hardcoded value
+	const prodAsgMaxCapacity = 20;
+	const desiredCapacity = Math.min(totalMessagesInQueue, prodAsgMaxCapacity);
+
 	logger.info(
 		`setting asg desired capacity to total messages in queue: ${totalMessagesInQueue}`,
 	);
-	await setDesiredCapacity(asgClient, asgName, totalMessagesInQueue);
+	await setDesiredCapacity(asgClient, asgName, desiredCapacity);
 };
 
 const updateASGsCapacity = async () => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

At the moment we're failing to update worker ASG capacity whenever the number of messages in the queue is higher than the ASG max capacity, leading to a backlog of transcription jobs.

## What does this change?
Set desired capacity to the min of prod's max capacity and the number of messages in the queue. 