### PR TITLE
Fix translation logic in worker (again) + write some unit tests 😭 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,8 +85,9 @@ jobs:
       - name: Package API/Client/Update
         run: |
           npm run package
-      - name: Package Worker
+      - name: Run tests and package Worker
         run: |
+          npm run worker::test
           npm run worker::build
           npm run worker::package
       - name: CDK synth

--- a/package-lock.json
+++ b/package-lock.json
@@ -15962,7 +15962,10 @@
 				"@guardian/transcription-service-backend-common": "1.0.0"
 			},
 			"devDependencies": {
+				"@types/jest": "^29.5.11",
 				"@types/node": "^20.11.5",
+				"jest": "^29.7.0",
+				"ts-jest": "^29.1.1",
 				"typescript": "^5.3.3"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"media-download::start": "APP=media-download AWS_REGION=eu-west-1 STAGE=DEV npm run start --workspace media-download",
 		"worker::build": "npm run build --workspace worker",
 		"worker::package": "npm run package --workspace worker",
+		"worker::test": "npm run test --workspace worker",
 		"gpu-worker::start": "APP=transcription-service-gpu-worker AWS_REGION=eu-west-1 STAGE=DEV TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=true pipenv run npm run start --workspace worker",
 		"gpu-worker::shakira": "SHAKIRA_MODE=true npm run gpu-worker::start",
 		"cpu-worker::start": "APP=transcription-service-worker AWS_REGION=eu-west-1 STAGE=DEV npm run start --workspace worker",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"build": "esbuild --bundle --platform=node --target=node20 --outfile=dist/index.js src/index.ts",
 		"package": "docker run --rm -v $PWD:/worker $(docker build -q deb-build/) fpm",
-		"start": "STAGE=DEV nodemon --watch src src/index.ts"
+		"start": "STAGE=DEV nodemon --watch src src/index.ts",
+		"test": "jest"
 	},
 	"keywords": [],
 	"author": "",
@@ -17,7 +18,17 @@
 		"@guardian/transcription-service-backend-common": "1.0.0"
 	},
 	"devDependencies": {
+		"@types/jest": "^29.5.11",
 		"@types/node": "^20.11.5",
+		"jest": "^29.7.0",
+		"ts-jest": "^29.1.1",
 		"typescript": "^5.3.3"
+	},
+	"jest": {
+		"preset": "ts-jest",
+		"testEnvironment": "node",
+		"testMatch": [
+			"<rootDir>/src/**/*.test.ts"
+		]
 	}
 }

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -15,6 +15,7 @@ import {
 	secondsForWhisperXStartupMetric,
 } from '@guardian/transcription-service-backend-common/src/metrics';
 import { SHAKIRA } from './shakira';
