### PR TITLE
Perform translation in the same job as transcription

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4313,14 +4313,6 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/@imaginerlabs/user-agent-generator": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@imaginerlabs/user-agent-generator/-/user-agent-generator-1.0.2.tgz",
-			"integrity": "sha512-QTOi46xtGLnYG4OFxyaoRL+KnL6RopZ5Foh2dO+OVnoYpv5wM9zhSlgiOwr43I0Q6cIeiDQ/8xQDmXY7f4As1A==",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"license": "ISC",
@@ -15892,8 +15884,7 @@
 			"dependencies": {
 				"@aws-sdk/lib-storage": "3.658.1",
 				"@guardian/transcription-service-backend-common": "1.0.0",
-				"@guardian/transcription-service-common": "1.0.0",
-				"@imaginerlabs/user-agent-generator": "1.0.2"
+				"@guardian/transcription-service-common": "1.0.0"
 			},
 			"devDependencies": {
 				"@types/node": "^20.11.5",

--- a/packages/client/src/components/ExportForm.tsx
+++ b/packages/client/src/components/ExportForm.tsx
@@ -133,7 +133,6 @@ const ExportForm = () => {
 	}
 
 	const transcriptId = searchParams.get('transcriptId');
-	const translationFailure = searchParams.get('translationFailure') === 'true';
 	const includesTranslation =
 		searchParams.get('includesTranslation') === 'true';
 	const availableExports = includesTranslation
@@ -406,11 +405,6 @@ const ExportForm = () => {
 				))}
 
 				<Flowbite theme={{ theme: customTheme }}>
