### PR TITLE
Don't log an error when instance-action returns a 404

### DIFF
--- a/packages/worker/src/spot-termination.ts
+++ b/packages/worker/src/spot-termination.ts
@@ -51,6 +51,9 @@ export const checkSpotInterrupt = async (
 				// once the interrupt warning has happened, we don't need to keep checking
 				return;
 			}
+		} else if (result.status === 404) {
+			// No action scheduled, do nothing
+			// (see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-instance-termination-notices.html#instance-action-metadata)
 		} else {
 			logger.error(
 				`Non-200 response from ${url}: ${result.status} ${result.statusText}`,


### PR DESCRIPTION
## What does this change?

If you have a look at the [transcription worker logs](https://logs.gutools.co.uk/s/investigations/app/r/s/RZT70) you can see this log line every 10 seconds:

`Non-200 response from http://169.254.169.254/latest/meta-data/spot/instance-action: 404 Not Found`

This happens because every 10 seconds the worker queries the instance-action endpoint to see if the spot instance that it is running on is scheduled for termination. Our assumption when implementing this was that the endpoint should always return something. However, if the instance is not scheduled for termination (so most of the time) then that endpoint returns a 404.

With that in mind, to tidy up the logs a bit, let's stop logging every time there's a 404 back from /instance-action.

See here for the relevant docs explaining this: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-instance-termination-notices.html#instance-action-metadata


## How to test
Deploy to CODE, run a job, check that the worker isn't logging the above every 10 seconds