### PR TITLE
Allow instance number to go above absolute min capacity

### DIFF
--- a/packages/worker-capacity-manager/src/index.ts
+++ b/packages/worker-capacity-manager/src/index.ts
@@ -29,11 +29,13 @@ const updateASGCapacity = async (
 		return;
 	}
 	logger.info(`ASG ${asgName} max capacity is ${asgMaxCapacity}`);
+	if (absoluteMinCapacity > asgMaxCapacity) {
+		throw new Error("absoluteMinCapacity can't be greater than asgMaxCapacity");
+	}
 
 	const minCapacity = Math.min(totalMessagesInQueue, asgMaxCapacity);
 
-	const desiredCapacity =
-		minCapacity > absoluteMinCapacity ? minCapacity : absoluteMinCapacity;
+	const desiredCapacity = Math.max(minCapacity, absoluteMinCapacity);
 
 	await setDesiredCapacity(asgClient, asgName, desiredCapacity);
 };


### PR DESCRIPTION
## What does this change?
A tweak of https://github.com/guardian/transcription-service/pull/218 to ensure we have at least 1 node rather than always 1 node. 

## How to test
Run 2 jobs at the same time, we should get 2 nodes