### PR TITLE
Only set content-encoding header in presigned url for gzipped content

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -14,13 +14,16 @@ export const uploadToS3 = async (
 	blob: Blob | Buffer,
 	gzipped: boolean = false,
 ): Promise<UploadResult> => {
+	// NOTE: Content-Encoding header MUST match that specified in the presigned url
+	const contentEncodingHeader: Record<string, string> = gzipped
+		? { 'Content-Encoding': 'gzip' }
+		: {};
 	try {
 		const response = await fetch(url, {
 			method: 'PUT',
 			body: blob,
 			headers: {
-				// NOTE: Content-Encoding header MUST match that specified in the presigned url
-				'Content-Encoding': gzipped ? 'gzip' : 'identity',
+				...contentEncodingHeader,
 			},
 		});
 		const status = response.status;


### PR DESCRIPTION
## What does this change?
This PR resolves a bug introduced by https://github.com/guardian/transcription-service/pull/167. In that PR I modified the [uploadToS3 function](https://github.com/guardian/transcription-service/blob/main/packages/common/src/utils.ts#L12) to set the content-encoding header. For gzipped content it would be set to 'gzip' and otherwise 'identity'. 

This was a mistake - 'identity' (no encoding) should only be used in the 'Accept-Encoding' header, not the 'Content-Encoding' one.

Also, we don't want to set the 'content-encoding' header at all where it isn't needed, as it constrains the presigned url so that it can only be used where the content-encoding header is set. 

This is a small change to stop setting the content-encoding header at all except where we want a url for gzipped content.

## How to test
Tested on CODE