### PR TITLE
Stop API downloading the submitted file

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -19,7 +19,6 @@ import {
 	getS3Client,
 	sendMessage,
 	writeDynamoItem,
-	downloadObject,
 	getYoutubeEventItem,
 } from '@guardian/transcription-service-backend-common';
 import {
@@ -178,14 +177,6 @@ const getApp = async () => {
 				res.status(404).send('missing s3 object metadata');
 				return;
 			}
-
-			const tempPath = `/tmp/${s3Key}`;
-			await downloadObject(
-				s3Client,
-				config.app.sourceMediaBucket,
-				s3Key,
-				tempPath,
-			);
 
 			const signedUrl = await getSignedDownloadUrl(
 				config.aws,


### PR DESCRIPTION
## What does this change?
Back when we had 2 engines for transcription (whisper.cpp and whisperx) we implemented this https://github.com/guardian/transcription-service/pull/136 to get the duration of the submitted media file so we could decide which engine to use for the job. 

We have since removed whisper.cpp so this feature is redundant, and as a result we no longer need to be downloading the submitted media file before sending it for transcription. This PR removes that step

This should significantly improve the response time of the /transcribe-file endpoint - we have been seeing timeouts there

## How has this change been tested?
Needs testing on CODE
