### PR TITLE
Alarm when a message has been in the task queue for more than a minute

### DIFF
--- a/packages/cdk/lib/alarms.ts
+++ b/packages/cdk/lib/alarms.ts
@@ -20,7 +20,9 @@ export const makeAlarms = (
 	gpuWorkerAsg: AutoScalingGroup,
 	alarmTopicArn: string,
 ) => {
-	const oldestMessageAlarmThreshold = 60;
+	const oldestMessageAlarmThresholdMinutes = 60;
+	const oldestMessageAlarmThresholdSeconds =
+		oldestMessageAlarmThresholdMinutes * 60;
 	const alarms = [
 		// alarm when a message is added to the dead letter queue
 		// note that queue metrics go to 'sleep' if it is empty for more than 6 hours, so it may take up to 16 minutes
@@ -45,10 +47,10 @@ export const makeAlarms = (
 				period: Duration.minutes(5),
 				statistic: 'max',
 			}),
-			threshold: oldestMessageAlarmThreshold,
+			threshold: oldestMessageAlarmThresholdSeconds,
 			evaluationPeriods: 1,
 			actionsEnabled: true,
-			alarmDescription: `A transcription job has been in the task queue for more than ${oldestMessageAlarmThreshold} seconds`,
+			alarmDescription: `A transcription job has been in the task queue for more than ${oldestMessageAlarmThresholdMinutes} minutes`,
 			treatMissingData: TreatMissingData.IGNORE,
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 		}),
@@ -58,10 +60,10 @@ export const makeAlarms = (
 				period: Duration.minutes(5),
 				statistic: 'max',
 			}),
-			threshold: oldestMessageAlarmThreshold,
+			threshold: oldestMessageAlarmThresholdSeconds,
 			evaluationPeriods: 1,
 			actionsEnabled: true,
-			alarmDescription: `A transcription job has been in the gpu task queue for more than ${oldestMessageAlarmThreshold} seconds`,
+			alarmDescription: `A transcription job has been in the gpu task queue for more than ${oldestMessageAlarmThresholdMinutes} minutes`,
 			treatMissingData: TreatMissingData.IGNORE,
 			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 		}),

