### PR TITLE
tweak `SecondsForWhisperXStartup` Cloudwatch metric

### DIFF
--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -352,8 +352,8 @@ export const runWhisperX = async (
 				wavPath,
 			],
 			false,
-			() => {
-				if (!secondsForWhisperXStartup) {
+			(data) => {
+				if (!secondsForWhisperXStartup && 'stdout' in data) {
 					secondsForWhisperXStartup = (Date.now() - startEpochMillis) / 1000;
 					logger.info(
 						`WhisperX has started actually doing something, after ${secondsForWhisperXStartup}s`,


### PR DESCRIPTION
Slight tweak following #216 to only record `SecondsForWhisperXStartup` Cloudwatch metric after we see something on stdout (rather than either stdout OR stderr) - as we think this is the duration we expect to see reduce most when we move to an always on instance