### PR TITLE
Fix spot instance check, updating visibility timeout in the correct queue

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -82,7 +82,7 @@ const main = async () => {
 	if (config.app.stage !== 'DEV') {
 		// start job to regularly check the instance interruption (Note: deliberately not using await here so the job
 		// runs in the background)
-		checkSpotInterrupt(sqsClient, config.app.taskQueueUrl);
+		checkSpotInterrupt(sqsClient, queueUrl);
 	}
 
 	let pollCount = 0;


### PR DESCRIPTION
## Before
When workers on spot instances get a notification that the instance is terminating, they are meant to update the visibility timeout of the message that they are currently transcribing to the time when the instance is expected to be terminated. This wasn't working for GPU workers which were attempting to update items in the non-GPU queue and receiving responses from SQS like `ReceiptHandleIsInvalid The receipt handle "xyz" is not valid for this queue.`.

This slows down overall transcription time after a spot instance termination. Instead of the task message being picked up by a new worker immediately, it stays invisible for up to 2 * file duration + 10 minutes - which for longer files is a long time!

## After 
Both worker types attempt to update the correct queue 