### PR TITLE
Update all transcription service AMIs during deployment

### DIFF
--- a/packages/cdk/riff-raff.yaml
+++ b/packages/cdk/riff-raff.yaml
@@ -28,15 +28,14 @@ deployments:
       templateStagePaths:
         CODE: TranscriptionService-CODE.template.json
         PROD: TranscriptionService-PROD.template.json
+      amiEncrypted: investigations
       amiParametersToTags:
         AMITranscriptionserviceworker:
           BuiltBy: amigo
           Recipe: investigations-transcription-service
-          amiEncrypted: investigations
         AMITranscriptionservicegpuworker:
           BuiltBy: amigo
           Recipe: investigations-transcription-service-gpu
-          amiEncrypted: investigations
     dependencies:
       - lambda-upload-eu-west-1-investigations-transcription-service
       - lambda-upload-eu-west-1-investigations-transcription-service-output-handler

--- a/packages/cdk/riff-raff.yaml
+++ b/packages/cdk/riff-raff.yaml
@@ -28,11 +28,15 @@ deployments:
       templateStagePaths:
         CODE: TranscriptionService-CODE.template.json
         PROD: TranscriptionService-PROD.template.json
-      amiTags:
-        Recipe: investigations-transcription-service
-        AmigoStage: PROD
-      amiParameter: AMITranscriptionserviceworker
-      amiEncrypted: investigations
+      amiParametersToTags:
+        AMITranscriptionserviceworker:
+          BuiltBy: amigo
+          Recipe: investigations-transcription-service
+          amiEncrypted: investigations
+        AMITranscriptionservicegpuworker:
+          BuiltBy: amigo
+          Recipe: investigations-transcription-service-gpu
+          amiEncrypted: investigations
     dependencies:
       - lambda-upload-eu-west-1-investigations-transcription-service
       - lambda-upload-eu-west-1-investigations-transcription-service-output-handler


### PR DESCRIPTION
## What does this change?
Back here https://github.com/guardian/transcription-service/pull/123 when we added the new GPU instance autoscaling group, I neglected to update the riffraff configuration so that it would update the AMI for the new autoscaling group upon deployment.

Today this resulted in an incident where AMIgo deleted the AMI we were using as it was very old, and we were unable to launch workers.

I don't think AMIgo should have deleted the AMI as it was clearly still in use in our launch template - this should have been resolved in https://github.com/guardian/amigo/pull/1507

However, we should be updating our AMIs anyway, so I think this is a good improvement even if we also fix the problem in AMIgo.

See here https://riffraff.gutools.co.uk/docs/magenta-lib/types#cloudformation for the relevant riffraff documentation about this configuration file

## How to test
Tested on CODE, it works.