--- a/packages/cdk/lib/alarms.ts
+++ b/packages/cdk/lib/alarms.ts
@@ -1,0 +1,90 @@
+import type { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { Duration } from 'aws-cdk-lib';
+import type { AutoScalingGroup } from 'aws-cdk-lib/aws-autoscaling';
+import {
+	Alarm,
+	ComparisonOperator,
+	Metric,
+	TreatMissingData,
+} from 'aws-cdk-lib/aws-cloudwatch';
+import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import type { Queue } from 'aws-cdk-lib/aws-sqs';
+
+export const makeAlarms = (
+	scope: GuStack,
+	taskQueue: Queue,
+	gpuTaskQueue: Queue,
+	dlQueue: Queue,
+	cpuWorkerAsg: AutoScalingGroup,
+	gpuWorkerAsg: AutoScalingGroup,
+	alarmTopicArn: string,
+) => {
+	const alarms = [
+		// alarm when a message is added to the dead letter queue
+		// note that queue metrics go to 'sleep' if it is empty for more than 6 hours, so it may take up to 16 minutes
+		// for this alarm to trigger - see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-monitoring-using-cloudwatch.html
+		new Alarm(scope, 'DeadLetterQueueAlarm', {
+			alarmName: `transcription-service-dead-letter-queue-${scope.stage}`,
+			metric: dlQueue.metricApproximateNumberOfMessagesVisible({
+				period: Duration.minutes(1),
+				statistic: 'max',
+			}),
+			threshold: 1,
+			evaluationPeriods: 1,
+			actionsEnabled: true,
+			alarmDescription: `A transcription job has been sent to the dead letter queue. This may be because ffmpeg can't convert the file (maybe it's a JPEG) or because the transcription job has failed multiple times.`,
+			treatMissingData: TreatMissingData.IGNORE,
+			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+		}),
+		// alarm when failure metric is greater than 0
+		new Alarm(scope, 'FailureAlarm', {
+			alarmName: `transcription-service-failure-${scope.stage}`,
+			//  reference the custom metric created in metrics.ts library
+			metric: new Metric({
+				namespace: 'TranscriptionService',
+				metricName: 'Failure',
+				dimensionsMap: {
+					Stage: scope.stage,
+				},
+				statistic: 'sum',
+				period: Duration.minutes(1),
+			}),
+			threshold: 1,
+			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+			evaluationPeriods: 1,
+			actionsEnabled: true,
+			alarmDescription: 'A transcription service failure has occurred',
+			treatMissingData: TreatMissingData.IGNORE,
+		}),
+		// alarm when at least one instance has been running in the worker asg during every 5 minute period for
+		// more than 12 hours
+		new Alarm(scope, 'WorkerInstanceAlarm', {
+			alarmName: `transcription-service-worker-instances-${scope.stage}`,
+			// this doesn't actually create the metric - just a reference to it
+			metric: new Metric({
+				namespace: 'AWS/AutoScaling',
+				metricName: 'GroupTotalInstances',
+				dimensionsMap: {
+					AutoScalingGroupName: gpuWorkerAsg.autoScalingGroupName,
+				},
+				statistic: 'min',
+				period: Duration.minutes(5),
+			}),
+			threshold: 1,
+			comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+			evaluationPeriods: 12 * 12, // 12 hours as metric has period of 5 minutes
+			actionsEnabled: true,
+			alarmDescription: `There has been at least 1 worker instance running for 12 hours.
+						This could mean that a worker is failing to be scaled in, which could have significant cost implications.
+						Please check that all running workers are doing something useful.`,
+			treatMissingData: TreatMissingData.IGNORE,
+		}),
+	];
+	const snsAction = new SnsAction(
+		Topic.fromTopicArn(scope, 'TranscriptionAlarmTopic', alarmTopicArn),
+	);
+	alarms.forEach((alarm) => {
+		alarm.addAlarmAction(snsAction);
+	});
+};

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -38,13 +38,6 @@ import {
 	GroupMetrics,
 	SpotAllocationStrategy,
 } from 'aws-cdk-lib/aws-autoscaling';
-import {
-	Alarm,
-	ComparisonOperator,
-	Metric,
-	TreatMissingData,
-} from 'aws-cdk-lib/aws-cloudwatch';
-import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
 import {
 	InstanceClass,
@@ -67,9 +60,9 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Bucket, HttpMethods } from 'aws-cdk-lib/aws-s3';
-import { Topic } from 'aws-cdk-lib/aws-sns';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { makeAlarms } from './alarms';
 import { makeMediaDownloadService } from './media-download-service';
 
 const topicArnToName = (topicArn: string) => {
@@ -820,78 +813,16 @@ export class TranscriptionService extends GuStack {
 		});
 
 		// alarms
-
 		if (isProd) {
-			const alarms = [
-				// alarm when a message is added to the dead letter queue
-				// note that queue metrics go to 'sleep' if it is empty for more than 6 hours, so it may take up to 16 minutes
-				// for this alarm to trigger - see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-monitoring-using-cloudwatch.html
-				new Alarm(this, 'DeadLetterQueueAlarm', {
-					alarmName: `transcription-service-dead-letter-queue-${props.stage}`,
-					metric:
-						transcriptionDeadLetterQueue.metricApproximateNumberOfMessagesVisible(
-							{ period: Duration.minutes(1), statistic: 'max' },
-						),
-					threshold: 1,
-					evaluationPeriods: 1,
-					actionsEnabled: true,
-					alarmDescription: `A transcription job has been sent to the dead letter queue. This may be because ffmpeg can't convert the file (maybe it's a JPEG) or because the transcription job has failed multiple times.`,
-					treatMissingData: TreatMissingData.IGNORE,
-					comparisonOperator:
-						ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-				}),
-				// alarm when failure metric is greater than 0
-				new Alarm(this, 'FailureAlarm', {
-					alarmName: `transcription-service-failure-${props.stage}`,
-					//  reference the custom metric created in metrics.ts library
-					metric: new Metric({
-						namespace: 'TranscriptionService',
-						metricName: 'Failure',
-						dimensionsMap: {
-							Stage: props.stage,
-						},
-						statistic: 'sum',
-						period: Duration.minutes(1),
-					}),
-					threshold: 1,
-					comparisonOperator:
-						ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-					evaluationPeriods: 1,
-					actionsEnabled: true,
-					alarmDescription: 'A transcription service failure has occurred',
-					treatMissingData: TreatMissingData.IGNORE,
-				}),
-				// alarm when at least one instance has been running in the worker asg during every 5 minute period for
-				// more than 12 hours
-				new Alarm(this, 'WorkerInstanceAlarm', {
-					alarmName: `transcription-service-worker-instances-${props.stage}`,
-					// this doesn't actually create the metric - just a reference to it
-					metric: new Metric({
-						namespace: 'AWS/AutoScaling',
-						metricName: 'GroupTotalInstances',
-						dimensionsMap: {
-							AutoScalingGroupName: transcriptionWorkerASG.autoScalingGroupName,
-						},
-						statistic: 'min',
-						period: Duration.minutes(5),
-					}),
-					threshold: 1,
-					comparisonOperator:
-						ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-					evaluationPeriods: 12 * 12, // 12 hours as metric has period of 5 minutes
-					actionsEnabled: true,
-					alarmDescription: `There has been at least 1 worker instance running for 12 hours.
-						This could mean that a worker is failing to be scaled in, which could have significant cost implications.
-						Please check that all running workers are doing something useful.`,
-					treatMissingData: TreatMissingData.IGNORE,
-				}),
-			];
-			const snsAction = new SnsAction(
-				Topic.fromTopicArn(this, 'TranscriptionAlarmTopic', alarmTopicArn),
+			makeAlarms(
+				this,
+				transcriptionTaskQueue,
+				transcriptionGpuTaskQueue,
+				transcriptionDeadLetterQueue,
+				transcriptionWorkerASG,
+				transcriptionGpuWorkerASG,
+				alarmTopicArn,
 			);
-			alarms.forEach((alarm) => {
-				alarm.addAlarmAction(snsAction);
-			});
 		}
 	}
 }


