### PR TITLE
Use combined output file for downloads

### DIFF
--- a/packages/api/src/export.ts
+++ b/packages/api/src/export.ts
@@ -1,12 +1,10 @@
 import {
 	getObjectText,
-	getSignedDownloadUrl,
 	isS3Failure,
 	logger,
 	TranscriptionConfig,
 } from '@guardian/transcription-service-backend-common';
 import {
-	DownloadUrls,
 	ExportItems,
 	ExportStatus,
 	ExportStatuses,
@@ -162,32 +160,4 @@ export const updateStatuses = (
 	return currentStatuses.map((s) =>
 		s.exportType === updatedStatus.exportType ? updatedStatus : s,
 	);
-};
-
-export const getDownloadUrls = async (
-	config: TranscriptionConfig,
-	item: TranscriptionDynamoItem,
-): Promise<DownloadUrls> => {
-	const text = await getSignedDownloadUrl(
-		config.aws.region,
-		config.app.transcriptionOutputBucket,
-		item.transcriptKeys.text,
-		60 * 60 * 12,
-		`${item.originalFilename}.txt`,
-	);
-	const srt = await getSignedDownloadUrl(
-		config.aws.region,
-		config.app.transcriptionOutputBucket,
-		item.transcriptKeys.srt,
-		60 * 60 * 12,
-		`${item.originalFilename}.srt`,
-	);
-	const sourceMedia = await getSignedDownloadUrl(
-		config.aws.region,
-		config.app.sourceMediaBucket,
-		item.id,
-		60 * 60 * 12,
-		`${item.originalFilename}`,
-	);
-	return { text, srt, sourceMedia };
 };

--- a/packages/client/src/components/ExportForm.tsx
+++ b/packages/client/src/components/ExportForm.tsx
@@ -87,6 +87,16 @@ const exportTypesToStatus = (exportTypes: ExportType[]): ExportStatuses => {
 	}));
 };
 
