### PR TITLE
Combine all transcription output text into a single JSON file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5923,10 +5923,17 @@
 		},
 		"node_modules/@types/node": {
 			"version": "20.16.10",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.19.2"
+			}
+		},
+		"node_modules/@types/node-gzip": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@types/node-gzip/-/node-gzip-1.1.3.tgz",
+			"integrity": "sha512-gonKbqhKCTrnTpgM5VoVIILYF6odOS4nN2xaIkOUq8ckdrbD3PyF6h5SHIM23eHK/Q1dpHAQsWk5v2WUW7q14Q==",
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -11833,6 +11840,11 @@
 				}
 			}
 		},
+		"node_modules/node-gzip": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/node-gzip/-/node-gzip-1.1.2.tgz",
+			"integrity": "sha512-ZB6zWpfZHGtxZnPMrJSKHVPrRjURoUzaDbLFj3VO70mpLTW5np96vXyHwft4Id0o+PYIzgDkBUjIzaNHhQ8srw=="
+		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
 			"dev": true,
@@ -14185,7 +14197,6 @@
 		},
 		"node_modules/undici-types": {
 			"version": "6.19.8",
-			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/universalify": {
@@ -14717,7 +14728,9 @@
 				"@aws-sdk/client-sqs": "^3.624.0",
 				"@aws-sdk/client-ssm": "^3.624.0",
 				"@aws-sdk/lib-dynamodb": "3.624.0",
+				"@types/node-gzip": "^1.1.3",
 				"axios": "^1.8.2",
+				"node-gzip": "^1.1.2",
 				"winston": "^3.11.0"
 			}
 		},

--- a/packages/api/src/export.ts
+++ b/packages/api/src/export.ts
@@ -44,18 +44,13 @@ export const getCombinedOutput = async (
 		config.app.transcriptionOutputBucket,
 		key,
 	);
