### PR TITLE
Tag GHCR whisper container with branch name

### DIFF
--- a/.github/workflows/build-whisper-container.yml
+++ b/.github/workflows/build-whisper-container.yml
@@ -57,6 +57,6 @@ jobs:
           # to add x86: linux/amd64
           platforms: linux/arm64
           push: true
-          tags: ${{ env.GITHUB_REGISTRY }}/${{ env.WHISPER_IMAGE_NAME }},${{ secrets.TRANSCRIPTION_SERVICE_ECR_URI }}:${{ github.ref_name }}
+          tags: ${{ env.GITHUB_REGISTRY }}/${{ env.WHISPER_IMAGE_NAME }}:${{ github.ref_name }},${{ secrets.TRANSCRIPTION_SERVICE_ECR_URI }}:${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## What does this change?
Currently when baking the whisper AMI we use for the transcription service we download the container with tag `transcription-service:latest`. This means that we end up baking the most recent container that has been published - even if it was baked on a feature branch. 

Recently this caused a problem where a broken container was published, baked into an AMI, then we deployed `main` and the new AMI was picked up with the container baked from the broken feature branch.

To get round this, we should instead only use containers baked from the `main` branch in production. If we need to test a container on a feature branch then we will have to do that locally, or to create a temporary test recipe in amigo. 

This PR is the first step -tagging containers published to the github container registry with the branch they were baked on.

## How to test
I tested this on this feature branch! Looks like this:

<img width="760" height="468" alt="Screenshot 2025-08-27 at 11 30 04" src="https://github.com/user-attachments/assets/5b034ba1-804c-4428-aa8a-b81dfe70d3b7" />