+const triggerFileDownload = (text: string, filename: string) => {
+	// copied from https://stackoverflow.com/questions/3665115/how-to-create-a-file-in-memory-for-user-to-download-but-not-through-server
+	const element = document.createElement('a');
+	const file = new Blob([text], { type: 'text/plain' });
+	element.href = URL.createObjectURL(file);
+	element.download = filename;
+	document.body.appendChild(element);
+	element.click();
+};
+
 const ExportForm = () => {
 	const { token } = useContext(AuthContext);
 	const searchParams = useSearchParams();
@@ -307,15 +317,10 @@ const ExportForm = () => {
 			if (!parsedTranscriptResp.success) {
 				return;
 			}
-			const element = document.createElement('a');
-			const file = new Blob(
-				[parsedTranscriptResp.data.transcript.transcripts[format]],
-				{ type: 'text/plain' },
-			);
-			element.href = URL.createObjectURL(file);
-			element.download = `${parsedTranscriptResp.data.item.originalFilename}.${format === 'text' ? 'txt' : 'srt'}`;
-			document.body.appendChild(element); // Required for this to work in FireFox
-			element.click();
+			const transcriptText =
+				parsedTranscriptResp.data.transcript.transcripts[format];
+			const filename = `${parsedTranscriptResp.data.item.originalFilename}.${format === 'text' ? 'txt' : 'srt'}`;
+			triggerFileDownload(transcriptText, filename);
 			setDownloadStatus(undefined);
 		} else {
 			setDownloadStatus('Failed to download transcript');

--- a/packages/client/src/components/ExportForm.tsx
+++ b/packages/client/src/components/ExportForm.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
 import {
-	DownloadUrls,
 	ExportStatus,
 	ExportStatuses,
 	ExportType,

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -1,3 +1,4 @@
 export const MAX_RECEIVE_COUNT = 3;
 
 export const ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+export const TWELVE_HOURS_IN_SECONDS = 12 * 60 * 60;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -209,14 +209,11 @@ export type ExportStatus = z.infer<typeof ExportStatus>;
 export const ExportStatuses = z.array(ExportStatus);
 export type ExportStatuses = z.infer<typeof ExportStatuses>;
 
-export const ExportStatusRequest = z.object({
+export const TranscriptIdentifier = z.object({
 	id: z.string(),
 });
 
-export const DownloadUrlRequest = z.object({
-	id: z.string(),
-});
-export type DownloadUrlRequest = z.infer<typeof DownloadUrlRequest>;
+export type TranscriptIdentifier = z.infer<typeof TranscriptIdentifier>;
 
 export const DownloadUrls = z.object({
 	text: z.string(),
@@ -224,6 +221,14 @@ export const DownloadUrls = z.object({
 	sourceMedia: z.string(),
 });
 export type DownloadUrls = z.infer<typeof DownloadUrls>;
+
+export const TranscriptDownloadRequest = z.object({
+	id: z.string(),
+	format: z.union([z.literal('text'), z.literal('srt')]),
+});
+export type TranscriptDownloadRequest = z.infer<
+	typeof TranscriptDownloadRequest
+>;
 
 export const TranscriptExportRequest = z.object({
 	id: z.string(),

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -215,13 +215,6 @@ export const TranscriptIdentifier = z.object({
 
 export type TranscriptIdentifier = z.infer<typeof TranscriptIdentifier>;
 
-export const DownloadUrls = z.object({
-	text: z.string(),
-	srt: z.string(),
-	sourceMedia: z.string(),
-});
-export type DownloadUrls = z.infer<typeof DownloadUrls>;
-
 export const TranscriptDownloadRequest = z.object({
 	id: z.string(),
 	format: z.union([z.literal('text'), z.literal('srt')]),
@@ -324,3 +317,11 @@ export const TranscriptionResult = z.object({
 	metadata: TranscriptionMetadata,
 });
 export type TranscriptionResult = z.infer<typeof TranscriptionResult>;
+
+export const TranscriptionItemWithTranscript = z.object({
+	item: TranscriptionDynamoItem,
+	transcript: TranscriptionResult,
+});
+export type TranscriptionItemWithTranscript = z.infer<
+	typeof TranscriptionItemWithTranscript
+>;

--- a/packages/output-handler/test/testMessage.ts
+++ b/packages/output-handler/test/testMessage.ts
@@ -1,19 +1,10 @@
 export const testMessage = {
 	Records: [
 		{
-			messageId: 'e60db2e5-b671-4832-abd4-c3fd40fe1c92',
-			status: 'SUCCESS',
-			receiptHandle: 'handle123',
-			body:
-				'{\n' +
-				'  "Type" : "Notification",\n' +
-				'  "MessageId" : "20c227f2-5767-5ac8-a037-79abd623a58a",\n' +
-				'  "TopicArn" : "arn:aws:sns:eu-west-1:123123123:transcription-service-destination-topic-CODE",\n' +
-				'  "Message" : "{\\"id\\":\\"e3df82e0-8e8a-4c36-9388-741ba97e502c\\",\\"languageCode\\":\\"en\\",\\"userEmail\\":\\"someone@guardian.co.uk\\",\\"originalFilename\\":\\"estoyaquishort.wav\\",\\"outputBucketKeys\\":{\\"srt\\":\\"srt/e3df82e0-8e8a-4c36-9388-741ba97e502c.srt\\",\\"json\\":\\"json/e3df82e0-8e8a-4c36-9388-741ba97e502c.json\\",\\"text\\":\\"text/e3df82e0-8e8a-4c36-9388-741ba97e502c.txt\\"}}",\n' +
-				'  "Timestamp" : "2024-02-28T18:44:20.741Z",\n' +
-				'  "SignatureVersion" : "1"' +
-				'}',
-			eventSourceARN: 'arn:aws:sqs:eu-west-1:123456789:queueMcQueueFace.fifo',
+			messageId: 'id123',
+			ReceiptHandle: 'abc123',
+			MD5OfBody: 'md5md5',
+			body: '{"id":"483be6b2-f0f8-4ba2-8416-35e0c0a0f4a3","status":"SUCCESS","languageCode":"en","userEmail":"hellyr@guardian.co.uk","originalFilename":"mysterious.mp3","outputBucketKeys":{"srt":"srt/75f2b8fd-769b-4e7f-997f-e0eaf49d4788.srt","json":"json/75f2b8fd-769b-4e7f-997f-e0eaf49d4788.json","text":"text/75f2b8fd-769b-4e7f-997f-e0eaf49d4788.txt"},"combinedOutputKey":"combined/75f2b8fd-769b-4e7f-997f-e0eaf49d4788.json","isTranslation":false,"duration":202}',
 		},
 	],
 };


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/transcription-service/pull/167, this updates the direct download functionality added in https://github.com/guardian/transcription-service/pull/156 to use the new combined output file. With this in place, along with this giant update https://github.com/guardian/giant/pull/279 we can deprecate the old way of handling transcription output

## How to test
Run a transcript on CODE (https://transcribe.code.dev-gutools.co.uk/) and check that these links work on the export page:


<img width="880" height="480" alt="Screenshot 2025-08-28 at 11 44 41" src="https://github.com/user-attachments/assets/00d09daf-70dc-456c-96ca-a8dd57b9ce47" />