### PR DESCRIPTION
## What does this change?
If, for some reason (e.g. unavailable spot capacity, invalid AMI) the transcription worker autoscaling group can't start any instances, then messages will just stay in the task queue indefinitely. This would be helpful to know about so we can login and give the workers a kick. 

As part of this I pulled the alarms out into a separate file which makes this harder to review - the actual new alarms are in here https://github.com/guardian/transcription-service/pull/177/commits/fe72aedb4428514cda9d7dd5f4c7c1b9dc881c89

**Alarm threshold**
Initially I set this to just 1 minute, thinking that the longest a message should be in the queue is the amount of time that an instance takes to start up - but that's wrong - messages stay in the queue until the transcription has finished (they are just not visible to other workers if a worker is mid transcription). This makes this metric less helpful for detecting the state of "transcription jobs are not being picked up" - really you need some number of metric relating to the queue and the size of the autoscaling group. 

I think it's still helpful setting this metric though - I've chosen 1 hour, which I think should be enough time for whisperx to transcribe 5 hours of audio (using the maximum approximate age of the oldest message).

Looking at the last week of transcription jobs, this would not have alarmed:
<img width="1136" height="119" alt="Screenshot 2025-09-18 at 17 12 56" src="https://github.com/user-attachments/assets/40f3b9cd-37c2-44dc-922c-ecb386e4229d" />

Looking at the same metric for the (broken) cpu worker queue, the alarm would definitely have triggered:

<img width="1136" height="117" alt="Screenshot 2025-09-18 at 17 13 05" src="https://github.com/user-attachments/assets/48978d86-83b4-4846-8f43-6b8f87373821" />



## How to test
As the alarms aren't deployed on CODE this needs testing on PROD

![wake up!](https://media1.tenor.com/m/_WLnJq8cw0kAAAAC/you-awake-yet-cat.gif)