### PR TITLE
If yt-dlp gets a 403, try a different proxy before giving up

### DIFF
--- a/packages/media-download/src/yt-dlp.ts
+++ b/packages/media-download/src/yt-dlp.ts
@@ -152,9 +152,13 @@ export const downloadMedia = async (
 			if (result.stderr.includes('ERROR: Unsupported URL')) {
 				return { errorType: 'INVALID_URL', status: 'FAILURE' };
 			}
-			if (result.stderr.includes('LOGIN_REQUIRED') && url.includes('youtube')) {
+			if (
+				url.includes('youtube') &&
+				(result.stderr.includes('LOGIN_REQUIRED') ||
+					result.stderr.includes('HTTP Error 403'))
+			) {
 				if (proxyUrls && proxyUrls.length > 1) {
-					console.log('Got blocked. Retrying yt-dlp with next proxy...');
+					logger.info('Got blocked. Retrying yt-dlp with next proxy...');
 					return downloadMedia(url, workingDirectory, id, proxyUrls?.slice(1));
 				}
 				return { errorType: 'BOT_BLOCKED', status: 'FAILURE' };


### PR DESCRIPTION
## What does this change?
I've noticed that yt-dlp sometimes receives a 403 back from youtube, but the same request from a different proxy succeeds. With that in mind, this PR modifies the media download service so that it tries again with a different proxy if it gets a 403 from youtube.

## How to test
I've tested this on CODE
