### PR TITLE
add `SecondsForWhisperXStartup` Cloudwatch metric

### DIFF
--- a/packages/backend-common/src/metrics.ts
+++ b/packages/backend-common/src/metrics.ts
@@ -17,6 +17,11 @@ export const secondsFromEnqueueToStartMetric = (value: number): Metric => ({
 	value,
 	unit: 'Seconds',
 });
+export const secondsForWhisperXStartupMetric = (value: number): Metric => ({
+	name: `SecondsForWhisperXStartup`,
+	value,
+	unit: 'Seconds',
+});
 export const attemptNumberMetric = (value: number): Metric => ({
 	name: `AttemptNumber`,
 	value,

--- a/packages/backend-common/src/process.ts
+++ b/packages/backend-common/src/process.ts
@@ -22,6 +22,9 @@ export const runSpawnCommand = (
 	cmd: string,
 	args: ReadonlyArray<string>,
 	logImmediately: boolean = false,
+	maybeLoggingCallback?: (
+		data: { stdout: string } | { stderr: string },
+	) => void,
 ): Promise<ProcessResult> => {
 	logger.info(
 		`Running process ${processName} with command: ${cmd} ${args.join(' ')}`,
@@ -32,18 +35,22 @@ export const runSpawnCommand = (
 		const stdout: string[] = [];
 		const stderr: string[] = [];
 		cp.stdout.on('data', (data) => {
-			stdout.push(data.toString());
+			const str = data.toString();
+			stdout.push(str);
 			if (logImmediately && logStdout) {
-				logger.info(data.toString());
+				logger.info(str);
 			}
+			maybeLoggingCallback?.({ stdout: str });
 		});
 
 		cp.stderr.on('data', (data) => {
-			stderr.push(data.toString());
+			const str = data.toString();
+			stderr.push(str);
 			if (logImmediately) {
 				// ffmpeg sends all text output to stderr even when it's successful
-				logger.info(data.toString());
+				logger.info(str);
 			}
+			maybeLoggingCallback?.({ stderr: str });
 		});
 
 		cp.on('error', (e) => {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -194,12 +194,12 @@ const pollTranscriptionQueue = async (
 
 	const maybeSentTimestamp: string | undefined | null =
 		message.message.Attributes?.SentTimestamp;
-	const enqueueTimestampInMillis =
+	const enqueuedAtEpochMillis =
 		maybeSentTimestamp && parseInt(maybeSentTimestamp);
-	const now = new Date();
+	const messageReceivedAtEpochMillis = Date.now();
 	const maybeSecondsFromEnqueueToStartMetric =
-		enqueueTimestampInMillis &&
-		(now.getTime() - enqueueTimestampInMillis) / 1000;
+		enqueuedAtEpochMillis &&
+		(messageReceivedAtEpochMillis - enqueuedAtEpochMillis) / 1000;
 
 	if (attemptNumber < 2 && maybeSecondsFromEnqueueToStartMetric) {
 		await metrics.putMetric(
@@ -380,6 +380,7 @@ const pollTranscriptionQueue = async (
 			job.translate,
 			combineTranscribeAndTranslate,
 			job.engine === 'whisperx',
+			metrics,
 		);
 		const transcriptionEndTime = new Date();
 		const transcriptionTimeSeconds = Math.round(


### PR DESCRIPTION
Following on from #215 we actually really needed to know how long the WhisperX warm up time is (since this is the lengthier thing, which we hope to reduce by having a minimum of one worker instance) and so adding a further metric `SecondsForWhisperXStartup`  for this purpose. 

We determine this based on the time between starting the WhisperX process and it emitting anything on either stdout or stderr.

Also added a new log line, showing this same information.