### PR TITLE
Set volume initialisation rate on worker instances

### DIFF
--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -1124,7 +1124,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
             {
               "DeviceName": "/dev/sda1",
               "Ebs": {
-                "VolumeInitializationRate": 1000,
+                "VolumeInitializationRate": 300,
                 "VolumeSize": 100,
               },
             },

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -1124,6 +1124,7 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
             {
               "DeviceName": "/dev/sda1",
               "Ebs": {
+                "VolumeInitializationRate": 1000,
                 "VolumeSize": 100,
               },
             },

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -1124,7 +1124,6 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
             {
               "DeviceName": "/dev/sda1",
               "Ebs": {
-                "VolumeInitializationRate": 300,
                 "VolumeSize": 100,
               },
             },

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -39,8 +39,7 @@ import {
 	SpotAllocationStrategy,
 } from 'aws-cdk-lib/aws-autoscaling';
 import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
-import type {
-	CfnLaunchTemplate} from 'aws-cdk-lib/aws-ec2';
+import type { CfnLaunchTemplate } from 'aws-cdk-lib/aws-ec2';
 import {
 	InstanceClass,
 	InstanceSize,
@@ -448,7 +447,7 @@ export class TranscriptionService extends GuStack {
 			.defaultChild as CfnLaunchTemplate;
 		cfnLaunchTemplate.addPropertyOverride(
 			'LaunchTemplateData.BlockDeviceMappings.0.Ebs.VolumeInitializationRate',
-			1000,
+			300,
 		);
 
 		// instance types we are happy to use for workers. Note - order matters as when launching 'on demand' instances

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -39,6 +39,8 @@ import {
 	SpotAllocationStrategy,
 } from 'aws-cdk-lib/aws-autoscaling';
 import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
+import type {
+	CfnLaunchTemplate} from 'aws-cdk-lib/aws-ec2';
 import {
 	InstanceClass,
 	InstanceSize,
@@ -415,6 +417,9 @@ export class TranscriptionService extends GuStack {
 			Port.tcp(443),
 		);
 
+		// The AMI with the nvidia cuda drivers and whisperx installed is enormous
+		const workerVolume = BlockDeviceVolume.ebs(100);
+
 		const gpuWorkerLaunchTemplate = new LaunchTemplate(
 			this,
 			'TranscriptionWorkerGPULaunchTemplate',
@@ -432,11 +437,18 @@ export class TranscriptionService extends GuStack {
 				blockDevices: [
 					{
 						deviceName: '/dev/sda1',
-						// The AMI with the nvidia cuda drivers and whisperx installed is enormous
-						volume: BlockDeviceVolume.ebs(100),
+						volume: workerVolume,
 					},
 				],
 			},
+		);
+
+		// Set VolumeInitializationRate via L1 escape hatch (not yet supported in L2)
+		const cfnLaunchTemplate = gpuWorkerLaunchTemplate.node
+			.defaultChild as CfnLaunchTemplate;
+		cfnLaunchTemplate.addPropertyOverride(
+			'LaunchTemplateData.BlockDeviceMappings.0.Ebs.VolumeInitializationRate',
+			1000,
 		);
 
 		// instance types we are happy to use for workers. Note - order matters as when launching 'on demand' instances

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -442,13 +442,16 @@ export class TranscriptionService extends GuStack {
 			},
 		);
 
-		// Set VolumeInitializationRate via L1 escape hatch (not yet supported in L2)
-		const cfnLaunchTemplate = gpuWorkerLaunchTemplate.node
-			.defaultChild as CfnLaunchTemplate;
-		cfnLaunchTemplate.addPropertyOverride(
-			'LaunchTemplateData.BlockDeviceMappings.0.Ebs.VolumeInitializationRate',
-			300,
-		);
+		if (this.stage === 'PROD') {
+			// Set VolumeInitializationRate via L1 escape hatch (not yet supported in L2)
+			// Note - EBS charges $0.0036/GB for this https://aws.amazon.com/ebs/pricing/ so we're only enabling for PROD
+			const cfnLaunchTemplate = gpuWorkerLaunchTemplate.node
+				.defaultChild as CfnLaunchTemplate;
+			cfnLaunchTemplate.addPropertyOverride(
+				'LaunchTemplateData.BlockDeviceMappings.0.Ebs.VolumeInitializationRate',
+				300,
+			);
+		}
 
 		// instance types we are happy to use for workers. Note - order matters as when launching 'on demand' instances
 		// the ASG will start at the top of the list and work down until it manages to launch an instance

--- a/whisperx-model-fetch/download_whisperx_models.py
+++ b/whisperx-model-fetch/download_whisperx_models.py
@@ -82,9 +82,9 @@ def download_diarization_models(auth_token):
 
 WHISPER_MODELS = {
     "tiny": "Systran/faster-whisper-tiny",
-    "small": "Systran/faster-whisper-small",
+    # "small": "Systran/faster-whisper-small",
     "medium": "Systran/faster-whisper-medium",
-    "large": "Systran/faster-whisper-large-v3",
+    # "large": "Systran/faster-whisper-large-v3",
 }
 
 


### PR DESCRIPTION
## What does this change?
This PR sets a volume initialization rate of 300MB/s (the maximum) for our worker instances. See here for details of what this is: https://docs.aws.amazon.com/ebs/latest/userguide/initalize-volume.html#volume-initialization-rate

The reason it helps us is that the transcription service worker AMI is large due to the CUDA drivers and (at the moment) the baked-in model files. Currently it is taking around 15 minutes for an instance to 'warm up' whilst EBS syncs all this data from S3, this cuts the time to around 4 minutes.

This is quite expensive - $0.0036 per GB. With that in mind, this change drops the (unused) small/large whisper models from the AMI (we can drop these completely after https://github.com/guardian/transcription-service/pull/280) 

To further cut the cost I've done this https://github.com/guardian/amigo/pull/1828 which should shave around 30GB off our AMI size.

That still leaves 40GB, so I think enabling this will cost $0.14 per instance start. Where the instance is an 'extra' box (not our reserved instance) then this will save us $0.04 due to the job finishing 10 minutes earlier (GPU instances are $0.52/hour). 

Over the last 30 days we have launched 300 boxes, at that rate this change would cost us $40ish/month.

## How has this change been tested?
I've tested this on CODE and verified the faster start times