### PR TITLE
Fix translation

### DIFF
--- a/packages/backend-common/src/sqs.ts
+++ b/packages/backend-common/src/sqs.ts
@@ -124,6 +124,17 @@ export const generateOutputSignedUrlAndSendMessage = async (
 	}
 	if (!isSqsFailure(messageResult) && translationRequested) {
 		const translationId = `${s3Key}-translation`;
+		const translationCombinedOutputKey = `combined/${translationId}.json`;
+		const translationCombinedUrl = await getSignedUploadUrl(
+			config.aws.region,
+			config.app.transcriptionOutputBucket,
+			userEmail,
+			ONE_WEEK_IN_SECONDS,
+			false,
+			translationCombinedOutputKey,
+			undefined,
+			'gzip',
+		);
 		return await sendMessage(
 			client,
 			queue,
@@ -131,6 +142,10 @@ export const generateOutputSignedUrlAndSendMessage = async (
 				...job,
 				id: translationId,
 				translate: true,
+				combinedOutputUrl: {
+					key: translationCombinedOutputKey,
+					url: translationCombinedUrl,
+				},
 			}),
 			translationId,
 		);

--- a/packages/client/src/app/viewer/page.tsx
+++ b/packages/client/src/app/viewer/page.tsx
@@ -50,6 +50,7 @@ const ViewerPage = () => {
 	const { token } = useContext(AuthContext);
 	const searchParams = useSearchParams();
 	const transcriptId = searchParams.get('transcriptId');
+	const transcriptIdNoTranslate = transcriptId?.replace('-translation', '');
 
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
@@ -83,7 +84,7 @@ const ViewerPage = () => {
 				setTranscriptData(parsedTranscript.data);
 
 				const mediaResponse = await authFetch(
-					`/api/export/source-media-download-url?id=${transcriptId}`,
+					`/api/export/source-media-download-url?id=${transcriptIdNoTranslate}`,
 					token,
 				);
 


### PR DESCRIPTION
## What does this change?
It looks like https://github.com/guardian/transcription-service/pull/167 broke translations, as transcription/translation output are currently both uploaded to the same location in s3.

This fixes that problem, but longer term we should modify the behaviour of the transcription service so that if you request a translation then both transcription/translation happen on the same worker and deliver a single file as the result. It's a small change as the functionality already exists for giant, but we'd need to adjust the email templates to include both outputs.



## How to test
Tested on CODE