### PR TITLE
Add warning text explaining that url transcription is out of service

### DIFF
--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -19,6 +19,7 @@ import {
 	Alert,
 	TextInput,
 	Button,
+	HelperText,
 } from 'flowbite-react';
 import { MediaUrlInput, RequestStatus } from '@/types';
 import { InfoMessage } from '@/components/InfoMessage';
@@ -314,6 +315,7 @@ export const UploadForm = () => {
 				This tool can transcribe both audio and video. You will receive an email
 				when the transcription is ready.
 			</p>
+
 			<form id="media-upload-form" onSubmit={handleSubmit}>
 				<div className={'mb-1'}>
 					<Label className="text-base">I want to transcribe a...</Label>
@@ -327,15 +329,11 @@ export const UploadForm = () => {
 						onClick={() => setMediaSource('file')}
 					/>
 					<Label htmlFor="file-radio">File</Label>
-					<Radio
-						id="url-radio"
-						name="media-type"
-						value="url"
-						checked={mediaSource === 'url'}
-						onClick={() => setMediaSource('url')}
-					/>
-					<Label htmlFor="url-radio">URL</Label>
 				</div>
+				<HelperText color={'failure'}>
+					Unfortunately, URL transcription is unavailable as of 22 July. We'll
+					send an email round when it has been fixed.
+				</HelperText>
 				{mediaSource === 'url' && (
 					<>
 						<div className="mb-4"></div>


### PR DESCRIPTION
## What does this change?
The media download service currently isn't working. It may take some time to work out a solution, so this PR disables url transcription in the UI with a big red error message to reduce user frustration

It looks like this:

<img width="1262" height="361" alt="Screenshot 2025-07-22 at 09 43 10" src="https://github.com/user-attachments/assets/eab4b6ef-7640-4c0a-b012-3420cd3b73eb" />

## How to test
Tested locally, I think this needs to go out sooner rather than later