### PR TITLE
Add download links to export page

### DIFF
--- a/packages/api/src/export.ts
+++ b/packages/api/src/export.ts
@@ -1,10 +1,12 @@
 import {
 	getObjectText,
+	getSignedDownloadUrl,
 	isS3Failure,
 	logger,
 	TranscriptionConfig,
 } from '@guardian/transcription-service-backend-common';
 import {
+	DownloadUrls,
 	ExportItems,
 	ExportStatus,
 	ExportStatuses,
@@ -91,4 +93,32 @@ export const updateStatuses = (
 	return currentStatuses.map((s) =>
 		s.exportType === updatedStatus.exportType ? updatedStatus : s,
 	);
+};
+
+export const getDownloadUrls = async (
+	config: TranscriptionConfig,
+	item: TranscriptionDynamoItem,
+): Promise<DownloadUrls> => {
+	const text = await getSignedDownloadUrl(
+		config.aws.region,
+		config.app.transcriptionOutputBucket,
+		item.transcriptKeys.text,
+		60 * 60 * 12,
+		`${item.originalFilename}.txt`,
+	);
+	const srt = await getSignedDownloadUrl(
+		config.aws.region,
+		config.app.transcriptionOutputBucket,
+		item.transcriptKeys.srt,
+		60 * 60 * 12,
+		`${item.originalFilename}.srt`,
+	);
+	const sourceMedia = await getSignedDownloadUrl(
+		config.aws.region,
+		config.app.sourceMediaBucket,
+		item.id,
+		60 * 60 * 12,
+		`${item.originalFilename}`,
+	);
+	return { text, srt, sourceMedia };
 };

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -232,7 +232,7 @@ const getApp = async () => {
 		}),
 	]);
 
