### PR TITLE
Transcription: more detailed user message for missing transcriptID

### DIFF
--- a/packages/api/src/export.ts
+++ b/packages/api/src/export.ts
@@ -50,7 +50,7 @@ export const getCombinedOutput = async (
 	if (isS3Failure(combinedOutputText)) {
 		const msg =
 			combinedOutputText.failureReason === 'NoSuchKey'
-				? `Failed to export transcript - file has expired. Please re-upload the file and try again.`
+				? `Your transcript no longer exists. As part of our privacy and security commitment, transcripts are only retained for a brief period. Please re-upload your recording to generate a new transcript.`
 				: `Failed to fetch transcript. Please contact the digital investigations team for support`;
 		logger.error(msg);
 		return {

--- a/packages/backend-common/src/dynamodb.ts
+++ b/packages/backend-common/src/dynamodb.ts
@@ -109,7 +109,8 @@ export const getTranscriptionItem = async (
 	ownershipCheck: OwnershipCheck,
 ): Promise<GetTranscriptionItemResult> => {
 	const item = await getItem(client, tableName, itemId);
-	const genericNotFoundMessage = 'Transcript not found';
+	const genericNotFoundMessage =
+		'We cannot find a transcript with this ID. Either the URL is wrong or the transcript has expired. As part of our privacy and security commitment, transcripts are only retained for a brief period. Please re-upload your recording to generate a new transcript.';
 	if (!item) {
 		const msg = `Failed to fetch item with id ${itemId} from database.`;
 		logger.error(msg);

--- a/packages/client/src/app/layout.tsx
+++ b/packages/client/src/app/layout.tsx
@@ -21,8 +21,15 @@ export default function RootLayout({
 						</div>
 						<p className={'italic pt-1 font-light '}>
 							This is a tool developed for GNM by the Investigations and
-							Reporting engineering team. Please email feedback / bug reports to
+						Reporting engineering team. Please email feedback / bug reports to{' '}
+						<a
+							href={`https://mail.google.com/mail/?view=cm&fs=1&to=digital.investigations@theguardian.com&su=Guardian%20Transcription%20Tool%20feedback%20-%20${new Date().toLocaleDateString('en-GB')}`}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-blue-600 hover:underline"
+						>
 							digital.investigations@theguardian.com
+						</a>
 						</p>
 					</div>
 				</header>

--- a/packages/client/src/app/viewer/page.tsx
+++ b/packages/client/src/app/viewer/page.tsx
@@ -71,7 +71,8 @@ const ViewerPage = () => {
 					token,
 				);
 				if (!transcriptResponse.ok) {
-					throw new Error('Failed to fetch transcript');
+					const errorText = await transcriptResponse.text();
+					throw new Error(errorText || 'Failed to fetch transcript');
 				}
 
 				const transcriptJson = await transcriptResponse.json();

--- a/packages/client/src/components/ExportForm.tsx
+++ b/packages/client/src/components/ExportForm.tsx
@@ -124,6 +124,11 @@ const ExportForm = () => {
 		'Fetching source media download url...',
 	);
 	const [downloadStatus, setDownloadStatus] = useState<string | undefined>('');
+	const [transcriptCheckInProgress, setTranscriptCheckInProgress] =
+		useState<boolean>(true);
+	const [transcriptCheckError, setTranscriptCheckError] = useState<
+		string | undefined
+	>(undefined);
 
 	// TODO: once we have some CSS/component library, tidy up this messy error handling
 	if (!token) {
@@ -147,19 +152,60 @@ const ExportForm = () => {
 		);
 	}
 	useEffect(() => {
-		authFetch(`/api/export/source-media-download-url?id=${transcriptId}`, token)
-			.then((resp) => resp.text())
-			.then((url: string) => {
-				setSourceMediaDownloadUrl(url);
+		// First check if the transcript exists
+		authFetch(`/api/export/transcript?id=${transcriptId}&format=text`, token)
+			.then(async (resp) => {
+				if (!resp.ok) {
+					const errorText = await resp.text();
+					setTranscriptCheckError(errorText);
+					setTranscriptCheckInProgress(false);
+					return;
+				}
+				// Transcript exists, now fetch source media download URL
+				setTranscriptCheckInProgress(false);
+				authFetch(
+					`/api/export/source-media-download-url?id=${transcriptId}`,
+					token,
+				)
+					.then((resp) => resp.text())
+					.then((url: string) => {
+						setSourceMediaDownloadUrl(url);
+					})
+					.catch((error) => {
+						console.error('Failed to fetch source media download URL', error);
+						setSourceMediaDownloadUrl(undefined);
+						setsourceMediaUrlStatus(
+							'Failed to fetch source media download URL. You can still export to Google Drive.',
+						);
+					});
 			})
 			.catch((error) => {
-				console.error('Failed to fetch source media download URL', error);
-				setSourceMediaDownloadUrl(undefined);
-				setsourceMediaUrlStatus(
-					'Failed to fetch source media download URL. You can still export to Google Drive.',
+				console.error('Failed to check transcript existence', error);
+				setTranscriptCheckError(
+					'Failed to check if transcript exists. Please try again.',
 				);
+				setTranscriptCheckInProgress(false);
 			});
 	}, [transcriptId]);
+
+	if (transcriptCheckInProgress) {
+		return (
+			<InfoMessage
+				message={'Checking transcript...'}
+				status={RequestStatus.InProgress}
+			/>
+		);
+	}
+
+	if (transcriptCheckError) {
+		return (
+			<InfoMessage
+				message={transcriptCheckError}
+				status={RequestStatus.Failed}
+			/>
+		);
+	}
+
 	if (requestStatus === RequestStatus.Failed) {
 		return (
 			<InfoMessage
@@ -342,7 +388,8 @@ const ExportForm = () => {
 				setDownloadStatus(`Failed to download ${getExportTypeText(format)}`);
 			}
 		} else {
-			setDownloadStatus('Failed to download transcript');
+			const errorText = await response.text();
+			setDownloadStatus(errorText || 'Failed to download transcript');
 		}
 	};
 

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -32,6 +32,16 @@ import {
 import { SESClient } from '@aws-sdk/client-ses';
 import { sqsMessageToTestMessage } from 'webpage-snapshot/test/testMessage';
 
+const getFeedbackEmailLink = () => {
+	const emailParams = new URLSearchParams({
+		view: 'cm',
+		fs: '1',
+		to: 'digital.investigations@theguardian.com',
+		su: `Guardian Transcription Tool feedback - ${new Date().toLocaleDateString('en-GB')}`,
+	});
+	return `https://mail.google.com/mail/?${emailParams.toString()}`;
+};
+
 const successMessageBody = (
 	transcriptId: string,
 	originalFilename: string,
@@ -59,11 +69,12 @@ const transcriptionFailureMessageBody = (
 		'No audio was detected in your source media file - please check that you uploaded the correct file.';
 	const basicErrorMessage =
 		'Please make sure that the file is a valid audio or video file.';
+	const feedbackLink = getFeedbackEmailLink();
 	return `
 		<h1>Transcription for ${originalFilename} has failed.</h1>
 		<p>${noAudioDetected ? noAudioMessage : basicErrorMessage}</p>
 		<p>Click <a href="${sourceMediaDownloadUrl}">here</a> to download the input media.</p>
-		<p>Contact digital.investigations@theguardian.com for support.</p>
+		<p>Contact <a href="${feedbackLink}">digital.investigations@theguardian.com</a> for support.</p>
 		<p>Transcription ID: ${id}</p>
 	`;
 };
@@ -88,11 +99,12 @@ const mediaDownloadFailureMessageBody = (
 	url: string,
 	failureReason: MediaDownloadFailureReason,
 ) => {
+	const feedbackLink = getFeedbackEmailLink();
 	return `
 		<h1>Media download failed for ${url}</h1>
 		<p>You recently requested a transcription of the media at this url ${url}.
 		${failureDescription(failureReason)}
-		<p>Please contact digital.investigations@theguardian.com for further assistance.</p>
+		<p>Please contact <a href="${feedbackLink}">digital.investigations@theguardian.com</a> for further assistance.</p>
 		`;
 };
 


### PR DESCRIPTION
## Add user-friendly error messages for expired/missing transcripts; replace mailtos with gmail weblinks since all GNM users are using Gmail 

Should fix #189 and #182 .

1. When users click export links from old emails (e.g., `https://transcribe.gutools.co.uk/export?transcriptId=...`), they encounter unhelpful error messages if the transcript no longer exists.  

2. When users click on the links to message the team with feedback or to report a problem, the email link usually doesn't work because Gmail is not set as the default mail client. 

This PR implements user-friendly error messages that explain missing transcripts better, and a google mail link for our exclusively gmail using users. 

The missing ID implementation distinguishes between two scenarios:

**1. Invalid/Expired Transcript ID** (not in DynamoDB)
> "We cannot find a transcript with this ID. Either the URL is wrong or the transcript has expired. As part of our privacy and security commitment, transcripts are only retained for a brief period. Please re-upload your recording to generate a new transcript."

**2. Expired Transcript File** (exists in DynamoDB but S3 file is missing)
> "Your transcript no longer exists. As part of our privacy and security commitment, transcripts are only retained for a brief period. Please re-upload your recording to generate a new transcript."

### Changes

#### Backend
- **`packages/backend-common/src/dynamodb.ts`**
  - Updated `getTranscriptionItem()` to return user-friendly message when transcript is not found in DynamoDB

- **`packages/api/src/export.ts`**
  - Updated `getCombinedOutput()` to return user-friendly message when S3 file is missing (NoSuchKey error)

#### Frontend
- **`packages/client/src/components/ExportForm.tsx`**
  - Added transcript existence check when page loads
  - Shows loading state during check
  - Displays backend error messages if transcript doesn't exist or is expired
  - Updated download handlers to propagate backend error messages

- **`packages/client/src/app/viewer/page.tsx`**
  - Updated error handling to display backend error messages instead of generic "Failed to fetch transcript"

### Testing
To test:
1. Try accessing an export link with an invalid transcript ID
2. Try accessing an export link where the transcript exists in DynamoDB but the S3 file has been deleted
3. Try accessing an export link to something that does exist but the user doesn't have permission?