### PR TITLE
Always log out errors before throwing them

### DIFF
--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -317,7 +317,9 @@ export const moveMessageToDeadLetterQueue = async (
 	);
 	if (sendResult.status == AWSStatus.Failure) {
 		// rethrow exception, let another worker retry
-		throw Error('Failed to send message to dead letter queue');
+		throw Error(
+			`Failed to send message to dead letter queue, error: ${sendResult.errorMsg}`,
+		);
 	}
 	// if the delete command throws an exception, it will be caught by
 	// deleteMessage and logged. Another worker will reprocess the message in

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -157,6 +157,7 @@ const runTranscription = async (
 	} catch (error) {
 		logger.error(
 			`Could not read the transcript result. Params: ${JSON.stringify(whisperBaseParams)}`,
+			error,
 		);
 		throw error;
 	}
@@ -221,6 +222,7 @@ const transcribeAndTranslate = async (
 	} catch (error) {
 		logger.error(
 			`Failed during combined detect language/transcribe/translate process result`,
+			error,
 		);
 		throw error;
 	}


### PR DESCRIPTION
## What does this change?
It's often quite hard to trace problems in the transcription tool logs. This PR makes use of the structured logging setup to include the full error object in our logging, so that you don't have to try tie a stack trace to a particular error message in kibana. 

The transcription worker logs get a bit mangled (multi line logs get split into different log entries in elastic) on their way to ELK as they go to a file first and then to ELK using devx logs. I think we could probably sort it to log in a JSON format, but this is a convenient stop gap 