### PR TITLE
increase visibility timeout grace period

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -318,7 +318,7 @@ const pollTranscriptionQueue = async (
 
 		if (ffmpegResult.duration && ffmpegResult.duration !== 0) {
 			// Transcription time is usually slightly longer than file duration.
-			// Update visibility timeout to 2x the file duration plus 25 minutes for the model to load.
+			// Update visibility timeout to 2x the file duration plus 1 hour for the model to load.
 			// (TODO: investigate whisperx model load time/transcription performance further - it seems to vary)
 			// This should avoid another worker picking up the task and to allow
 			// this worker to delete the message when it's finished.
@@ -326,7 +326,7 @@ const pollTranscriptionQueue = async (
 				sqsClient,
 				taskQueueUrl,
 				receiptHandle,
-				(ffmpegResult.duration * 2 + 1500) * extraTranslationTimeMultiplier,
+				(ffmpegResult.duration * 2 + 3_600) * extraTranslationTimeMultiplier,
 			);
 		}
 


### PR DESCRIPTION
Co-authored-by: @dominickendrick 

Since we're now using on-demand instances, its very unlikely box's will be terminated mid job (so a short/tighter timeout is less valuable) and there are occasions when transcription takes much longer than the duration [anecdotally very noisy videos] and so to avoid unnecessary reprocessing of jobs, this change gives them more time to complete before being retried.