+
 	if (isS3Failure(combinedOutputText)) {
-		if (combinedOutputText.failureReason === 'NoSuchKey') {
-			const msg = `Failed to export transcript - file has expired. Please re-upload the file and try again.`;
-			return {
-				status: 'failure',
-				failureReason: msg,
-			};
-		}
-		const msg = `Failed to fetch transcript. Please contact the digital investigations team for support`;
-		logger.error(
-			`Fetching from s3 failed, failure reason: ${combinedOutputText.failureReason}`,
-		);
+		const msg =
+			combinedOutputText.failureReason === 'NoSuchKey'
+				? `Failed to export transcript - file has expired. Please re-upload the file and try again.`
+				: `Failed to fetch transcript. Please contact the digital investigations team for support`;
+		logger.error(msg);
 		return {
 			status: 'failure',
 			failureReason: msg,

--- a/packages/api/src/export.ts
+++ b/packages/api/src/export.ts
@@ -58,7 +58,9 @@ export const getCombinedOutput = async (
 		};
 	}
 
-	const result = TranscriptionResult.safeParse(combinedOutputText);
+	const result = TranscriptionResult.safeParse(
+		JSON.parse(combinedOutputText.text),
+	);
 	if (result.success) {
 		return {
 			status: 'success',

--- a/packages/api/src/export.ts
+++ b/packages/api/src/export.ts
@@ -12,10 +12,71 @@ import {
 	ExportStatuses,
 	ExportType,
 	TranscriptionDynamoItem,
+	TranscriptionResult,
 } from '@guardian/transcription-service-common';
 import { uploadToGoogleDocs } from './services/googleDrive';
 import { S3Client } from '@aws-sdk/client-s3';
 import { docs_v1, drive_v3 } from 'googleapis';
+
+type CombinedOutputFailure = {
+	status: 'failure';
+	failureReason: string;
+};
+type CombinedOutputSuccess = {
+	status: 'success';
+	data: TranscriptionResult;
+};
+type CombinedOutputResult = CombinedOutputFailure | CombinedOutputSuccess;
+
+export const combinedOutputResultIsSuccess = (
+	result: CombinedOutputResult,
+): result is { status: 'success'; data: TranscriptionResult } => {
+	return result.status === 'success';
+};
+
+export const getCombinedOutput = async (
+	config: TranscriptionConfig,
+	s3Client: S3Client,
+	key: string,
+): Promise<CombinedOutputResult> => {
+	const combinedOutputText = await getObjectText(
+		s3Client,
+		config.app.transcriptionOutputBucket,
+		key,
+	);
+	if (isS3Failure(combinedOutputText)) {
+		if (combinedOutputText.failureReason === 'NoSuchKey') {
+			const msg = `Failed to export transcript - file has expired. Please re-upload the file and try again.`;
+			return {
+				status: 'failure',
+				failureReason: msg,
+			};
+		}
+		const msg = `Failed to fetch transcript. Please contact the digital investigations team for support`;
+		logger.error(
+			`Fetching from s3 failed, failure reason: ${combinedOutputText.failureReason}`,
+		);
+		return {
+			status: 'failure',
+			failureReason: msg,
+		};
+	}
+
+	const result = TranscriptionResult.safeParse(combinedOutputText);
+	if (result.success) {
+		return {
+			status: 'success',
+			data: result.data,
+		};
+	} else {
+		const msg = `Failed to parse combined output from S3 for key ${key}: ${result.error.message}`;
+		logger.error(msg);
+		return {
+			status: 'failure',
+			failureReason: msg,
+		};
+	}
+};
 
 export const exportTranscriptToDoc = async (
 	config: TranscriptionConfig,
@@ -25,40 +86,49 @@ export const exportTranscriptToDoc = async (
 	folderId: string,
 	drive: drive_v3.Drive,
 	docs: docs_v1.Docs,
+	combinedOutput?: TranscriptionResult,
 ): Promise<ExportStatus> => {
 	logger.info(`Starting export, export type: ${format}`);
 	const transcriptS3Key = item.transcriptKeys[format];
-	const transcriptText = await getObjectText(
-		s3Client,
-		config.app.transcriptionOutputBucket,
-		transcriptS3Key,
-	);
-	if (isS3Failure(transcriptText)) {
-		if (transcriptText.failureReason === 'NoSuchKey') {
-			const msg = `Failed to export transcript - file has expired. Please re-upload the file and try again.`;
+	// use a mutable variable here as a temporary measure until the old non-combined format is removed
+	let text: string;
+	if (combinedOutput) {
+		text = combinedOutput.transcripts[format];
+	} else {
+		const transcriptText = await getObjectText(
+			s3Client,
+			config.app.transcriptionOutputBucket,
+			transcriptS3Key,
+		);
+		if (isS3Failure(transcriptText)) {
+			if (transcriptText.failureReason === 'NoSuchKey') {
+				const msg = `Failed to export transcript - file has expired. Please re-upload the file and try again.`;
+				return {
+					status: 'failure',
+					message: msg,
+					exportType: format,
+				};
+			}
+			const msg = `Failed to fetch transcript. Please contact the digital investigations team for support`;
+			logger.error(
+				`Fetching from s3 failed, failure reason: ${transcriptText.failureReason}`,
+			);
 			return {
 				status: 'failure',
 				message: msg,
 				exportType: format,
 			};
 		}
-		const msg = `Failed to fetch transcript. Please contact the digital investigations team for support`;
-		logger.error(
-			`Fetching from s3 failed, failure reason: ${transcriptText.failureReason}`,
-		);
-		return {
-			status: 'failure',
-			message: msg,
-			exportType: format,
-		};
+		text = transcriptText.text;
 	}
+
 	try {
 		const docId = await uploadToGoogleDocs(
 			drive,
 			docs,
 			folderId,
 			`${item.originalFilename} transcript${format === 'srt' ? ' with timecodes' : ''} ${item.isTranslation ? ' (English translation)' : ''}`,
-			transcriptText.text,
+			text,
 		);
 		logger.info(`Export of ${format} complete, file id: ${docId}`);
 		return {

--- a/packages/api/src/export.ts
+++ b/packages/api/src/export.ts
@@ -88,7 +88,7 @@ export const exportTranscriptToDoc = async (
 ): Promise<ExportStatus> => {
 	logger.info(`Starting export, export type: ${format}`);
 	const transcriptS3Key = item.transcriptKeys[format];
-	// use a mutable variable here as a temporary measure until the old non-combined format is removed
+	// FIXME use a mutable variable here as a temporary measure until the old non-combined format is removed
 	let text: string;
 	if (combinedOutput) {
 		text = combinedOutput.transcripts[format];

--- a/packages/api/src/export.ts
+++ b/packages/api/src/export.ts
@@ -43,6 +43,7 @@ export const getCombinedOutput = async (
 		s3Client,
 		config.app.transcriptionOutputBucket,
 		key,
+		true,
 	);
 
 	if (isS3Failure(combinedOutputText)) {
@@ -94,6 +95,7 @@ export const exportTranscriptToDoc = async (
 			s3Client,
 			config.app.transcriptionOutputBucket,
 			transcriptS3Key,
+			false,
 		);
 		if (isS3Failure(transcriptText)) {
 			if (transcriptText.failureReason === 'NoSuchKey') {

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -11,7 +11,9 @@
 		"@aws-sdk/client-cloudwatch": "^3.624.0",
 		"@aws-sdk/client-auto-scaling": "^3.624.0",
 		"axios": "^1.8.2",
-		"winston": "^3.11.0"
+		"winston": "^3.11.0",
+		"node-gzip": "^1.1.2",
+		"@types/node-gzip": "^1.1.3"
 	},
 	"private": true,
 	"main": "src/index.ts",

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -52,6 +52,7 @@ export const getSignedUploadUrl = (
 			Bucket: bucket,
 			Key: id,
 			Metadata: metadataWithFilename,
+			// NOTE: Content-Encoding header MUST be specified when file is uploaded if it is defined here
 			ContentEncoding: contentEncoding,
 		}),
 		{ expiresIn }, // override default expiration time of 15 minutes

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -34,6 +34,7 @@ export const getSignedUploadUrl = (
 	useAccelerateEndpoint: boolean,
 	id: string,
 	fileName?: string,
+	contentEncoding?: string,
 ) => {
 	const metadata = {
 		'user-email': userEmail,
@@ -51,6 +52,7 @@ export const getSignedUploadUrl = (
 			Bucket: bucket,
 			Key: id,
 			Metadata: metadataWithFilename,
+			ContentEncoding: contentEncoding,
 		}),
 		{ expiresIn }, // override default expiration time of 15 minutes
 	);
@@ -114,7 +116,7 @@ export const getObjectText = async (
 	client: S3Client,
 	bucket: string,
 	key: string,
-	gzipped?: boolean,
+	gzipped: boolean,
 ): Promise<GetObjectTextResult> => {
 	try {
 		const data = await client.send(

--- a/packages/backend-common/src/s3.ts
+++ b/packages/backend-common/src/s3.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import axios from 'axios';
 import { logger } from '@guardian/transcription-service-backend-common';
 import { AWSStatus } from './types';
+import { ungzip } from 'node-gzip';
 
 const ReadableBody = z.instanceof(Readable);
 
@@ -113,6 +114,7 @@ export const getObjectText = async (
 	client: S3Client,
 	bucket: string,
 	key: string,
+	gzipped?: boolean,
 ): Promise<GetObjectTextResult> => {
 	try {
 		const data = await client.send(
@@ -126,9 +128,17 @@ export const getObjectText = async (
 		for await (const chunk of body) {
 			chunks.push(chunk);
 		}
+		const buffer = Buffer.concat(chunks);
+		if (gzipped) {
+			const dezipped = await ungzip(buffer);
+			return {
+				status: AWSStatus.Success,
+				text: dezipped.toString('utf-8'),
+			};
+		}
 		return {
 			status: AWSStatus.Success,
-			text: Buffer.concat(chunks).toString('utf-8'),
+			text: buffer.toString('utf-8'),
 		};
 	} catch (error: unknown) {
 		if (error instanceof Error) {

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -86,9 +86,11 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		config.aws.region,
 		config.app.transcriptionOutputBucket,
 		userEmail,
-		7,
+		7 * 24 * 60 * 60,
 		false,
 		combinedOutputKey,
+		undefined,
+		'gzip',
 	);
 
 	// user whisperX if whisperX enabled and...

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -80,6 +80,17 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		7,
 	);
 
+	const combinedOutputKey = `combined/${s3Key}.json`;
+
+	const combinedUrl = await getSignedUploadUrl(
+		config.aws.region,
+		config.app.transcriptionOutputBucket,
+		userEmail,
+		7,
+		false,
+		combinedOutputKey,
+	);
+
 	// user whisperX if whisperX enabled and...
 	// duration is either unknown or greater than 10 minutes or  diarization has been requested
 	const engine =
@@ -101,6 +112,7 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		transcriptDestinationService: DestinationService.TranscriptionService,
 		originalFilename,
 		outputBucketUrls: signedUrls,
+		combinedOutputUrl: { key: combinedOutputKey, url: combinedUrl },
 		languageCode,
 		translate: false,
 		diarize: diarizationRequested,

--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -13,6 +13,7 @@ import {
 	TranscriptionOutput,
 	TranscriptionEngine,
 	InputLanguageCode,
+	ONE_WEEK_IN_SECONDS,
 } from '@guardian/transcription-service-common';
 import {
 	getSignedUploadUrl,
@@ -86,7 +87,7 @@ export const generateOutputSignedUrlAndSendMessage = async (
 		config.aws.region,
 		config.app.transcriptionOutputBucket,
 		userEmail,
-		7 * 24 * 60 * 60,
+		ONE_WEEK_IN_SECONDS,
 		false,
 		combinedOutputKey,
 		undefined,

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -92,7 +92,7 @@ const uploadFileAndTranscribe = async (
 		return false;
 	}
 
-	const uploadStatus = await uploadToS3(body.data.presignedS3Url, blob);
+	const uploadStatus = await uploadToS3(body.data.presignedS3Url, blob, false);
 	if (!uploadStatus.isSuccess) {
 		console.error('Failed to upload to s3');
 		return false;

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -1,1 +1,3 @@
 export const MAX_RECEIVE_COUNT = 3;
+
+export const ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -63,6 +63,8 @@ export const TranscriptionJob = z.object({
 	userEmail: z.string(),
 	transcriptDestinationService: z.nativeEnum(DestinationService),
 	outputBucketUrls: OutputBucketUrls,
+	// TODO: make this required once giant has been updated accordingly
+	combinedOutputUrl: z.optional(SignedUrl),
 	languageCode: InputLanguageCode,
 	translate: z.boolean(),
 	diarize: z.boolean(),
@@ -87,6 +89,8 @@ export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
 	// status must be kept in sync with https://github.com/guardian/giant/blob/main/backend/app/extraction/ExternalTranscriptionExtractor.scala#L76
 	status: z.literal('SUCCESS'),
 	languageCode: OutputLanguageCode,
+	// TODO: make non optional once we are confident everything has a combinedOutputKey
+	combinedOutputKey: z.optional(z.string()),
 	outputBucketKeys: OutputBucketKeys,
 	// we can get rid of this when we switch to using a zip
 	translationOutputBucketKeys: z.optional(OutputBucketKeys),
@@ -284,6 +288,8 @@ export const TranscriptionDynamoItem = z.object({
 	id: z.string(),
 	originalFilename: z.string(),
 	transcriptKeys: TranscriptKeys,
+	// TODO: make this non optional and deprecate transcriptKeys
+	combinedOutputKey: z.optional(z.string()),
 	userEmail: z.string(),
 	completedAt: z.optional(z.string()), // dynamodb can't handle dates so we need to use an ISO date
 	isTranslation: z.boolean(),
@@ -292,3 +298,24 @@ export const TranscriptionDynamoItem = z.object({
 });
 
 export type TranscriptionDynamoItem = z.infer<typeof TranscriptionDynamoItem>;
+
+export const Transcripts = z.object({
+	srt: z.string(),
+	text: z.string(),
+	json: z.string(),
+});
+export type Transcripts = z.infer<typeof Transcripts>;
+
+export const TranscriptionMetadata = z.object({
+	detectedLanguageCode: OutputLanguageCode,
+	loadTimeMs: z.optional(z.number()),
+	totalTimeMs: z.optional(z.number()),
+});
+export type TranscriptionMetadata = z.infer<typeof TranscriptionMetadata>;
+
+export const TranscriptionResult = z.object({
+	transcripts: Transcripts,
+	transcriptTranslations: z.optional(Transcripts),
+	metadata: TranscriptionMetadata,
+});
+export type TranscriptionResult = z.infer<typeof TranscriptionResult>;

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -12,11 +12,15 @@ type UploadResult = UploadSuccess | UploadFailure;
 export const uploadToS3 = async (
 	url: string,
 	blob: Blob | Buffer,
+	gzipped: boolean = false,
 ): Promise<UploadResult> => {
 	try {
 		const response = await fetch(url, {
 			method: 'PUT',
 			body: blob,
+			headers: {
+				'Content-Encoding': gzipped ? 'gzip' : 'identity',
+			},
 		});
 		const status = response.status;
 		const isSuccess = status === 200;

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -19,6 +19,7 @@ export const uploadToS3 = async (
 			method: 'PUT',
 			body: blob,
 			headers: {
+				// NOTE: Content-Encoding header MUST match that specified in the presigned url
 				'Content-Encoding': gzipped ? 'gzip' : 'identity',
 			},
 		});

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -11,7 +11,7 @@ type UploadResult = UploadSuccess | UploadFailure;
 
 export const uploadToS3 = async (
 	url: string,
-	blob: Blob,
+	blob: Blob | Buffer,
 ): Promise<UploadResult> => {
 	try {
 		const response = await fetch(url, {

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -84,6 +84,7 @@ const handleTranscriptionSuccess = async (
 			text: transcriptionOutput.outputBucketKeys.text,
 			json: transcriptionOutput.outputBucketKeys.json,
 		},
+		combinedOutputKey: transcriptionOutput.combinedOutputKey,
 		userEmail: transcriptionOutput.userEmail,
 		completedAt: new Date().toISOString(),
 		isTranslation: transcriptionOutput.isTranslation,

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -20,6 +20,7 @@ import {
 	TranscriptionDynamoItem,
 	transcriptionOutputIsMediaDownloadFailure,
 	MediaDownloadFailure,
+	ONE_WEEK_IN_SECONDS,
 } from '@guardian/transcription-service-common';
 import {
 	MetricsService,
@@ -218,7 +219,7 @@ const processMessage = async (event: unknown) => {
 				config.aws.region,
 				config.app.sourceMediaBucket,
 				transcriptionOutput.id,
-				7 * 24 * 60 * 60,
+				ONE_WEEK_IN_SECONDS,
 				transcriptionOutput.originalFilename,
 			);
 			logger.info(`handling transcription success`);
@@ -237,7 +238,7 @@ const processMessage = async (event: unknown) => {
 				config.aws.region,
 				config.app.sourceMediaBucket,
 				transcriptionOutput.id,
-				7 * 24 * 60 * 60,
+				ONE_WEEK_IN_SECONDS,
 				transcriptionOutput.originalFilename,
 			);
 			await handleTranscriptionFailure(

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -366,7 +366,7 @@ const pollTranscriptionQueue = async (
 			process.exit(0);
 		}
 
-		// TODO: combinedOutputUrl won't be optional one day, at which point this if should be removed
+		// TODO: combinedOutputUrl won't be optional one day, at which point this conditional should be removed
 		if (combinedOutputUrl) {
 			await uploadedCombinedResultsToS3(
 				combinedOutputUrl.url,

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -7,6 +7,8 @@ import {
 	languageCodes,
 	OutputLanguageCode,
 	TranscriptionEngine,
+	TranscriptionMetadata,
+	TranscriptionResult,
 } from '@guardian/transcription-service-common';
 import { runSpawnCommand } from '@guardian/transcription-service-backend-common/src/process';
 
@@ -15,24 +17,6 @@ interface FfmpegResult {
 }
 
 export type WhisperModel = 'medium' | 'tiny';
-
-export interface Transcripts {
-	srt: string;
-	text: string;
-	json: string;
-}
-
-type TranscriptionMetadata = {
-	detectedLanguageCode: OutputLanguageCode;
-	loadTimeMs?: number;
-	totalTimeMs?: number;
-};
-
-type TranscriptionResult = {
-	transcripts: Transcripts;
-	transcriptTranslations?: Transcripts;
-	metadata: TranscriptionMetadata;
-};
 
 export type WhisperBaseParams = {
 	containerId?: string;

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -35,7 +35,6 @@ export const uploadedCombinedResultsToS3 = async (
 	result: TranscriptionResult,
 ) => {
 	const gzippedResult: Buffer = await gzip(JSON.stringify(result));
-	// const blob = new Blob([gzippedResult as BlobPart]);
 	const response = await uploadToS3(combinedOutputUrl, gzippedResult, true);
 	if (!response.isSuccess) {
 		throw new Error(

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -1,5 +1,5 @@
 import { logger } from '@guardian/transcription-service-backend-common';
-import { Transcripts } from './transcribe';
+import { TranscriptionResult, Transcripts } from './transcribe';
 import {
 	uploadToS3,
 	type OutputBucketUrls,
@@ -26,4 +26,18 @@ export const uploadAllTranscriptsToS3 = async (
 		}
 		logger.info(`Successfully uploaded file format ${fileFormat} to S3`);
 	}
+};
+
+export const uploadedCombinedResultsToS3 = async (
+	combinedOutputUrl: string,
+	result: TranscriptionResult,
+) => {
+	const blob = new Blob([JSON.stringify(result) as BlobPart]);
+	const response = await uploadToS3(combinedOutputUrl, blob);
+	if (!response.isSuccess) {
+		throw new Error(
+			`Could not upload combined results to S3! ${response.errorMsg}`,
+		);
+	}
+	logger.info(`Successfully uploaded combined results to S3`);
 };

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -1,8 +1,9 @@
 import { logger } from '@guardian/transcription-service-backend-common';
-import { TranscriptionResult, Transcripts } from './transcribe';
 import {
 	uploadToS3,
 	type OutputBucketUrls,
+	Transcripts,
+	TranscriptionResult,
 } from '@guardian/transcription-service-common';
 import { gzip } from 'node-gzip';
 
@@ -19,7 +20,7 @@ export const uploadAllTranscriptsToS3 = async (
 
 	for (const blobDetail of blobs) {
 		const [fileFormat, url, blob] = blobDetail;
-		const response = await uploadToS3(url, blob);
+		const response = await uploadToS3(url, blob, false);
 		if (!response.isSuccess) {
 			throw new Error(
 				`Could not upload file format: ${fileFormat} to S3! ${response.errorMsg}`,
@@ -35,7 +36,7 @@ export const uploadedCombinedResultsToS3 = async (
 ) => {
 	const gzippedResult: Buffer = await gzip(JSON.stringify(result));
 	// const blob = new Blob([gzippedResult as BlobPart]);
-	const response = await uploadToS3(combinedOutputUrl, gzippedResult);
+	const response = await uploadToS3(combinedOutputUrl, gzippedResult, true);
 	if (!response.isSuccess) {
 		throw new Error(
 			`Could not upload combined results to S3! ${response.errorMsg}`,

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -4,6 +4,7 @@ import {
 	uploadToS3,
 	type OutputBucketUrls,
 } from '@guardian/transcription-service-common';
+import { gzip } from 'node-gzip';
 
 export const uploadAllTranscriptsToS3 = async (
 	destinationBucketUrls: OutputBucketUrls,
@@ -32,8 +33,9 @@ export const uploadedCombinedResultsToS3 = async (
 	combinedOutputUrl: string,
 	result: TranscriptionResult,
 ) => {
-	const blob = new Blob([JSON.stringify(result) as BlobPart]);
-	const response = await uploadToS3(combinedOutputUrl, blob);
+	const gzippedResult: Buffer = await gzip(JSON.stringify(result));
+	// const blob = new Blob([gzippedResult as BlobPart]);
+	const response = await uploadToS3(combinedOutputUrl, gzippedResult);
 	if (!response.isSuccess) {
 		throw new Error(
 			`Could not upload combined results to S3! ${response.errorMsg}`,


### PR DESCRIPTION
## What does this change?
This PR aims to make it easier to add new output formats to the transcription service, as well as generally simplifying how files are handled in the service.

Right now, when a transcript is requested the API generates 3 presigned urls for the srt, text and json output formats we request from whisper. These are passed via SQS and used by the worker to upload the output files. The output handler then downloads the files from these locations.

Handling 3 different urls for every transcript adds a bit of complexity.

In this PR I'm adding the concept of 'combinedOutput' which is a single json file containing the transcription output in every format. This would mean that the API (or Giant) just need to provide a single presigned url to the transcription service, the worker only needs to upload one file and the export service only needs to download one file. Happy times!

I've not removed the old functionality yet because:
 - there may be transcription jobs in progress at the point of deployment
 - we still need the txt/srt urls to support the 'download raw file' functionality on the export page. I'll reimplement this in a future PR to use the combined output.

This replaces the work started by @marjisound in https://github.com/guardian/transcription-service/pull/122  - sorry Marjan! I thought this would be less effort than dealing with a zip file. 

Following a discussion with @zekehuntergreen we decided to gzip the combined file. This adds some complexity - not so much in the zipping/unzipping but I decided to set the Content-Encoding header on the file in S3 (to gzip for the gzipped file).

The advantage of setting the content-encoding header in s3 is mainly to tell a potential browser that downloads the file how to open it. The disadvantage is that you have to set the header at the point of generating the presigned url, and the exact same header must be set for the upload. You can then only use that url to upload a file with the right content-encoding header set. 

TODO (in future prs):
 - Get the SRT/TXT downloads working with the new combined file
 - Remove the old 3 file logic

## How to test
I've tested this on CODE. There's a lot of zod 