### PR TITLE
[devx] Add script to trigger the output handler using localstack sqs queue.

### DIFF
--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -30,6 +30,7 @@ import {
 	secondsFromEnqueueToCompleteEmailSentMetric,
 } from '@guardian/transcription-service-backend-common/src/metrics';
 import { SESClient } from '@aws-sdk/client-ses';
+import { sqsMessageToTestMessage } from 'webpage-snapshot/test/testMessage';
 
 const successMessageBody = (
 	transcriptId: string,
@@ -283,6 +284,11 @@ const handler: Handler = async (event) => {
 
 // when running locally bypass the handler
 if (!process.env['AWS_EXECUTION_ENV']) {
-	processMessage(testMessage);
+	const messageBodyEnv = process.env['MESSAGE_BODY'];
+	if (messageBodyEnv) {
+		processMessage(sqsMessageToTestMessage(messageBodyEnv));
+	} else {
+		processMessage(testMessage);
+	}
 }
 export { handler as outputHandler };

--- a/scripts/trigger-output-handler-from-localstack-sqs.sh
+++ b/scripts/trigger-output-handler-from-localstack-sqs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+QUEUE_URL="http://localhost:4566/000000000000/transcription-service-output-queue-DEV"
+
+export MESSAGE_BODY=$(aws sqs receive-message --queue-url $QUEUE_URL --max-number-of-messages 1 --wait-time-seconds 10 --endpoint-url http://localhost:4566 | jq -r '.Messages[0].Body')
+echo $MESSAGE_BODY
+
+if [ -z "$MESSAGE_BODY" ]; then
+  echo "No messages in the queue."
+  exit 0
+fi
+
+npm run output-handler::start


### PR DESCRIPTION
## What does this change?
This PR copies an existing pattern in the webpage-snapshot and media-download apps, adding a script to fetch a message from the localstack sqs queue then trigger the output handler service. This is very helpful when running end to end testing locally, reducing the amount of aws cli faff needed.

## How to test

 - Run transcription api, client, gpu-worker
 - Transcribe a file, wait for the worker to finish
 - Run `scripts/trigger-output-handler-from-localstack-sqs.sh` - you should receive an email with the transcript you requested in the step above
