### PR TITLE
Use intel for whisper.cpp jobs. Upgrade whisper.cpp

### DIFF
--- a/.github/workflows/build-whisper-container.yml
+++ b/.github/workflows/build-whisper-container.yml
@@ -18,7 +18,15 @@ env:
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, 2core-ubuntu-latest-arm]
+        include:
+          - runner: ubuntu-latest
+            architecture: amd64
+          - runner: 2core-ubuntu-latest-arm
+            architecture: arm64
+    runs-on: ${{ matrix.runner }}
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
@@ -54,8 +62,7 @@ jobs:
         with:
           context: .
           file: containers/whisper.Dockerfile
-          # to add x86: linux/amd64
-          platforms: linux/amd64
+          platforms: linux/${{ matrix.architecture }}
           push: true
           tags: ${{ env.GITHUB_REGISTRY }}/${{ env.WHISPER_IMAGE_NAME }}:${{ github.ref_name }},${{ secrets.TRANSCRIPTION_SERVICE_ECR_URI }}:${{ github.ref_name }}
           cache-from: type=gha

--- a/.github/workflows/build-whisper-container.yml
+++ b/.github/workflows/build-whisper-container.yml
@@ -18,15 +18,7 @@ env:
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image:
-    strategy:
-      matrix:
-        runner: [ubuntu-latest, 2core-ubuntu-latest-arm]
-        include:
-          - runner: ubuntu-latest
-            architecture: amd64
-          - runner: 2core-ubuntu-latest-arm
-            architecture: arm64
-    runs-on: ${{ matrix.runner }}
+    runs-on: 2core-ubuntu-latest-arm
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
@@ -62,7 +54,7 @@ jobs:
         with:
           context: .
           file: containers/whisper.Dockerfile
-          platforms: linux/${{ matrix.architecture }}
+          platforms: linux/arm64
           push: true
           tags: ${{ env.GITHUB_REGISTRY }}/${{ env.WHISPER_IMAGE_NAME }}:${{ github.ref_name }},${{ secrets.TRANSCRIPTION_SERVICE_ECR_URI }}:${{ github.ref_name }}
           cache-from: type=gha

--- a/.github/workflows/build-whisper-container.yml
+++ b/.github/workflows/build-whisper-container.yml
@@ -18,7 +18,7 @@ env:
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image:
-    runs-on: 2core-ubuntu-latest-arm
+    runs-on: ubuntu-latest
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
@@ -55,7 +55,7 @@ jobs:
           context: .
           file: containers/whisper.Dockerfile
           # to add x86: linux/amd64
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.GITHUB_REGISTRY }}/${{ env.WHISPER_IMAGE_NAME }}:${{ github.ref_name }},${{ secrets.TRANSCRIPTION_SERVICE_ECR_URI }}:${{ github.ref_name }}
           cache-from: type=gha

--- a/.github/workflows/build-whisper-container.yml
+++ b/.github/workflows/build-whisper-container.yml
@@ -58,7 +58,7 @@ jobs:
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push whisper Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: containers/whisper.Dockerfile

--- a/containers/whisper.Dockerfile
+++ b/containers/whisper.Dockerfile
@@ -5,7 +5,9 @@ LABEL com.theguardian.transcription-service.whisper-container="Whisper.cpp conta
 RUN apt-get update
 RUN apt-get install -y ffmpeg wget git build-essential cmake
 RUN git clone https://github.com/ggerganov/whisper.cpp
-RUN cd whisper.cpp && git reset --hard v1.7.6 && cmake -B build && cmake --build build -j --config Release
+RUN cd whisper.cpp && git reset --hard v1.7.6
+RUN cd whisper.cpp && cmake -B build  -DWHISPER_NO_AVX=ON -DWHISPER_NO_AVX2=ON -DWHISPER_NO_FMA=ON -DWHISPER_NO_F16C=ON
+RUN cd whisper.cpp cmake --build build -j --config Release
 RUN bash /opt/whisper.cpp/models/download-ggml-model.sh tiny
 RUN bash /opt/whisper.cpp/models/download-ggml-model.sh medium
 

--- a/containers/whisper.Dockerfile
+++ b/containers/whisper.Dockerfile
@@ -5,7 +5,7 @@ LABEL com.theguardian.transcription-service.whisper-container="Whisper.cpp conta
 RUN apt-get update
 RUN apt-get install -y ffmpeg wget git build-essential
 RUN git clone https://github.com/ggerganov/whisper.cpp
-RUN cd whisper.cpp && git reset --hard v1.5.5 && make
+RUN cd whisper.cpp && git reset --hard v1.7.6 && make
 RUN bash /opt/whisper.cpp/models/download-ggml-model.sh tiny
 RUN bash /opt/whisper.cpp/models/download-ggml-model.sh medium
 

--- a/containers/whisper.Dockerfile
+++ b/containers/whisper.Dockerfile
@@ -5,7 +5,7 @@ LABEL com.theguardian.transcription-service.whisper-container="Whisper.cpp conta
 RUN apt-get update
 RUN apt-get install -y ffmpeg wget git build-essential
 RUN git clone https://github.com/ggerganov/whisper.cpp
-RUN cd whisper.cpp && git reset --hard v1.7.6 && make
+RUN cd whisper.cpp && git reset --hard v1.7.6 && cmake -B build && cmake --build build -j --config Release
 RUN bash /opt/whisper.cpp/models/download-ggml-model.sh tiny
 RUN bash /opt/whisper.cpp/models/download-ggml-model.sh medium
 

--- a/containers/whisper.Dockerfile
+++ b/containers/whisper.Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /opt
 LABEL com.theguardian.transcription-service.whisper-container="Whisper.cpp container with models downloaded, including ffmpeg"
 
 RUN apt-get update