-	apiRouter.get('/export/get-download-urls', [
+	apiRouter.get('/export/download-urls', [
 		checkAuth,
 		asyncHandler(async (req, res) => {
 			const downloadUrlRequest = DownloadUrlRequest.safeParse(req.query);

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -64,7 +64,7 @@ const sanitizeFilename = (filename: string) => {
 		return sanitized.substring(0, 250);
 	}
 	// file has an extension - truncate that to 20 chars and the filename to 220 chars
-	const truncatedExtension = extension.substring(0, 20);
+	const truncatedExtension = extension.substring(1, 21);
 	const nameNoExtension = path.basename(sanitized, extension);
 	const truncatedName = nameNoExtension.substring(0, 220);
 	return `${truncatedName}.${truncatedExtension}`;

--- a/packages/client/src/components/ExportForm.tsx
+++ b/packages/client/src/components/ExportForm.tsx
@@ -21,7 +21,6 @@ import {
 	Checkbox,
 	CustomFlowbiteTheme,
 	Flowbite,
-	HelperText,
 	Label,
 } from 'flowbite-react';
 import { authFetch } from '@/helpers';
@@ -391,14 +390,34 @@ const ExportForm = () => {
 				Export to Google Drive
 			</button>
 
-			{downloadUrls && (
-				<HelperText>
-					You can also download the transcription output and input media:{' '}
-					<a href={downloadUrls.text}>transcript text</a>,{' '}
-					<a href={downloadUrls.srt}>transcript SRT</a>,{' '}
-					<a href={downloadUrls.sourceMedia}>input media</a>.
-				</HelperText>
-			)}
+			<div className="flex flex-col mt-5">
+				{downloadUrls && (
+					<p className="font-light">
+						Alternatively, you can directly download the files to your computer:{' '}
+						<a
+							className="ml-1 font-medium text-cyan-600 hover:underline dark:text-cyan-500"
+							href={downloadUrls.text}
+						>
+							transcript text
+						</a>
+						,{' '}
+						<a
+							className="ml-1 font-medium text-cyan-600 hover:underline dark:text-cyan-500"
+							href={downloadUrls.srt}
+						>
+							transcript SRT
+						</a>
+						,{' '}
+						<a
+							className="ml-1 font-medium text-cyan-600 hover:underline dark:text-cyan-500"
+							href={downloadUrls.sourceMedia}
+						>
+							input media
+						</a>
+						.
+					</p>
+				)}
+			</div>
 		</>
 	);
 };

--- a/packages/client/src/components/ExportForm.tsx
+++ b/packages/client/src/components/ExportForm.tsx
@@ -21,6 +21,7 @@ import {
 	Checkbox,
 	CustomFlowbiteTheme,
 	Flowbite,
+	HelperText,
 	Label,
 } from 'flowbite-react';
 import { authFetch } from '@/helpers';
@@ -322,9 +323,7 @@ const ExportForm = () => {
 							)
 						}
 					/>
-					<Label htmlFor="transcript-text">
-						Transcript text (<a href={downloadUrls?.text}>Download</a>)
-					</Label>
+					<Label htmlFor="transcript-text">Transcript text</Label>
 				</div>
 				<div className="flex items-center gap-2">
 					<Checkbox
@@ -341,8 +340,7 @@ const ExportForm = () => {
 						}
 					/>
 					<Label htmlFor="transcript-srt">
-						Transcript text with timecodes (SRT) (
-						<a href={downloadUrls?.srt}>Download</a>)
+						Transcript text with timecodes (SRT)
 					</Label>
 				</div>
 				<div className="flex gap-2">
@@ -362,9 +360,7 @@ const ExportForm = () => {
 						/>
 					</div>
 					<div className="flex flex-col">
-						<Label htmlFor="source-media">
-							Input media (<a href={downloadUrls?.sourceMedia}>Download</a>)
-						</Label>
+						<Label htmlFor="source-media">Input media</Label>
 						<div className="text-gray-500 dark:text-gray-300">
 							<span className="text-xs font-normal">
 								Max 10GB (roughly 3 hours of video)
@@ -394,6 +390,15 @@ const ExportForm = () => {
 			>
 				Export to Google Drive
 			</button>
+
+			{downloadUrls && (
+				<HelperText>
+					You can also download the transcription output and input media:{' '}
+					<a href={downloadUrls.text}>transcript text</a>,{' '}
+					<a href={downloadUrls.srt}>transcript SRT</a>,{' '}
+					<a href={downloadUrls.sourceMedia}>input media</a>.
+				</HelperText>
+			)}
 		</>
 	);
 };

--- a/packages/client/src/components/ExportForm.tsx
+++ b/packages/client/src/components/ExportForm.tsx
@@ -1,5 +1,6 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import {
+	DownloadUrls,
 	ExportStatus,
 	ExportStatuses,
 	ExportType,
@@ -98,6 +99,9 @@ const ExportForm = () => {
 		ExportType[]
 	>(['text']);
 	const [exportStatuses, setExportStatuses] = useState<ExportStatuses>([]);
+	const [downloadUrls, setDownloadUrls] = useState<DownloadUrls | undefined>(
+		undefined,
+	);
 
 	// TODO: once we have some CSS/component library, tidy up this messy error handling
 	if (!token) {
@@ -115,6 +119,21 @@ const ExportForm = () => {
 			/>
 		);
 	}
+	useEffect(() => {
+		authFetch(`/api/export/download-urls?id=${transcriptId}`, token).then(
+			(urls) => {
+				const parsedUrls = DownloadUrls.safeParse(urls);
+				if (!parsedUrls.success) {
+					console.error(
+						'Failed to parse download URLs response',
+						parsedUrls.error,
+					);
+					return;
+				}
+				setDownloadUrls(parsedUrls.data);
+			},
+		);
+	}, [transcriptId]);
 	if (requestStatus === RequestStatus.Failed) {
 		return (
 			<InfoMessage
@@ -303,7 +322,9 @@ const ExportForm = () => {
 							)
 						}
 					/>
-					<Label htmlFor="transcript-text">Transcript text</Label>
+					<Label htmlFor="transcript-text">
+						Transcript text (<a href={downloadUrls?.text}>Download</a>)
+					</Label>
 				</div>
 				<div className="flex items-center gap-2">
 					<Checkbox
@@ -320,7 +341,8 @@ const ExportForm = () => {
 						}
 					/>
 					<Label htmlFor="transcript-srt">
-						Transcript text with timecodes (SRT)
+						Transcript text with timecodes (SRT) (
+						<a href={downloadUrls?.srt}>Download</a>)
 					</Label>
 				</div>
 				<div className="flex gap-2">
@@ -340,7 +362,9 @@ const ExportForm = () => {
 						/>
 					</div>
 					<div className="flex flex-col">
-						<Label htmlFor="source-media">Input media</Label>
+						<Label htmlFor="source-media">
+							Input media (<a href={downloadUrls?.sourceMedia}>Download</a>)
+						</Label>
 						<div className="text-gray-500 dark:text-gray-300">
 							<span className="text-xs font-normal">
 								Max 10GB (roughly 3 hours of video)

--- a/packages/client/src/components/ExportForm.tsx
+++ b/packages/client/src/components/ExportForm.tsx
@@ -121,9 +121,10 @@ const ExportForm = () => {
 		);
 	}
 	useEffect(() => {
-		authFetch(`/api/export/download-urls?id=${transcriptId}`, token).then(
-			(urls) => {
-				const parsedUrls = DownloadUrls.safeParse(urls);
+		authFetch(`/api/export/download-urls?id=${transcriptId}`, token)
+			.then((urls) => urls.json())
+			.then((json) => {
+				const parsedUrls = DownloadUrls.safeParse(json);
 				if (!parsedUrls.success) {
 					console.error(
 						'Failed to parse download URLs response',
@@ -132,8 +133,7 @@ const ExportForm = () => {
 					return;
 				}
 				setDownloadUrls(parsedUrls.data);
-			},
-		);
+			});
 	}, [transcriptId]);
 	if (requestStatus === RequestStatus.Failed) {
 		return (

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -206,6 +206,18 @@ export const ExportStatusRequest = z.object({
 	id: z.string(),
 });
 
+export const DownloadUrlRequest = z.object({
+	id: z.string(),
+});
+export type DownloadUrlRequest = z.infer<typeof DownloadUrlRequest>;
+
+export const DownloadUrls = z.object({
+	text: z.string(),
+	srt: z.string(),
+	sourceMedia: z.string(),
+});
+export type DownloadUrls = z.infer<typeof DownloadUrls>;
+
 export const TranscriptExportRequest = z.object({
 	id: z.string(),
 	oAuthTokenResponse: ZTokenResponse,

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -37,7 +37,7 @@ const successMessageBody = (
 	const exportUrl = `${rootUrl}/export?transcriptId=${transcriptId}`;
 	return `
 		<h1>${isTranslation ? 'English translation ' : 'Transcription'} for ${originalFilename} ready</h1>
-		<p>Click <a href="${exportUrl}">here</a> to export transcript/input media to Google drive.</p>
+		<p>Click <a href="${exportUrl}">here</a> to download or export transcript/input media to Google drive.</p>
 		<p>Click <a href="${sourceMediaDownloadUrl}">here</a> to download the input media.</p>
 		<p><b>Note:</b> transcripts and input media will be deleted from this service after 7 days. Export your data now if you want to keep it.</p>
 	`;


### PR DESCRIPTION
## What does this change?
This PR adds a sentence to the bottom of the export form containing download links for the text and srt output of the transcription, as well as the source media. This is following a user request to be able to get the original SRT file from the transcription process.

It looks like this:

<img width="1232" height="433" alt="Screenshot 2025-07-23 at 16 29 58" src="https://github.com/user-attachments/assets/58c6ff4c-7741-406c-bb7b-92ef5e037a5a" />

## How to test
This is currently live on CODE - it looks ok to me