### PR TITLE
Ensure bgutil-pot-provider script and plugin use the same version

### DIFF
--- a/containers/media-download.Dockerfile
+++ b/containers/media-download.Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /opt
 LABEL com.theguardian.transcription-service.media-download-container="Media download container with yt-dlp, associated dependencies and media download app"
 
 ARG node_version
+ARG BGUTIL_YTDLP_POT_PROVIDER_VERSION=1.2.2
 
 RUN pip install yt-dlp
 
@@ -13,14 +14,14 @@ RUN echo "node version: $node_version"
 RUN n $node_version
 
 # Setup bgutil-ytdlp-pot-provider provider
-RUN git clone --single-branch --branch 1.1.0 https://github.com/Brainicism/bgutil-ytdlp-pot-provider.git
+RUN git clone --single-branch --branch ${BGUTIL_YTDLP_POT_PROVIDER_VERSION} https://github.com/Brainicism/bgutil-ytdlp-pot-provider.git
 WORKDIR /opt/bgutil-ytdlp-pot-provider/server
 RUN yarn install --frozen-lockfile
 RUN yarn tsc
 
 WORKDIR /opt
 # Install the bgutil-ytdlp-pot-provider plugin for yt-dlp
-RUN python -m pip install -U bgutil-ytdlp-pot-provider
+RUN python -m pip install -U bgutil-ytdlp-pot-provider==${BGUTIL_YTDLP_POT_PROVIDER_VERSION}
 
 # Install and run media-download app
 COPY ./packages/media-download/dist/index.js /opt/media-download.js


### PR DESCRIPTION
## What does this change?

I recently saw this error in the logs regarding the [bgutil-ytdlp-pot-provider](https://github.com/Brainicism/bgutil-ytdlp-pot-provider?tab=readme-ov-file) in the media download service:
```
WARNING: [pot:bgutil:script] The provider plugin and the script are on different versions, this may cause compatibility issues. Please ensure they are on the same version. Otherwise, help will NOT be provided for any issues that arise. (plugin: 1.2.2, script: 1.1.0)
```

This PR brings both plugin and script onto version 1.2.2. This plugin was originally added in https://github.com/guardian/transcription-service/pull/154

## How to test
Tested on CODE