### PR TITLE
Generate a user agent when running yt-dlp

### DIFF
--- a/packages/media-download/package.json
+++ b/packages/media-download/package.json
@@ -13,7 +13,8 @@
 	"dependencies": {
 		"@guardian/transcription-service-common": "1.0.0",
 		"@guardian/transcription-service-backend-common": "1.0.0",
-		"@aws-sdk/lib-storage": "3.658.1"
+		"@aws-sdk/lib-storage": "3.658.1",
+		"@imaginerlabs/user-agent-generator": "1.0.2"
 	},
 	"devDependencies": {
 		"@types/node": "^20.11.5",

--- a/packages/media-download/src/yt-dlp.ts
+++ b/packages/media-download/src/yt-dlp.ts
@@ -6,6 +6,7 @@ import {
 	MediaMetadata,
 	YoutubeEventDynamoItem,
 } from '@guardian/transcription-service-common';
+import { generateUserAgent } from '@imaginerlabs/user-agent-generator';
 
 type YtDlpSuccess = {
 	status: 'SUCCESS';
@@ -112,6 +113,7 @@ export const downloadMedia = async (
 	const nextProxy =
 		proxyUrls && proxyUrls.length > 0 ? proxyUrls[0] : undefined;
 	const proxyParams = nextProxy ? ['--proxy', nextProxy] : [];
+	const userAgent = generateUserAgent();
 	try {
 		const filepathLocation = `${workingDirectory}/${id}.txt`;
 		// yt-dlp --print-to-file appends to the file, so wipe it first
@@ -135,6 +137,8 @@ export const downloadMedia = async (
 				'--newline',
 				'-o',
 				`${workingDirectory}/${id}.%(ext)s`,
+				'--user-agent',
+				userAgent,
 				...proxyParams,
 				url,
 			],


### PR DESCRIPTION
## What does this change?
As suggested by @twrichards , use  https://www.npmjs.com/package/@imaginerlabs/user-agent-generator to make the media download service look a bit more human. 

## How to test
Tested on CODE. Only time will tell the impact of this 