### PR TITLE
Bump minimum visibility timeout to 25 minutes

### DIFF
--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -222,7 +222,7 @@ export const getNextMessage = async (
 				QueueUrl: queueUrl,
 				// workers process one transcript at a time
 				MaxNumberOfMessages: 1,
-				VisibilityTimeout: 1500, // 25 minutes
+				VisibilityTimeout: 300, // 	5 minutes
 				// we need to get message attributes so that we can use ApproximateReceiveCount
 				AttributeNames: ['All'],
 			}),
@@ -255,6 +255,7 @@ export const deleteMessage = async (
 	client: SQSClient,
 	queueUrl: string,
 	receiptHandle: string,
+	jobId: string,
 ): Promise<DeleteResult> => {
 	try {
 		await client.send(
@@ -267,7 +268,7 @@ export const deleteMessage = async (
 			status: AWSStatus.Success,
 		};
 	} catch (error) {
-		const errorMsg = `Failed to delete message ${receiptHandle}`;
+		const errorMsg = `Failed to delete message ${receiptHandle} for job ${jobId}`;
 		logger.error(errorMsg, error);
 		return {
 			status: AWSStatus.Failure,
@@ -303,7 +304,7 @@ export const moveMessageToDeadLetterQueue = async (
 	// if the delete command throws an exception, it will be caught by
 	// deleteMessage and logged. Another worker will reprocess the message in
 	// the main task queue and we'll have a duplicate in the dead letter queue.
-	await deleteMessage(client, taskQueueUrl, receiptHandle);
+	await deleteMessage(client, taskQueueUrl, receiptHandle, id);
 };
 
 export const parseTranscriptJobMessage = (

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -402,7 +402,7 @@ const pollTranscriptionQueue = async (
 		);
 
 		logger.info(`Deleting message ${taskMessage.MessageId}`);
-		await deleteMessage(sqsClient, taskQueueUrl, receiptHandle);
+		await deleteMessage(sqsClient, taskQueueUrl, receiptHandle, job.id);
 	} catch (error) {
 		const msg = 'Worker failed to complete';
 		logger.error(msg, error);


### PR DESCRIPTION
## What does this change?
Recently we [started using whisperx for all transcription jobs](https://github.com/guardian/transcription-service/pull/175). WhisperX has a much longer cold start than whisper.cpp - I need to do more investigation across the different instance types we use, but I have noticed it taking 28 minutes to transcribe a 6 minute file. For longer length files, the performance is significantly better than whisper.cpp, we just suffer a bit for shorter files.

With this in mind, we need to increase the visibility timeout we are setting in the worker to allow enough time for the job to complete before the message times out. I think 25 minutes is a bit conservative - probably 20 would be fine, but I think it makes sense to play it safe - better for it to take longer for another worker to pick up the job in the event of a worker failure than to let the message become visible again before the worker has finished. 

Why we don't want the message to become visible: 
 - another worker could start doing the job when it is still in progress
 - after the visibility timeout the receipt handle expires, so we're unable to delete the message from the queue

## How to test
Thankfully there is enough data in kibana to observe this going wrong. For example [here](https://logs.gutools.co.uk/s/investigations/app/r/s/lEUc4) you can see two instances on the same worker of a transcription job taking longer than the visibility timeout we set. 

![not ready](https://media1.giphy.com/media/v1.Y2lkPTZjMDliOTUyMG9jaDBpeHNqZjh3MDdkdHZia2d1MzFjMXhpZDBkdXE4MjhudG5rcyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xTeV7s0qHSWgWI4PMQ/giphy.gif)