### PR TITLE
Upgrading next.js to fix CVE-2025-29927

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4693,14 +4693,14 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "14.2.10",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.10.tgz",
-			"integrity": "sha512-dZIu93Bf5LUtluBXIv4woQw2cZVZ2DJTjax5/5DOs3lzEOeKLy7GxRSr4caK9/SCPdaW6bCgpye6+n4Dh9oJPw=="
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.25.tgz",
+			"integrity": "sha512-JnzQ2cExDeG7FxJwqAksZ3aqVJrHjFwZQAEJ9gQZSoEhIow7SNoKZzju/AwQ+PLIR4NY8V0rhcVozx/2izDO0w=="
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "14.2.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.10.tgz",
-			"integrity": "sha512-V3z10NV+cvMAfxQUMhKgfQnPbjw+Ew3cnr64b0lr8MDiBJs3eLnM6RpGC46nhfMZsiXgQngCJKWGTC/yDcgrDQ==",
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.25.tgz",
+			"integrity": "sha512-09clWInF1YRd6le00vt750s3m7SEYNehz9C4PUcSu3bAdCTpjIV4aTYQZ25Ehrr83VR1rZeqtKUPWSI7GfuKZQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -4713,9 +4713,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "14.2.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.10.tgz",
-			"integrity": "sha512-Y0TC+FXbFUQ2MQgimJ/7Ina2mXIKhE7F+GUe1SgnzRmwFY3hX2z8nyVCxE82I2RicspdkZnSWMn4oTjIKz4uzA==",
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.25.tgz",
+			"integrity": "sha512-V+iYM/QR+aYeJl3/FWWU/7Ix4b07ovsQ5IbkwgUK29pTHmq+5UxeDr7/dphvtXEq5pLB/PucfcBNh9KZ8vWbug==",
 			"cpu": [
 				"x64"
 			],
@@ -4728,9 +4728,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "14.2.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.10.tgz",
-			"integrity": "sha512-ZfQ7yOy5zyskSj9rFpa0Yd7gkrBnJTkYVSya95hX3zeBG9E55Z6OTNPn1j2BTFWvOVVj65C3T+qsjOyVI9DQpA==",
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.25.tgz",
+			"integrity": "sha512-LFnV2899PJZAIEHQ4IMmZIgL0FBieh5keMnriMY1cK7ompR+JUd24xeTtKkcaw8QmxmEdhoE5Mu9dPSuDBgtTg==",
 			"cpu": [
 				"arm64"
 			],
@@ -4743,9 +4743,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "14.2.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.10.tgz",
-			"integrity": "sha512-n2i5o3y2jpBfXFRxDREr342BGIQCJbdAUi/K4q6Env3aSx8erM9VuKXHw5KNROK9ejFSPf0LhoSkU/ZiNdacpQ==",
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.25.tgz",
+			"integrity": "sha512-QC5y5PPTmtqFExcKWKYgUNkHeHE/z3lUsu83di488nyP0ZzQ3Yse2G6TCxz6nNsQwgAx1BehAJTZez+UQxzLfw==",
 			"cpu": [
 				"arm64"
 			],
@@ -4758,9 +4758,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "14.2.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.10.tgz",
-			"integrity": "sha512-GXvajAWh2woTT0GKEDlkVhFNxhJS/XdDmrVHrPOA83pLzlGPQnixqxD8u3bBB9oATBKB//5e4vpACnx5Vaxdqg==",
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.25.tgz",
+			"integrity": "sha512-y6/ML4b9eQ2D/56wqatTJN5/JR8/xdObU2Fb1RBidnrr450HLCKr6IJZbPqbv7NXmje61UyxjF5kvSajvjye5w==",
 			"cpu": [
 				"x64"
 			],
@@ -4773,9 +4773,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "14.2.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.10.tgz",
-			"integrity": "sha512-opFFN5B0SnO+HTz4Wq4HaylXGFV+iHrVxd3YvREUX9K+xfc4ePbRrxqOuPOFjtSuiVouwe6uLeDtabjEIbkmDA==",
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.25.tgz",
+			"integrity": "sha512-sPX0TSXHGUOZFvv96GoBXpB3w4emMqKeMgemrSxI7A6l55VBJp/RKYLwZIB9JxSqYPApqiREaIIap+wWq0RU8w==",
 			"cpu": [
 				"x64"
 			],