+import { transcribeAndTranslate } from './translate';
 
 interface FfmpegResult {
 	duration?: number;
@@ -124,7 +125,7 @@ const getDuration = (ffmpegOutput: string) => {
 	return duration;
 };
 
-const runTranscription = async (
+export const runTranscription = async (
 	whisperBaseParams: WhisperBaseParams,
 	languageCode: InputLanguageCode,
 	translate: boolean,
@@ -160,72 +161,6 @@ const runTranscription = async (
 	} catch (error) {
 		logger.error(
 			`Could not read the transcript result. Params: ${JSON.stringify(whisperBaseParams)}`,
-			error,
-		);
-		throw error;
-	}
-};
-
-const transcribeAndTranslate = async (
-	whisperBaseParams: WhisperBaseParams,
-	whisperX: boolean,
-	metrics: MetricsService,
-	languageCode: InputLanguageCode,
-): Promise<TranscriptionResult> => {
-	const run = (translate: boolean) =>
-		runTranscription(
-			whisperBaseParams,
-			languageCode,
-			translate,
-			whisperX,
-			metrics,
-		);
-	try {
-		const transcription = run(false);
-
-		// if we don't know the language code then run transcription and decide whether to run translation based off the
-		// detected language code
-		if (languageCode === 'auto') {
-			const finishedTranscription = await transcription;
-			if (
-				finishedTranscription.metadata.detectedLanguageCode !== 'UNKNOWN' &&
-				finishedTranscription.metadata.detectedLanguageCode !== 'en'
-			) {
-				const translation = await run(true);
-				return {
-					transcripts: finishedTranscription.transcripts,
-					transcriptTranslations: translation?.transcripts,
-					metadata: finishedTranscription.metadata,
-				};
-			}
-		}
-
-		// if we have a language code and it's not English, run translation in parallel
-		if (languageCode !== 'en') {
-			const translation = run(true);
-			const [finishedTranscription, finishedTranslation] = await Promise.all([
-				transcription,
-				translation,
-			]);
-			return {
-				transcripts: finishedTranscription.transcripts,
-				transcriptTranslations: finishedTranslation.transcripts,
-				metadata: finishedTranscription.metadata,
-			};
-		}
-
-		// otherwise, skip translation
-		const finishedTranscription = await transcription;
-
-		return {
-			transcripts: finishedTranscription.transcripts,
-			// we only return one metadata field here even though we might have two (one from the translation) - a
-			// bit messy but I can't think of much use for the translation metadata at the moment
-			metadata: finishedTranscription.metadata,
-		};
-	} catch (error) {
-		logger.error(
-			`Failed during combined detect language/transcribe/translate process result`,
 			error,
 		);
 		throw error;

--- a/packages/worker/src/translate.test.ts
+++ b/packages/worker/src/translate.test.ts
@@ -1,4 +1,4 @@
-import { getTranslationConfig } from './transcribe';
+import { getTranslationConfig } from './translate';
 
 describe('getTranslationConfig', () => {
 	describe('when inputLanguageCode is "auto"', () => {

--- a/packages/worker/src/translate.test.ts
+++ b/packages/worker/src/translate.test.ts
@@ -1,0 +1,77 @@
+import { getTranslationConfig } from './transcribe';
+
+describe('getTranslationConfig', () => {
+	describe('when inputLanguageCode is "auto"', () => {
+		it('should translate when detected language is not English and not UNKNOWN', () => {
+			const result = getTranslationConfig('auto', 'es');
+			expect(result).toEqual({
+				code: 'es',
+				shouldTranslate: true,
+			});
+		});
+
+		it('should not translate when detected language is English', () => {
+			const result = getTranslationConfig('auto', 'en');
+			expect(result).toEqual({
+				shouldTranslate: false,
+			});
+		});
+
+		it('should not translate when detected language is UNKNOWN', () => {
+			const result = getTranslationConfig('auto', 'UNKNOWN');
+			expect(result).toEqual({
+				shouldTranslate: false,
+			});
+		});
+	});
+
+	describe('when inputLanguageCode is a specific non-English language', () => {
+		it('should translate Spanish to English', () => {
+			const result = getTranslationConfig('es', 'es');
+			expect(result).toEqual({
+				code: 'es',
+				shouldTranslate: true,
+			});
+		});
+
+		it('should prioritise input code rather than detected language', () => {
+			const result = getTranslationConfig('es', 'fr');
+			expect(result).toEqual({
+				code: 'es',
+				shouldTranslate: true,
+			});
+		});
+
+		describe('when inputLanguageCode is English', () => {
+			it('should not translate when input is English even if detected language differs', () => {
+				const result = getTranslationConfig('en', 'es');
+				expect(result).toEqual({
+					shouldTranslate: false,
+				});
+			});
+
+			it('should not translate when input is English and detected is UNKNOWN', () => {
+				const result = getTranslationConfig('en', 'UNKNOWN');
+				expect(result).toEqual({
+					shouldTranslate: false,
+				});
+			});
+		});
+
+		describe('edge cases', () => {
+			it('should return correct structure with code when translation is needed', () => {
+				const result = getTranslationConfig('es', 'es');
+				expect(result).toHaveProperty('code');
+				expect(result).toHaveProperty('shouldTranslate');
+				expect(result.code).toBeDefined();
+			});
+
+			it('should return correct structure without code when translation is not needed', () => {
+				const result = getTranslationConfig('en', 'en');
+				expect(result).toHaveProperty('shouldTranslate');
+				expect(result.shouldTranslate).toBe(false);
+				expect(result.code).toBeUndefined();
+			});
+		});
+	});
+});

--- a/packages/worker/src/translate.ts
+++ b/packages/worker/src/translate.ts
@@ -1,0 +1,74 @@
+import {
+	InputLanguageCode,
+	OutputLanguageCode,
+	TranscriptionResult,
+} from '@guardian/transcription-service-common';
+import { MetricsService } from '@guardian/transcription-service-backend-common/src/metrics';
+import { logger } from '@guardian/transcription-service-backend-common';
+import { runTranscription, WhisperBaseParams } from './transcribe';
+
+type TranslationConfig = {
+	code?: InputLanguageCode;
+	shouldTranslate: boolean;
+};
+
+export const getTranslationConfig = (
+	inputLanguageCode: InputLanguageCode,
+	detectedLanguageCode: OutputLanguageCode,
+): TranslationConfig => {
+	if (inputLanguageCode === 'auto') {
+		if (detectedLanguageCode !== 'UNKNOWN' && detectedLanguageCode !== 'en') {
+			return {
+				code: detectedLanguageCode,
+				shouldTranslate: true,
+			};
+		} else {
+			return {
+				shouldTranslate: false,
+			};
+		}
+	} else if (inputLanguageCode !== 'en') {
+		return {
+			code: inputLanguageCode,
+			shouldTranslate: true,
+		};
+	}
+	return { shouldTranslate: false };
+};
+
+export const transcribeAndTranslate = async (
+	whisperBaseParams: WhisperBaseParams,
+	whisperX: boolean,
+	metrics: MetricsService,
+	languageCode: InputLanguageCode,
+): Promise<TranscriptionResult> => {
+	const run = (translate: boolean, languageCode: InputLanguageCode) =>
+		runTranscription(
+			whisperBaseParams,
+			languageCode,
+			translate,
+			whisperX,
+			metrics,
+		);
+	try {
+		const transcription = await run(false, languageCode);
+		const translationConfig = getTranslationConfig(
+			languageCode,
+			transcription.metadata.detectedLanguageCode,
+		);
+		if (translationConfig.shouldTranslate && translationConfig.code) {
+			const translation = await run(true, translationConfig.code);
+			return {
+				...transcription,
+				transcriptTranslations: translation.transcripts,
+			};
+		}
+		return transcription;
+	} catch (error) {
+		logger.error(
+			`Failed during combined detect language/transcribe/translate process result`,
+			error,
+		);
+		throw error;
+	}
+};


### PR DESCRIPTION
## What does this change?
There's currently a bug in the transcription tool where, if no language code is specified (it is set to 'auto') - which is true of all files coming from giant - the file will gets transcribed _and_ translated, even if during the transcription we detect that the source language is english.

I've fixed this with a new 'getTranslationConfig' function which handles all the logic about deciding whether to translate a file or not and what language code to use. As this is the third time I've had to mess with this logic, I've added some unit tests to document the expected behaviour

Some history on this:
 - https://github.com/guardian/transcription-service/pull/235
 - https://github.com/guardian/transcription-service/pull/241
 - github.com/guardian/transcription-service/pull/234

## How to test
Run a transcription job from giant for a file in english, you should only see whisperx get run once