### PR TITLE
Upload models directly to s3 rather than going via riffraff

### DIFF
--- a/.github/workflows/fetch-models.yaml
+++ b/.github/workflows/fetch-models.yaml
@@ -96,29 +96,32 @@ jobs:
       - name: Zip and upload models to s3
         run: |
           zip -r models.zip models
+          aws s3 cp models.zip s3://${{ secrets.INVESTIGATIONS_DIST_BUCKET_NAME }}/investigations/${{ github.ref == 'refs/heads/main' && 'PROD' || 'CODE' }}/transcription-service-models/models.zip
 
-      - name: Upload models to riff-raff
-        uses: guardian/actions-riff-raff@v4
-        with:
-          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          projectName: investigations::transcription-service-models
-          contentDirectories: |
-            transcription-service-models:
-              - models.zip
-          config: |
-            allowedStages:
-              - PROD
-              - CODE
-            regions:
-              - eu-west-1
-            stacks:
-              - investigations
-            deployments:
-              transcription-service-models:
-                type: aws-s3
-                app: transcription-service-models
-                parameters:
-                  bucketSsmLookup: true
-                  publicReadAcl: false
-                  cacheControl: 'max-age=0, no-cache'
+# Riffraff currently can't deploy files larger than 5GB so disabling this step for now
+# See https://riffraff.gutools.co.uk/deployment/view/c8371929-1867-4b2b-8f3e-442d05919863
+#      - name: Upload models to riff-raff
+#        uses: guardian/actions-riff-raff@v4
+#        with:
+#          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+#          githubToken: ${{ secrets.GITHUB_TOKEN }}
+#          projectName: investigations::transcription-service-models
+#          contentDirectories: |
+#            transcription-service-models:
+#              - models.zip
+#          config: |
+#            allowedStages:
+#              - PROD
+#              - CODE
+#            regions:
+#              - eu-west-1
+#            stacks:
+#              - investigations
+#            deployments:
+#              transcription-service-models:
+#                type: aws-s3
+#                app: transcription-service-models
+#                parameters:
+#                  bucketSsmLookup: true
+#                  publicReadAcl: false
+#                  cacheControl: 'max-age=0, no-cache'


### PR DESCRIPTION
## What does this change?

I turns out the riffraff app itself doesn't support multipart uploads to S3. This limits the max artifact size that the aws-s3 deployment type can support to 5GB. Our artifact output from the fetch models action added in https://github.com/guardian/transcription-service/pull/280 is about 8GB. Unfortunately when testing this I was skipping some of the model fetches to save build time, resulting in a smaller artifact.

As a temporary measure, this PR gets the action to upload directly to the investigations-dist s3 bucket (rather than uploading to riffraff-artifact and a deploy copying to investigations-dist). I'm working on enabling multipart uploads in riffraff but that will take some time to test etc as it's a change to such a fundamental part of deployments

## How has this change been tested?
I'm confident this will work as I was using this step in testing before I decided it would be cleaner to go via riffraff