### PR TITLE
Prefer mp4 format for media download service

### DIFF
--- a/packages/media-download/src/yt-dlp.ts
+++ b/packages/media-download/src/yt-dlp.ts
@@ -77,6 +77,8 @@ export const downloadMedia = async (
 			'yt-dlp',
 			[
 				'-v',
+				'-S',
+				'ext', // prefer mp4 format - see https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#format-selection-examples
 				'--extractor-args',
 				'youtubepot-bgutilscript:script_path=/opt/bgutil-ytdlp-pot-provider/server/build/generate_once.js',
 				'--write-info-json',


### PR DESCRIPTION
## What does this change?

We had a user complaint about the webm files the transcription tool sometimes outputs. This change sets yt-dlp to prefer the mp4 format rather than webm, following guidance here https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#format-selection-examples

See [here](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#sorting-formats) for details of what the '-S ext' option actually does

## How to test
I've tested this on CODE and verified that the output video changes from being a webm to a mp4. Only one test case though so it might not work all the time