-RUN apt-get install -y ffmpeg wget git build-essential
+RUN apt-get install -y ffmpeg wget git build-essential cmake
 RUN git clone https://github.com/ggerganov/whisper.cpp
 RUN cd whisper.cpp && git reset --hard v1.7.6 && cmake -B build && cmake --build build -j --config Release
 RUN bash /opt/whisper.cpp/models/download-ggml-model.sh tiny

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -433,7 +433,7 @@ export class TranscriptionService extends GuStack {
 				machineImage: MachineImage.genericLinux({
 					'eu-west-1': workerAmi.valueAsString,
 				}),
-				instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.XLARGE4),
+				instanceType: InstanceType.of(InstanceClass.C7I, InstanceSize.XLARGE4),
 				// the size of this block device will determine the max input file size for transcription. In future we could
 				// attach the block device on startup once we know how large the file to be transcribed is, or try some kind
 				// of streaming approach to the transcription so we don't need the whole file on disk
@@ -470,13 +470,13 @@ export class TranscriptionService extends GuStack {
 		// the ASG will start at the top of the list and work down until it manages to launch an instance
 		const acceptableInstanceTypes = isProd
 			? [
-					InstanceType.of(InstanceClass.C7G, InstanceSize.XLARGE4),
-					InstanceType.of(InstanceClass.C6G, InstanceSize.XLARGE4),
-					InstanceType.of(InstanceClass.M7G, InstanceSize.XLARGE4),
-					InstanceType.of(InstanceClass.C7G, InstanceSize.XLARGE8),
-					InstanceType.of(InstanceClass.C6G, InstanceSize.XLARGE8),
+					InstanceType.of(InstanceClass.C7I, InstanceSize.XLARGE4),
+					InstanceType.of(InstanceClass.C6I, InstanceSize.XLARGE4),
+					InstanceType.of(InstanceClass.M7I, InstanceSize.XLARGE4),
+					InstanceType.of(InstanceClass.C7I, InstanceSize.XLARGE8),
+					InstanceType.of(InstanceClass.C6I, InstanceSize.XLARGE8),
 				]
-			: [InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM)];
+			: [InstanceType.of(InstanceClass.T3, InstanceSize.MEDIUM)];
 
 		const gpuInstanceTypes = isProd
 			? [

--- a/packages/cdk/riff-raff.yaml
+++ b/packages/cdk/riff-raff.yaml
@@ -32,7 +32,7 @@ deployments:
       amiParametersToTags:
         AMITranscriptionserviceworker:
           BuiltBy: amigo
-          Recipe: investigations-transcription-service
+          Recipe: investigations-transcription-service-cpu-intel
         AMITranscriptionservicegpuworker:
           BuiltBy: amigo
           Recipe: investigations-transcription-service-gpu

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -53,7 +53,7 @@ export const getOrCreateContainer = async (
 		'whisper',
 		'-v',
 		`${tempDir}:${CONTAINER_FOLDER}`,
-		'ghcr.io/guardian/transcription-service:pm-bump-whispercpp',
+		'ghcr.io/guardian/transcription-service:main',
 	]);
 	return newContainer.stdout.trim();
 };

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -53,7 +53,7 @@ export const getOrCreateContainer = async (
 		'whisper',
 		'-v',
 		`${tempDir}:${CONTAINER_FOLDER}`,
-		'ghcr.io/guardian/transcription-service:main',
+		'ghcr.io/guardian/transcription-service@sha256:4bf85a1160cbe8e98a634d84119f761663cecdadf8c0b31820671a49e49cbaa9',
 	]);
 	return newContainer.stdout.trim();
 };

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -361,7 +361,7 @@ export const runWhisper = async (
 		const result = await runSpawnCommand('transcribe', 'docker', [
 			'exec',
 			containerId,
-			'whisper.cpp/main',
+			'whisper.cpp/build/bin/whisper-cli',
 			'--model',
 			`whisper.cpp/models/ggml-${model}.bin`,
 			'--threads',

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -53,7 +53,7 @@ export const getOrCreateContainer = async (
 		'whisper',
 		'-v',
 		`${tempDir}:${CONTAINER_FOLDER}`,
-		'ghcr.io/guardian/transcription-service',
+		'ghcr.io/guardian/transcription-service:pm-bump-whispercpp',
 	]);
 	return newContainer.stdout.trim();
 };


### PR DESCRIPTION
## What does this change?
Recently, the bakes AMIgo was generating with whisper.cpp seemed to stop working - whisper would fail with `illegal instruction (core dumped)`. I haven't tried to debug this, instead I decided to create a new whisper.cpp container with the latest version of whisper.cpp. 

Unfortunately, I couldn't get this new version of whisper.cpp to run on a graviton instance. As an experiment I tried switching to intel, which worked fine - so I think we should just switch to intel.

Downsides:
 - higher costs
 - possibly worse transcription performance

However, we only use whisper.cpp to transcribe files shorter than 10 minutes (longer files run with whisperx on gpu instances), so these downsides won't have much of an impact. The alternative is to spend time trying to get whisper.cpp working on graviton, I think our time could be better spent experimenting with parakeet (https://medium.com/data-science-in-your-pocket/nvidia-parakeet-v2-the-smallest-fastest-free-speech-recognition-asr-model-28ee2ccfac51) or on the giant/transcription service integration.

I did try using the containers published here https://github.com/ggml-org/whisper.cpp/pkgs/container/whisper.cpp - it does say they publish one for linux/arm64, but I wasn't able to pull a container to a graviton instance

## How to test
I've tested this on CODE and verified that it can succesfully transcribe files.
