### PR TITLE
Set yt-dlp progress delta to 10 seconds

### DIFF
--- a/packages/media-download/src/yt-dlp.ts
+++ b/packages/media-download/src/yt-dlp.ts
@@ -77,6 +77,8 @@ export const downloadMedia = async (
 				'youtubepot-bgutilscript:script_path=/opt/bgutil-ytdlp-pot-provider/server/build/generate_once.js',
 				'--write-info-json',
 				'--no-clean-info-json',
+				'--progress-delta',
+				'10', //seconds
 				'--print-to-file',
 				'after_move:filepath',
 				`${filepathLocation}`,


### PR DESCRIPTION
## What does this change?
We're getting way too many logs out of yt-dlp at the moment, mostly because of the download progress. Let's calm it down a bit by setting `--progress-delta` - see https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#verbosity-and-simulation-options for the docs

For small files every 10s is long enough that we won't get many logs at all, but I think the progress is mainly useful when you're trying to work out if anything is happening, and 10s is short enough for an engineer anxiously refreshing the logs to cope I think 

## How to test
Deploy to CODE, run a download, check it works and that the logging is less chatty here https://logs.gutools.co.uk/s/investigations/app/r/s/zLlrb. I did this, and it worked - just 2 log lines rather than 200:

<img width="723" height="130" alt="Screenshot 2025-10-17 at 13 28 58" src="https://github.com/user-attachments/assets/3f70eebf-0725-458d-972e-c4da4f430f61" />
