### PR TITLE
Switch on diarization and translation by default

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -37,6 +37,7 @@ import {
 	TWELVE_HOURS_IN_SECONDS,
 	TranscriptionItemWithTranscript,
 	TranscriptionMediaDownloadJob,
+	isEnglish,
 } from '@guardian/transcription-service-common';
 import type { SignedUrlResponseBody } from '@guardian/transcription-service-common';
 import {
@@ -116,7 +117,8 @@ const getApp = async () => {
 				id,
 				url: body.data.url,
 				languageCode: body.data.languageCode,
-				translationRequested: body.data.translationRequested,
+				translationRequested:
+					body.data.translationRequested && !isEnglish(body.data.languageCode),
 				diarizationRequested: body.data.diarizationRequested,
 				userEmail,
 				client: 'TRANSCRIPTION_SERVICE',
@@ -206,7 +208,7 @@ const getApp = async () => {
 				body.data.fileName,
 				signedUrl,
 				body.data.languageCode,
-				body.data.translationRequested,
+				body.data.translationRequested && !isEnglish(body.data.languageCode),
 				body.data.diarizationRequested,
 			);
 			if (isSqsFailure(sendResult)) {

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -207,7 +207,7 @@ export const UploadForm = () => {
 	const [translationRequested, setTranslationRequested] =
 		useState<boolean>(false);
 	const [diarizationRequested, setDiarizationRequested] =
-		useState<boolean>(false);
+		useState<boolean>(true);
 	const [mediaSource, setMediaSource] = useState<MediaSourceType>('file');
 	const [mediaUrls, setMediaUrls] = useState<Record<string, RequestStatus>>({});
 	const [mediaUrlInputs, setMediaUrlInputs] = useState<MediaUrlInput[]>([
@@ -489,6 +489,9 @@ export const UploadForm = () => {
 							onChange={(e) => {
 								setMediaFileLanguageCode(e.target.value as InputLanguageCode);
 								setLanguageCodeValid(true);
+								if (e.target.value !== 'en') {
+									setTranslationRequested(true);
+								}
 							}}
 						>
 							<option disabled selected>

--- a/packages/client/src/components/UploadForm.tsx
+++ b/packages/client/src/components/UploadForm.tsx
@@ -10,6 +10,7 @@ import {
 	languageCodeToLanguageWithAuto,
 	YoutubeStatus,
 	ABOUT_THIS_TOOL_YOUTUBE,
+	isEnglish,
 } from '@guardian/transcription-service-common';
 import { AuthContext } from '@/app/template';
 import {
@@ -205,7 +206,7 @@ export const UploadForm = () => {
 		boolean | undefined
 	>(undefined);
 	const [translationRequested, setTranslationRequested] =
-		useState<boolean>(false);
+		useState<boolean>(true);
 	const [diarizationRequested, setDiarizationRequested] =
 		useState<boolean>(true);
 	const [mediaSource, setMediaSource] = useState<MediaSourceType>('file');
@@ -290,7 +291,7 @@ export const UploadForm = () => {
 					urlWithProtocol,
 					token,
 					mediaFileLanguageCode,
-					translationRequested,
+					translationRequested && !isEnglish(mediaFileLanguageCode),
 					diarizationRequested,
 				);
 				if (success) {
@@ -329,7 +330,7 @@ export const UploadForm = () => {
 				file,
 				token,
 				mediaFileLanguageCode,
-				translationRequested,
+				translationRequested && !isEnglish(mediaFileLanguageCode),
 				diarizationRequested,
 			);
 			if (!result) {
@@ -489,9 +490,6 @@ export const UploadForm = () => {
 							onChange={(e) => {
 								setMediaFileLanguageCode(e.target.value as InputLanguageCode);
 								setLanguageCodeValid(true);
-								if (e.target.value !== 'en') {
-									setTranslationRequested(true);
-								}
 							}}
 						>
 							<option disabled selected>

--- a/packages/common/src/languages.ts
+++ b/packages/common/src/languages.ts
@@ -124,3 +124,5 @@ function getKeys<T extends Record<string, any>>(obj: T) {
 export const languageCodes = getKeys(languageCodeToLanguage);
 export const inputLanguageCodes = getKeys(languageCodeToLanguageWithAuto);
 export const outputLanguageCodes = getKeys(languageCodeToLanguageWithUnknown);
+export const isEnglish = (languageCodeOrName: string): boolean =>
+	['en', languageCodeToLanguage['en']].includes(languageCodeOrName);


### PR DESCRIPTION
## What does this change?
It can be frustrating for users who forget to enable translation/diarization to have to redo a transcription because they for got to tick these boxes. Let's enable them by default

## How to test
Check the the boxes get ticked automatically