@@ -4788,9 +4788,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "14.2.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.10.tgz",
-			"integrity": "sha512-9NUzZuR8WiXTvv+EiU/MXdcQ1XUvFixbLIMNQiVHuzs7ZIFrJDLJDaOF1KaqttoTujpcxljM/RNAOmw1GhPPQQ==",
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.25.tgz",
+			"integrity": "sha512-ReO9S5hkA1DU2cFCsGoOEp7WJkhFzNbU/3VUF6XxNGUCQChyug6hZdYL/istQgfT/GWE6PNIg9cm784OI4ddxQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -4803,9 +4803,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "14.2.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.10.tgz",
-			"integrity": "sha512-fr3aEbSd1GeW3YUMBkWAu4hcdjZ6g4NBl1uku4gAn661tcxd1bHs1THWYzdsbTRLcCKLjrDZlNp6j2HTfrw+Bg==",
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.25.tgz",
+			"integrity": "sha512-DZ/gc0o9neuCDyD5IumyTGHVun2dCox5TfPQI/BJTYwpSNYM3CZDI4i6TOdjeq1JMo+Ug4kPSMuZdwsycwFbAw==",
 			"cpu": [
 				"ia32"
 			],
@@ -4818,9 +4818,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "14.2.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.10.tgz",
-			"integrity": "sha512-UjeVoRGKNL2zfbcQ6fscmgjBAS/inHBh63mjIlfPg/NG8Yn2ztqylXt5qilYb6hoHIwaU2ogHknHWWmahJjgZQ==",
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.25.tgz",
+			"integrity": "sha512-KSznmS6eFjQ9RJ1nEc66kJvtGIL1iZMYmGEXsZPh2YtnLtqrgdVvKXJY2ScjjoFnG6nGLyPFR0UiEvDwVah4Tw==",
 			"cpu": [
 				"x64"
 			],
@@ -11212,11 +11212,11 @@
 			}
 		},
 		"node_modules/next": {
-			"version": "14.2.10",
-			"resolved": "https://registry.npmjs.org/next/-/next-14.2.10.tgz",
-			"integrity": "sha512-sDDExXnh33cY3RkS9JuFEKaS4HmlWmDKP1VJioucCG6z5KuA008DPsDZOzi8UfqEk3Ii+2NCQSJrfbEWtZZfww==",
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/next/-/next-14.2.25.tgz",
+			"integrity": "sha512-N5M7xMc4wSb4IkPvEV5X2BRRXUmhVHNyaXwEM86+voXthSZz8ZiRyQW4p9mwAoAPIm6OzuVZtn7idgEJeAJN3Q==",
 			"dependencies": {
-				"@next/env": "14.2.10",
+				"@next/env": "14.2.25",
 				"@swc/helpers": "0.5.5",
 				"busboy": "1.6.0",
 				"caniuse-lite": "^1.0.30001579",
@@ -11231,15 +11231,15 @@
 				"node": ">=18.17.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "14.2.10",
-				"@next/swc-darwin-x64": "14.2.10",
-				"@next/swc-linux-arm64-gnu": "14.2.10",
-				"@next/swc-linux-arm64-musl": "14.2.10",
-				"@next/swc-linux-x64-gnu": "14.2.10",
-				"@next/swc-linux-x64-musl": "14.2.10",
-				"@next/swc-win32-arm64-msvc": "14.2.10",
-				"@next/swc-win32-ia32-msvc": "14.2.10",
-				"@next/swc-win32-x64-msvc": "14.2.10"
+				"@next/swc-darwin-arm64": "14.2.25",
+				"@next/swc-darwin-x64": "14.2.25",
+				"@next/swc-linux-arm64-gnu": "14.2.25",
+				"@next/swc-linux-arm64-musl": "14.2.25",
+				"@next/swc-linux-x64-gnu": "14.2.25",
+				"@next/swc-linux-x64-musl": "14.2.25",
+				"@next/swc-win32-arm64-msvc": "14.2.25",
+				"@next/swc-win32-ia32-msvc": "14.2.25",
+				"@next/swc-win32-x64-msvc": "14.2.25"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",
@@ -15012,7 +15012,7 @@
 				"flowbite-react": "^0.7.3",
 				"history": "^5.3.0",
 				"jwt-decode": "^4.0.0",
-				"next": "14.2.10",
+				"next": "14.2.25",
 				"react": "^18",
 				"react-dom": "^18"
 			},

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,7 +15,7 @@
 		"history": "^5.3.0",
 		"@heroicons/react": "^2.1.1",
 		"jwt-decode": "^4.0.0",
-		"next": "14.2.10",
+		"next": "14.2.25",
 		"react": "^18",
 		"react-dom": "^18"
 	},


### PR DESCRIPTION
## What does this change?

Fix for [CVE-2025-29927](https://github.com/advisories/GHSA-f82v-jwr5-mffw), an authorisation bypass vulnerability which affects all versions of 14.x before 14.2.25. 

More details here https://vercel.com/blog/postmortem-on-next-js-middleware-bypass

## How to test

Tested on CODE

