### PR TITLE
Improve youtube failure documentation

### DIFF
--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -9,6 +9,7 @@ import {
 	InputLanguageCode,
 	languageCodeToLanguageWithAuto,
 	YoutubeStatus,
+	ABOUT_THIS_TOOL_YOUTUBE,
 } from '@guardian/transcription-service-common';
 import { AuthContext } from '@/app/template';
 import {
@@ -160,8 +161,6 @@ const checkUrlValid = (url_input: string): MediaUrlInput => {
 };
 
 const renderYoutubeStatus = (status?: YoutubeStatus) => {
-	const aboutThisToolDoc =
-		'https://docs.google.com/document/d/1e224Fe5tJJNeLBNvYLVJ4FWd_O-1nwrJcqKyEXI03lA';
 	if (!status || status === 'LIVE') {
 		return null;
 	} else
@@ -172,7 +171,7 @@ const renderYoutubeStatus = (status?: YoutubeStatus) => {
 						YouTube is currently blocking the transcription tool. The block is
 						temporary but can last several days. You will need to manually
 						download the media from youtube (guide{' '}
-						<a href={aboutThisToolDoc} target="_blank">
+						<a href={ABOUT_THIS_TOOL_YOUTUBE} target="_blank">
 							here
 						</a>
 						) and use the file upload option rather than using this service.
@@ -184,7 +183,7 @@ const renderYoutubeStatus = (status?: YoutubeStatus) => {
 						YouTube recently blocked a request from the transcription service.
 						If your download fails then we recommend downloading the file
 						manually following the instructions{' '}
-						<a href={aboutThisToolDoc} target="_blank">
+						<a href={ABOUT_THIS_TOOL_YOUTUBE} target="_blank">
 							here
 						</a>{' '}
 						before uploading to the transcription service. Other sites are

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -2,3 +2,6 @@ export const MAX_RECEIVE_COUNT = 3;
 
 export const ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
 export const TWELVE_HOURS_IN_SECONDS = 12 * 60 * 60;
+
+export const ABOUT_THIS_TOOL_YOUTUBE =
+	'https://docs.google.com/document/d/1e224Fe5tJJNeLBNvYLVJ4FWd_O-1nwrJcqKyEXI03lA/edit?tab=t.0#heading=h.9ldpalu9ztlj';

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -22,6 +22,7 @@ import {
 	MediaDownloadFailure,
 	ONE_WEEK_IN_SECONDS,
 	MediaDownloadFailureReason,
+	ABOUT_THIS_TOOL_YOUTUBE,
 } from '@guardian/transcription-service-common';
 import {
 	MetricsService,
@@ -71,7 +72,7 @@ const failureDescription = (failureReason: MediaDownloadFailureReason) => {
 					`;
 		case 'BOT_BLOCKED':
 			return `<p>Unfortunately, YouTube blocked the download of this video. You will need to download the media 
-manually (instructions <a href="https://docs.google.com/document/d/1e224Fe5tJJNeLBNvYLVJ4FWd_O-1nwrJcqKyEXI03lA/edit?" target="_blank"> here</a>)
+manually (instructions <a href="${ABOUT_THIS_TOOL_YOUTUBE}" target="_blank"> here</a>)
  and then upload it using the 'File' upload option in the transcription tool.</p> `;
 		default:
 			return `<p>Unfortunately, an error occurred when trying to download the media from this URL for transcription.</p>`;


### PR DESCRIPTION
## What does this change?
This PR attempts to make it clearer to the user what's going on when there's an issue with youtube, as well as providing an alternative way to get a transcript.

## How to test
I've not tested this thoroughly, but think given it's just a wording change maybe that's ok