### PR TITLE
always have a minimum of one GPU worker

### DIFF
--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -713,7 +713,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
             "Granularity": "1Minute",
           },
         ],
-        "MinSize": "1",
+        "MinSize": "0",
         "MixedInstancesPolicy": {
           "InstancesDistribution": {
             "OnDemandBaseCapacity": 0,

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -540,7 +540,7 @@ export class TranscriptionService extends GuStack {
 			'TranscriptionGpuWorkerASG',
 			{
 				...commonAsgProps,
-				minCapacity: 1,
+				minCapacity: this.stage === 'PROD' ? 1 : 0,
 				autoScalingGroupName: gpuWorkerAutoscalingGroupName,
 				mixedInstancesPolicy: {
 					launchTemplate: gpuWorkerLaunchTemplate,

--- a/packages/worker-capacity-manager/src/index.ts
+++ b/packages/worker-capacity-manager/src/index.ts
@@ -16,6 +16,7 @@ const updateASGCapacity = async (
 	sqsClient: SQSClient,
 	queueUrl: string,
 	asgName: string,
+	absoluteMinCapacity: number = 0,
 ) => {
 	const totalMessagesInQueue = await getSQSQueueLengthIncludingInvisible(
 		sqsClient,
@@ -32,7 +33,7 @@ const updateASGCapacity = async (
 	const desiredCapacity = Math.min(
 		totalMessagesInQueue,
 		asgMaxCapacity,
-		1, // always have at least 1 worker
+		absoluteMinCapacity,
 	);
 
 	await setDesiredCapacity(asgClient, asgName, desiredCapacity);
@@ -58,6 +59,7 @@ const updateASGsCapacity = async () => {
 		sqsClient,
 		config.app.gpuTaskQueueUrl,
 		gpuAsgName,
+		config.app.stage === 'PROD' ? 1 : 0, // always have at least 1 GPU worker in PROD
 	);
 };
 const handler: Handler = async () => {


### PR DESCRIPTION
Now we have #215, #216 & #217 released we're in a good place to know/understand the benefit (to user experience of transcription service) of having a minimum of one GPU worker - primarily to avoid warm-up time (both the box visible `SecondsFromEnqueueToStart` metric and the WhisperX warm-up time visible via `SecondsForWhisperXStartup` metric).

So this PR does that (both in the CDK infra definition and in the `worker-capacity-manager`).