### PR TITLE
Set worker asg to 100% on-demand

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -493,7 +493,7 @@ export class TranscriptionService extends GuStack {
 			// 0 is the default, including this here just to make it more obvious what's happening
 			onDemandBaseCapacity: 0,
 			// if this value is set to 100, then we won't use spot instances at all, if it is 0 then we use 100% spot
-			onDemandPercentageAboveBaseCapacity: 10,
+			onDemandPercentageAboveBaseCapacity: 100,
 			spotAllocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED,
 		};
 


### PR DESCRIPTION
## What does this change?
We have twice now run into an issue where no spot capacity was available for the GPU ASG. This PR stops using spot instances for that autoscaling group.

Unfortunately we can't fall back to on-demand instances. (e.g. see https://repost.aws/questions/QUca_6CG6lTvmgEHXsXEr8MA/asg-distribution-instances-unavailable-spot-instances) I'm going to raise this with AWS as a feature that should exist.

An alternative workaround would be to get the worker capacity manager or something else to switch the ASG to on demand instances when it detects that spot instances have been unable to launch. In the short term this seems like the easiest fix though.

## How to test
Already live on production following the incident yesterday