### PR TITLE
Add transcription time and rate to structured logging

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -345,6 +345,7 @@ const pollTranscriptionQueue = async (
 			stage: config.app.stage,
 		};
 
+		const transcriptionStartTime = new Date();
 		const transcriptResult = await getTranscriptionText(
 			whisperBaseParams,
 			job.languageCode,
@@ -352,6 +353,13 @@ const pollTranscriptionQueue = async (
 			combineTranscribeAndTranslate,
 			job.engine === 'whisperx',
 		);
+		const transcriptionEndTime = new Date();
+		const transcriptionTimeSeconds = Math.round(
+			(transcriptionEndTime.getTime() - transcriptionStartTime.getTime()) /
+				1000,
+		);
+		const transcriptionRate =
+			ffmpegResult.duration && ffmpegResult.duration / transcriptionTimeSeconds;
 
 		const languageCode: OutputLanguageCode =
 			job.languageCode === 'auto'
@@ -396,6 +404,9 @@ const pollTranscriptionQueue = async (
 				filename: transcriptionOutput.originalFilename,
 				userEmail: transcriptionOutput.userEmail,
 				mediaDurationSeconds: ffmpegResult.duration || 0,
+				transcriptionTimeSeconds,
+				transcriptionRate: transcriptionRate || '',
+				engine: job.engine,
 				specifiedLanguageCode: job.languageCode,
 				...transcriptResult.metadata,
 			},


### PR DESCRIPTION
## What does this change?
We've had various performance issues with the transcription service recently. These logs are a simple way of improving the visibility we have on performance. Ideally we'd use cloudwatch rather than just logs (as logs are lost after 10 days) but I think it's still helpful to have this information in logs even if we do the cloudwatch work, and in the short term this will give us much better visbility of the performance of the transcription service.

## How to test
Tested on CODE - example log line here https://logs.gutools.co.uk/s/investigations/app/r/s/0v5FA