### PR TITLE
Simplify useEffect for adding time update handler

### DIFF
--- a/packages/client/src/components/TranscriptViewer.tsx
+++ b/packages/client/src/components/TranscriptViewer.tsx
@@ -36,21 +36,15 @@ export const TranscriptViewer: React.FC<TranscriptViewerProps> = ({
 	}, [transcript]);
 
 	useEffect(() => {
-		if (mediaRef.current) {
-			const handleTimeUpdate = () => {
-				if (mediaRef.current) {
-					setCurrentTime(mediaRef.current.currentTime);
-				}
-			};
+		const handleTimeUpdate = () => {
+			if (mediaRef.current) {
+				setCurrentTime(mediaRef.current.currentTime);
+			}
+		};
+		mediaRef.current?.addEventListener('timeupdate', handleTimeUpdate);
 
-			mediaRef.current.addEventListener('timeupdate', handleTimeUpdate);
-
-			return () => {
-				if (mediaRef.current) {
-					mediaRef.current.removeEventListener('timeupdate', handleTimeUpdate);
-				}
-			};
-		}
+		return () =>
+			mediaRef.current?.removeEventListener('timeupdate', handleTimeUpdate);
 	}, [mediaUrl]);
 
 	useEffect(() => {


### PR DESCRIPTION
## What does this change?
In the final commit of https://github.com/guardian/transcription-service/pull/224 I deleted a seemingly unnecessary return statement from the useEffect that attaches the event listener to allow us to track the current time of the player in the component state. Full discussion here: https://github.com/guardian/transcription-service/pull/224#discussion_r2571374743

This triggered a linter error (TS7030 not all code paths return a value). Typescript didn't like that sometimes we returned a function and sometimes there was no explicit return. 

Adding back the explicit 'return undefined' resolves this, but actually this bit of code could be simpler anyway with fewer conditionals, making use of optional chaining - that's what this PR does.

## How to test
Tested on CODE