### PR TITLE
add `TranscriptionRate` and `SecondsFromEnqueueToCompleteEmailSent` CloudWatch metrics

### DIFF
--- a/packages/backend-common/src/metrics.ts
+++ b/packages/backend-common/src/metrics.ts
@@ -17,6 +17,13 @@ export const secondsFromEnqueueToStartMetric = (value: number): Metric => ({
 	value,
 	unit: 'Seconds',
 });
+export const secondsFromEnqueueToCompleteEmailSentMetric = (
+	value: number,
+): Metric => ({
+	name: `SecondsFromEnqueueToCompleteEmailSent`,
+	value,
+	unit: 'Seconds',
+});
 export const secondsForWhisperXStartupMetric = (value: number): Metric => ({
 	name: `SecondsForWhisperXStartup`,
 	value,

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -151,6 +151,7 @@ export const TranscriptionOutputSuccess = TranscriptionOutputBase.extend({
 	languageCode: OutputLanguageCode,
 	combinedOutputKey: z.string(),
 	duration: z.optional(z.number()),
+	maybeEnqueuedAtEpochMillis: z.optional(z.number()),
 });
 
 export const MediaDownloadFailure = OutputBase.extend({

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -25,6 +25,7 @@ import {
 import {
 	MetricsService,
 	FailureMetric,
+	secondsFromEnqueueToCompleteEmailSentMetric,
 } from '@guardian/transcription-service-backend-common/src/metrics';
 import { SESClient } from '@aws-sdk/client-ses';
 
@@ -107,6 +108,14 @@ const handleTranscriptionSuccess = async (
 				sourceMediaDownloadUrl,
 			),
 		);
+
+		if (transcriptionOutput.maybeEnqueuedAtEpochMillis) {
+			await metrics.putMetric(
+				secondsFromEnqueueToCompleteEmailSentMetric(
+					(Date.now() - transcriptionOutput.maybeEnqueuedAtEpochMillis) / 1000,
+				),
+			);
+		}
 
 		logger.info('Output handler sent success email notification', {
 			id: transcriptionOutput.id,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -195,12 +195,12 @@ const pollTranscriptionQueue = async (
 
 	const maybeSentTimestamp: string | undefined | null =
 		message.message.Attributes?.SentTimestamp;
-	const enqueuedAtEpochMillis =
+	const maybeEnqueuedAtEpochMillis =
 		maybeSentTimestamp && parseInt(maybeSentTimestamp);
 	const messageReceivedAtEpochMillis = Date.now();
 	const maybeSecondsFromEnqueueToStartMetric =
-		enqueuedAtEpochMillis &&
-		(messageReceivedAtEpochMillis - enqueuedAtEpochMillis) / 1000;
+		maybeEnqueuedAtEpochMillis &&
+		(messageReceivedAtEpochMillis - maybeEnqueuedAtEpochMillis) / 1000;
 
 	if (attemptNumber < 2 && maybeSecondsFromEnqueueToStartMetric) {
 		await metrics.putMetric(
@@ -423,6 +423,7 @@ const pollTranscriptionQueue = async (
 			combinedOutputKey: combinedOutputUrl?.key,
 			isTranslation: job.translate,
 			duration: ffmpegResult.duration,
+			maybeEnqueuedAtEpochMillis: maybeEnqueuedAtEpochMillis || undefined,
 		};
 
 		await publishTranscriptionOutput(


### PR DESCRIPTION
Related: #215, #216 & #217 

Add two further CloudWatch metrics for:

- `TranscriptionRate` which emits the ratio of transcription duration VS duration of the file (as already calculated & logged since https://github.com/guardian/transcription-service/pull/212)
- `SecondsFromEnqueueToCompleteEmailSent` total duration from a user's perspective from when they submit their file to when they get their completion email (required a refactor to have the enqueue timestamp emitted from the worker to the output-handler, so it can calculate & publish this metric after the email has been sent.

<img width="611" height="440" alt="image" src="https://github.com/user-attachments/assets/55b66345-27fc-4133-ab25-fbd75adb6cd0" />
