### PR TITLE
Revert "Generate a user agent when running yt-dlp"

### DIFF
--- a/packages/media-download/package.json
+++ b/packages/media-download/package.json
@@ -13,8 +13,7 @@
 	"dependencies": {
 		"@guardian/transcription-service-common": "1.0.0",
 		"@guardian/transcription-service-backend-common": "1.0.0",
-		"@aws-sdk/lib-storage": "3.658.1",
-		"@imaginerlabs/user-agent-generator": "1.0.2"
+		"@aws-sdk/lib-storage": "3.658.1"
 	},
 	"devDependencies": {
 		"@types/node": "^20.11.5",

--- a/packages/media-download/src/yt-dlp.ts
+++ b/packages/media-download/src/yt-dlp.ts
@@ -6,7 +6,6 @@ import {
 	MediaMetadata,
 	YoutubeEventDynamoItem,
 } from '@guardian/transcription-service-common';
-import { generateUserAgent } from '@imaginerlabs/user-agent-generator';
 
 type YtDlpSuccess = {
 	status: 'SUCCESS';
@@ -113,7 +112,6 @@ export const downloadMedia = async (
 	const nextProxy =
 		proxyUrls && proxyUrls.length > 0 ? proxyUrls[0] : undefined;
 	const proxyParams = nextProxy ? ['--proxy', nextProxy] : [];
-	const userAgent = generateUserAgent();
 	try {
 		const filepathLocation = `${workingDirectory}/${id}.txt`;
 		// yt-dlp --print-to-file appends to the file, so wipe it first
@@ -137,8 +135,6 @@ export const downloadMedia = async (
 				'--newline',
 				'-o',
 				`${workingDirectory}/${id}.%(ext)s`,
-				'--user-agent',
-				userAgent,
 				...proxyParams,
 				url,
 			],


### PR DESCRIPTION
Reverts guardian/transcription-service#228 as yt-dlp already does this automatically in the standard headers https://github.com/yt-dlp/yt-dlp/blob/7ec6b9bc40ee8a21b11cce83a09a07a37014062e/yt_dlp/utils/networking.py#L162