### PR TITLE
Remove multi-file output code

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -23,14 +23,6 @@ const SignedUrl = z.object({
 
 export type SignedUrl = z.infer<typeof SignedUrl>;
 
-const OutputBucketKeys = z.object({
-	srt: z.string(),
-	text: z.string(),
-	json: z.string(),
-});
-
-export type OutputBucketKeys = z.infer<typeof OutputBucketKeys>;
-
 export const MediaDownloadJob = z.object({
 	id: z.string(),
 	url: z.string(),

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -23,14 +23,6 @@ const SignedUrl = z.object({
 
 export type SignedUrl = z.infer<typeof SignedUrl>;
 
-const OutputBucketUrls = z.object({
-	srt: SignedUrl,
-	text: SignedUrl,
-	json: SignedUrl,
-});
-
-export type OutputBucketUrls = z.infer<typeof OutputBucketUrls>;
-
 const OutputBucketKeys = z.object({
 	srt: z.string(),
 	text: z.string(),
@@ -104,15 +96,11 @@ export const TranscriptionJob = z.object({
 	sentTimestamp: z.string(),
 	userEmail: z.string(),
 	transcriptDestinationService: z.nativeEnum(DestinationService),
-	outputBucketUrls: OutputBucketUrls,
-	// TODO: make this required once giant has been updated accordingly
-	combinedOutputUrl: z.optional(SignedUrl),
+	combinedOutputUrl: SignedUrl,
 	languageCode: InputLanguageCode,
 	translate: z.boolean(),
 	diarize: z.boolean(),
 	engine: z.nativeEnum(TranscriptionEngine),
-	// we can get rid of this when we switch to using a zip
-	translationOutputBucketUrls: z.optional(OutputBucketUrls),
 });
 
 export type TranscriptionJob = z.infer<typeof TranscriptionJob>;
@@ -131,11 +119,7 @@ export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
 	// status must be kept in sync with https://github.com/guardian/giant/blob/main/backend/app/extraction/ExternalTranscriptionExtractor.scala#L76
 	status: z.literal('SUCCESS'),
 	languageCode: OutputLanguageCode,
-	// TODO: make non optional once we are confident everything has a combinedOutputKey
-	combinedOutputKey: z.optional(z.string()),
-	outputBucketKeys: OutputBucketKeys,
-	// we can get rid of this when we switch to using a zip
-	translationOutputBucketKeys: z.optional(OutputBucketKeys),
+	combinedOutputKey: z.string(),
 	duration: z.optional(z.number()),
 });
 
@@ -328,8 +312,7 @@ export const TranscriptionDynamoItem = z.object({
 	id: z.string(),
 	originalFilename: z.string(),
 	transcriptKeys: TranscriptKeys,
-	// TODO: make this non optional and deprecate transcriptKeys
-	combinedOutputKey: z.optional(z.string()),
+	combinedOutputKey: z.string(),
 	userEmail: z.string(),
 	completedAt: z.optional(z.string()), // dynamodb can't handle dates so we need to use an ISO date
 	isTranslation: z.boolean(),

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -80,11 +80,6 @@ const handleTranscriptionSuccess = async (
 	const dynamoItem: TranscriptionDynamoItem = {
 		id: transcriptionOutput.id,
 		originalFilename: transcriptionOutput.originalFilename,
-		transcriptKeys: {
-			srt: transcriptionOutput.outputBucketKeys.srt,
-			text: transcriptionOutput.outputBucketKeys.text,
-			json: transcriptionOutput.outputBucketKeys.json,
-		},
 		combinedOutputKey: transcriptionOutput.combinedOutputKey,
 		userEmail: transcriptionOutput.userEmail,
 		completedAt: new Date().toISOString(),

--- a/packages/output-handler/test/testMessage.ts
+++ b/packages/output-handler/test/testMessage.ts
@@ -4,7 +4,7 @@ export const testMessage = {
 			messageId: 'id123',
 			ReceiptHandle: 'abc123',
 			MD5OfBody: 'md5md5',
-			body: '{"id":"483be6b2-f0f8-4ba2-8416-35e0c0a0f4a3","status":"SUCCESS","languageCode":"en","userEmail":"hellyr@guardian.co.uk","originalFilename":"mysterious.mp3","outputBucketKeys":{"srt":"srt/75f2b8fd-769b-4e7f-997f-e0eaf49d4788.srt","json":"json/75f2b8fd-769b-4e7f-997f-e0eaf49d4788.json","text":"text/75f2b8fd-769b-4e7f-997f-e0eaf49d4788.txt"},"combinedOutputKey":"combined/75f2b8fd-769b-4e7f-997f-e0eaf49d4788.json","isTranslation":false,"duration":202}',
+			body: '{"id":"483be6b2-f0f8-4ba2-8416-35e0c0a0f4a3","status":"SUCCESS","languageCode":"en","userEmail":"hellyr@guardian.co.uk","originalFilename":"mysterious.mp3","combinedOutputKey":"combined/75f2b8fd-769b-4e7f-997f-e0eaf49d4788.json","isTranslation":false,"duration":202}',
 		},
 	],
 };

--- a/packages/worker/src/util.ts
+++ b/packages/worker/src/util.ts
@@ -1,34 +1,9 @@
 import { logger } from '@guardian/transcription-service-backend-common';
 import {
 	uploadToS3,
-	type OutputBucketUrls,
-	Transcripts,
 	TranscriptionResult,
 } from '@guardian/transcription-service-common';
 import { gzip } from 'node-gzip';
-
-export const uploadAllTranscriptsToS3 = async (
-	destinationBucketUrls: OutputBucketUrls,
-	files: Transcripts,
-) => {
-	const getBlob = (file: string) => new Blob([file as BlobPart]);
-	const blobs: [string, string, Blob][] = [
-		['srt', destinationBucketUrls.srt.url, getBlob(files.srt)],
-		['json', destinationBucketUrls.json.url, getBlob(files.json)],
-		['text', destinationBucketUrls.text.url, getBlob(files.text)],
-	];
-
-	for (const blobDetail of blobs) {
-		const [fileFormat, url, blob] = blobDetail;
-		const response = await uploadToS3(url, blob, false);
-		if (!response.isSuccess) {
-			throw new Error(
-				`Could not upload file format: ${fileFormat} to S3! ${response.errorMsg}`,
-			);
-		}
-		logger.info(`Successfully uploaded file format ${fileFormat} to S3`);
-	}
-};
 
 export const uploadedCombinedResultsToS3 = async (
 	combinedOutputUrl: string,


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/transcription-service/pull/167 there's no need to publish multiple output files anymore as we publish a single combined JSON file, this PR tidies up the codebase a bit.

## How to test
Tested on CODE, I verified I could still get a transcript back