-					{translationFailure && (
-						<Alert className="font-light text-sm align-middle" color="yellow">
-							Unfortunately the english translation of your transcript failed
-						</Alert>
-					)}
 					{!atLeastOneExport() ? (
 						<Alert className="font-light text-sm align-middle" color="red">
 							Please select at least one item for export

--- a/packages/client/src/components/TranscriptViewer.tsx
+++ b/packages/client/src/components/TranscriptViewer.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { TranscriptionResult } from '@guardian/transcription-service-common';
 import { formatTime, parseSRT, TranscriptSegment } from '@/services/srt';
+import { Label, Radio } from 'flowbite-react';
 
 type TranscriptViewerProps = {
 	transcript: TranscriptionResult;
@@ -27,13 +28,17 @@ export const TranscriptViewer: React.FC<TranscriptViewerProps> = ({
 	const [segments, setSegments] = useState<TranscriptSegment[]>([]);
 	const activeSegmentRef = useRef<HTMLDivElement>(null);
 	const transcriptContainerRef = useRef<HTMLDivElement>(null);
+	const [showTranslation, setShowTranslation] = useState(false);
 
 	useEffect(() => {
-		if (transcript.transcripts.srt) {
-			const parsed = parseSRT(transcript.transcripts.srt);
+		const srt = showTranslation
+			? transcript.transcriptTranslations?.srt
+			: transcript.transcripts.srt;
+		if (srt) {
+			const parsed = parseSRT(srt);
 			setSegments(parsed);
 		}
-	}, [transcript]);
+	}, [transcript, showTranslation]);
 
 	useEffect(() => {
 		const handleTimeUpdate = () => {
@@ -131,9 +136,39 @@ export const TranscriptViewer: React.FC<TranscriptViewerProps> = ({
 
 			{/* Interactive Transcript - Order 2 on mobile, 2 on desktop */}
 			<div className="order-2">
-				<h3 className="font-semibold text-gray-900 mb-3">
-					Interactive Transcript
-				</h3>
+				<div className="mb-4">
+					{transcript.transcriptTranslations && (
+						<fieldset>
+							<div className="flex items-center gap-4">
+								<legend className="font-semibold text-gray-900">
+									Transcript version:
+								</legend>
+								<div className="flex items-center gap-2">
+									<Radio
+										id="show-transcript"
+										name="transcript-view"
+										value="original"
+										checked={!showTranslation}
+										onChange={() => setShowTranslation(false)}
+									/>
+									<Label htmlFor="show-transcript">Original</Label>
+								</div>
+								<div className="flex items-center gap-2">
+									<Radio
+										id="show-english-translation"
+										name="transcript-view"
+										value="translation"
+										checked={showTranslation}
+										onChange={() => setShowTranslation(true)}
+									/>
+									<Label htmlFor="show-english-translation">
+										English translation
+									</Label>
+								</div>
+							</div>
+						</fieldset>
+					)}
+				</div>
 				<div
 					ref={transcriptContainerRef}
 					className="bg-white border border-gray-200 rounded-lg max-h-[600px] overflow-y-auto"

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -511,9 +511,8 @@ export const UploadForm = () => {
 								value="English translation"
 							/>
 							<p className="font-light">
-								If you request a translation, you will receive two emails - one
-								with the transcript in the original language, and another with
-								the translation into English. Translation quality varies.
+								Translation results are now included in the same email.
+								Translation quality varies
 							</p>
 						</div>
 						<div className={'ml-3'}>

--- a/packages/client/src/components/UploadSuccess.tsx
+++ b/packages/client/src/components/UploadSuccess.tsx
@@ -30,14 +30,12 @@ export const UploadSuccess = ({
 				{mediaDownloadText}
 				<p>
 					{' '}
-					The transcription service can take a few minutes to start up, but
-					thereafter the transcription process is typically shorter than the
-					duration of the media file.{' '}
+					The transcription process is typically shorter than the duration of
+					the media file.{' '}
 				</p>
 				<p>
-					If you have requested a translation, you will receive two emails: one
-					for the transcription in the original language; another for the
-					English translation. The emails will arrive at different times.
+					English translations are now included in the same email as the
+					transcript in the original language.
 				</p>
 			</div>
 			<button

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -68,6 +68,6 @@ export const getTranscriptDoc = (
 		case 'translation-text':
 			return transcriptResult.transcriptTranslations?.['text'];
 		default:
-			throw new Error();
+			throw new Error('Invalid doc export type');
 	}
 };

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,3 +1,5 @@
+import { DocExportType, TranscriptionResult } from './types';
+
 interface UploadSuccess {
 	isSuccess: true;
 }
@@ -50,5 +52,22 @@ export const uploadToS3 = async (
 			isSuccess: false,
 			errorMsg,
 		};
+	}
+};
+
+export const getTranscriptDoc = (
+	docExportType: DocExportType,
+	transcriptResult: TranscriptionResult,
+) => {
+	switch (docExportType) {
+		case 'text':
+		case 'srt':
+			return transcriptResult.transcripts[docExportType];
+		case 'translation-srt':
+			return transcriptResult.transcriptTranslations?.['srt'];
+		case 'translation-text':
+			return transcriptResult.transcriptTranslations?.['text'];
+		default:
+			throw new Error();
 	}
 };

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -37,19 +37,13 @@ const successMessageBody = (
 	originalFilename: string,
 	rootUrl: string,
 	includesTranslation: boolean,
-	translationRequested: boolean,
 ): string => {
-	const translationFailure = translationRequested && !includesTranslation;
-	const exportUrl = `${rootUrl}/export?transcriptId=${transcriptId}&translationFailure=${translationFailure}&includesTranslation=${includesTranslation}`;
+	const exportUrl = `${rootUrl}/export?transcriptId=${transcriptId}&includesTranslation=${includesTranslation}`;
 	const viewerUrl = `${rootUrl}/viewer?transcriptId=${transcriptId}`;
-	const transcriptionError = translationFailure
-		? `<p>Unfortunately the translation job failed. Please contact digital.investigations@theguardian.com for support.</p>`
-		: '';
 	return `
 		<h1>${includesTranslation ? 'Transcription and english translation ' : 'Transcription'} for ${originalFilename} ready</h1>
 		<p>Click <a href="${exportUrl}">here</a> to download or export transcript/input media to Google drive.</p>
 		<p>Click <a href="${viewerUrl}">here</a> to view and play back your transcript.</p>
-		${transcriptionError}
 		<p>You may wish to open the playback view and the Google Document side by side to review the transcript and make corrections.</p>
 		<p><b>Note:</b> transcripts and input media will be deleted from this service after 7 days. Export your data now if you want to keep it.</p>
 	`;
@@ -130,7 +124,6 @@ const handleTranscriptionSuccess = async (
 				transcriptionOutput.originalFilename,
 				config.app.rootUrl,
 				transcriptionOutput.includesTranslation,
-				transcriptionOutput.translationRequested,
 			),
 		);
 

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -42,11 +42,14 @@ const successMessageBody = (
 	const translationFailure = translationRequested && !includesTranslation;
 	const exportUrl = `${rootUrl}/export?transcriptId=${transcriptId}&translationFailure=${translationFailure}&includesTranslation=${includesTranslation}`;
 	const viewerUrl = `${rootUrl}/viewer?transcriptId=${transcriptId}`;
+	const transcriptionError = translationFailure
+		? `<p>Unfortunately the translation job failed. Please contact digital.investigations@theguardian.com for support.</p>`
+		: '';
 	return `
 		<h1>${includesTranslation ? 'Transcription and english translation ' : 'Transcription'} for ${originalFilename} ready</h1>
 		<p>Click <a href="${exportUrl}">here</a> to download or export transcript/input media to Google drive.</p>
 		<p>Click <a href="${viewerUrl}">here</a> to view and play back your transcript.</p>
-		<p>${translationFailure && 'Unfortunately the translation job failed. Please contact digital.investigations@theguardian.com for support.'}</p>
+		${transcriptionError}
 		<p>You may wish to open the playback view and the Google Document side by side to review the transcript and make corrections.</p>
 		<p><b>Note:</b> transcripts and input media will be deleted from this service after 7 days. Export your data now if you want to keep it.</p>
 	`;

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -274,7 +274,6 @@ const pollTranscriptionQueue = async (
 			: '/tmp';
 		const translationDirectory = `${destinationDirectory}/translation/`;
 
-		// ensure destination directory exists
 		logger.info(
 			`Ensuring ${destinationDirectory} and ${translationDirectory} exist`,
 		);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -44,6 +44,7 @@ import { setTimeout } from 'timers/promises';
 import { MAX_RECEIVE_COUNT } from '@guardian/transcription-service-common';
 import { checkSpotInterrupt } from './spot-termination';
 import { AutoScalingClient } from '@aws-sdk/client-auto-scaling';
+import fs from 'node:fs';
 
 const POLLING_INTERVAL_SECONDS = 15;
 
@@ -271,6 +272,14 @@ const pollTranscriptionQueue = async (
 		const destinationDirectory = isDev
 			? `${__dirname}/../../../worker-tmp-files`
 			: '/tmp';
+		const translationDirectory = `${destinationDirectory}/translation/`;
+
+		// ensure destination directory exists
+		logger.info(
+			`Ensuring ${destinationDirectory} and ${translationDirectory} exist`,
+		);
+		fs.mkdirSync(destinationDirectory, { recursive: true });
+		fs.mkdirSync(translationDirectory, { recursive: true });
 
 		const fileToTranscribe = await getObjectWithPresignedUrl(
 			inputSignedUrl,
@@ -352,6 +361,8 @@ const pollTranscriptionQueue = async (
 			diarize: job.diarize,
 			stage: config.app.stage,
 			huggingFaceToken: config.dev?.huggingfaceToken,
+			baseDirectory: destinationDirectory,
+			translationDirectory,
 		};
 
 		const transcriptionStartTime = new Date();

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -169,10 +169,6 @@ const runTranscription = async (
 	}
 };
 
-// Note: this functionality is only for transcription jobs coming from giant at the moment, though it could be good
-// to make it the standard approach for the transcription tool too (rather than what happens currently, where the
-// transcription API sends two messages to the worker - one for transcription, another for transcription with translation
-// (see generateOutputSignedUrlAndSendMessage in sqs.ts)
 const transcribeAndTranslate = async (
 	whisperBaseParams: WhisperBaseParams,
 	whisperX: boolean,
@@ -243,7 +239,6 @@ export const getTranscriptionText = async (
 	whisperBaseParams: WhisperBaseParams,
 	languageCode: InputLanguageCode,
 	translate: boolean,
-	combineTranscribeAndTranslate: boolean,
 	whisperX: boolean,
 	metrics: MetricsService,
 ): Promise<TranscriptionResult> => {
@@ -251,7 +246,7 @@ export const getTranscriptionText = async (
 		// in shakira mode, all input transcribes to shakira
 		return SHAKIRA;
 	}
-	if (combineTranscribeAndTranslate) {
+	if (translate) {
 		return transcribeAndTranslate(
 			whisperBaseParams,
 			whisperX,


### PR DESCRIPTION
## What does this change?
Currently, when a user requests a translation of their transcription task, the transcription API just sends two jobs to the queue, one for the transcription, the other for the translation. The user then receives 2 emails - one for each job.

This PR modifies that behaviour so that transcripion and translation are performed in a single job on the same worker. This was already the behaviour for jobs coming from giant, and issues such as this one https://github.com/guardian/transcription-service/pull/235 have made me think that it would be preferable to have fewer pathways through the app rather than separate flows for giant/transcription service. 

The main interesting change in this pr is in the `transcribeAndTranslate` function - which now will attempt to run the translation job in parallel with the transcription job (based off learnings from https://github.com/guardian/transcription-service/pull/238). Otherwise, it's a lot of rewiring in the output handler, viewer and export page to account for the user now only getting one email when the job(s) finish.  

Note: Based on [some testing](https://docs.google.com/spreadsheets/d/1P1Vq9ltKNHFcTMs6Ak9C04RLEVWOfjxV57wYcZf7ODg/edit?gid=0#gid=0), we think that running 2 jobs in parallel on the instance type we're using has a negligible affect on run time - the job takes about twice as long but we get two jobs done at once. Doing more than 2 jobs at a time with our current batch size risks running out of GPU memory.

## How to test
I've tested this locally and on CODE. Attempting to transcribe any foreign language file and asking for a translation would be a suitable test