### PR TITLE
Better error wording for transcription failures

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -119,7 +119,7 @@ const publishTranscriptionOutputFailure = async (
 	destination: string,
 	job: TranscriptionJob,
 ) => {
-	logger.info('publishing transcription output failed');
+	logger.info(`Sending failure message to ${destination}`);
 	const failureMessage: TranscriptionOutputFailure = {
 		id: job.id,
 		status: 'TRANSCRIPTION_FAILURE',
@@ -130,7 +130,7 @@ const publishTranscriptionOutputFailure = async (
 	try {
 		await publishTranscriptionOutput(sqsClient, destination, failureMessage);
 	} catch (e) {
-		logger.error('error publishing transcription output failed', e);
+		logger.error(`error publishing failure message to ${destination}`, e);
 	}
 };
 


### PR DESCRIPTION
## What does this change?
This wording was confusing me, it sounded before like "the transcription output failed to published" when actually it means "I am sending a failure message"

## How to test
it's logs who cares!
