### PR TITLE
Allow bedrock calls from transcription API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3144,6 +3144,126 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/@next/swc-darwin-x64": {
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.25.tgz",
+			"integrity": "sha512-V+iYM/QR+aYeJl3/FWWU/7Ix4b07ovsQ5IbkwgUK29pTHmq+5UxeDr7/dphvtXEq5pLB/PucfcBNh9KZ8vWbug==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-arm64-gnu": {
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.25.tgz",
+			"integrity": "sha512-LFnV2899PJZAIEHQ4IMmZIgL0FBieh5keMnriMY1cK7ompR+JUd24xeTtKkcaw8QmxmEdhoE5Mu9dPSuDBgtTg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-arm64-musl": {
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.25.tgz",
+			"integrity": "sha512-QC5y5PPTmtqFExcKWKYgUNkHeHE/z3lUsu83di488nyP0ZzQ3Yse2G6TCxz6nNsQwgAx1BehAJTZez+UQxzLfw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-x64-gnu": {
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.25.tgz",
+			"integrity": "sha512-y6/ML4b9eQ2D/56wqatTJN5/JR8/xdObU2Fb1RBidnrr450HLCKr6IJZbPqbv7NXmje61UyxjF5kvSajvjye5w==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-x64-musl": {
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.25.tgz",
+			"integrity": "sha512-sPX0TSXHGUOZFvv96GoBXpB3w4emMqKeMgemrSxI7A6l55VBJp/RKYLwZIB9JxSqYPApqiREaIIap+wWq0RU8w==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-win32-arm64-msvc": {
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.25.tgz",
+			"integrity": "sha512-ReO9S5hkA1DU2cFCsGoOEp7WJkhFzNbU/3VUF6XxNGUCQChyug6hZdYL/istQgfT/GWE6PNIg9cm784OI4ddxQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-win32-ia32-msvc": {
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.25.tgz",
+			"integrity": "sha512-DZ/gc0o9neuCDyD5IumyTGHVun2dCox5TfPQI/BJTYwpSNYM3CZDI4i6TOdjeq1JMo+Ug4kPSMuZdwsycwFbAw==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-win32-x64-msvc": {
+			"version": "14.2.25",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.25.tgz",
+			"integrity": "sha512-KSznmS6eFjQ9RJ1nEc66kJvtGIL1iZMYmGEXsZPh2YtnLtqrgdVvKXJY2ScjjoFnG6nGLyPFR0UiEvDwVah4Tw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"license": "MIT",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -37,13 +37,10 @@ import {
 	ExportStatuses,
 	TranscriptDownloadRequest,
 	TWELVE_HOURS_IN_SECONDS,
-	ONE_WEEK_IN_SECONDS,
 	TranscriptionItemWithTranscript,
 	TranscriptionMediaDownloadJob,
 	isEnglish,
-	llmRequestBody,
-	DestinationService,
-	LLMJob,
+	LlmRequestBody,
 	LlmResult,
 	LlmPrompt,
 } from '@guardian/transcription-service-common';
@@ -66,6 +63,8 @@ import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { invokeLambda } from './services/lambda';
 import { LambdaClient } from '@aws-sdk/client-lambda';
 import { getS3Keys } from 'worker/src/llama-cpp';
+import { bedrockLlmJob, sendLlmJob, sendLlmResultIsSuccess } from './llm';
+import { MetricsService } from '@guardian/transcription-service-backend-common/src/metrics';
 
 const runningOnAws = process.env['AWS_EXECUTION_ENV'];
 const emulateProductionLocally =
@@ -86,6 +85,7 @@ const getApp = async () => {
 		config.dev?.localstackEndpoint,
 	);
 	const lambdaClient = new LambdaClient(config.aws);
+	const metrics = new MetricsService(config.app.stage, config.aws, 'api');
 
 	app.use(bodyParser.json({ limit: '40mb' }));
 	app.use(passport.initialize());
@@ -243,7 +243,7 @@ const getApp = async () => {
 				return;
 			}
 
-			const body = llmRequestBody.safeParse(req.body);
+			const body = LlmRequestBody.safeParse(req.body);
 			if (!body.success) {
 				logger.error('Failed to parse LLM request body', body.error);
 				res.status(422).send('Invalid request body');
@@ -265,50 +265,30 @@ const getApp = async () => {
 				`Uploaded LLM prompt to s3://${config.app.sourceMediaBucket}/${promptKey}`,
 			);
 
-			const inputSignedUrl = await getSignedDownloadUrl(
-				config.aws,
-				config.app.sourceMediaBucket,
-				promptKey,
-				ONE_WEEK_IN_SECONDS,
-			);
-
-			const outputSignedUrl = await getSignedUploadUrl(
-				config.aws,
-				config.app.transcriptionOutputBucket,
-				userEmail,
-				ONE_WEEK_IN_SECONDS,
-				false,
-				outputKey,
-			);
-
-			const job: LLMJob = {
-				id,
-				jobType: 'llm',
-				originalFilename: `${id}.txt`,
-				inputSignedUrl,
-				sentTimestamp: new Date().toISOString(),
-				userEmail,
-				transcriptDestinationService: DestinationService.TranscriptionService,
-				combinedOutputUrl: { key: outputKey, url: outputSignedUrl },
-				backend: body.data.backend,
-			};
-
-			const sendResult = await sendMessage(
-				sqsClient,
-				config.app.gpuTaskQueueUrl,
-				JSON.stringify(job),
-				id,
-			);
-			if (isSqsFailure(sendResult)) {
-				res.status(500).send(sendResult.errorMsg);
-				return;
+			const sendResult =
+				// if bedrock is the backend we don't need to use the worker - just query directly
+				body.data.backend === 'BEDROCK'
+					? await bedrockLlmJob(
+							id,
+							userEmail,
+							outputKey,
+							body.data,
+							config,
+							metrics,
+							s3Client,
+						)
+					: await sendLlmJob(
+							id,
+							userEmail,
+							promptKey,
+							outputKey,
+							body.data,
+							sqsClient,
+							config,
+						);
+			if (!sendLlmResultIsSuccess(sendResult)) {
+				res.status(500).send(sendResult.failureReason);
 			}
-
-			logger.info('API successfully sent LLM job to task queue', {
-				id,
-				userEmail,
-				queue: config.app.gpuTaskQueueUrl,
-			});
 
 			res.send({ id });
 		}),

--- a/packages/api/src/llm.ts
+++ b/packages/api/src/llm.ts
@@ -1,0 +1,141 @@
+import {
+	getSignedDownloadUrl,
+	getSignedUploadUrl,
+	isSqsFailure,
+	logger,
+	putObject,
+	sendMessage,
+	TranscriptionConfig,
+} from '@guardian/transcription-service-backend-common';
+import {
+	DestinationService,
+	LLMJob,
+	LLMOutputSuccess,
+	LlmRequestBody,
+	ONE_WEEK_IN_SECONDS,
+} from '@guardian/transcription-service-common';
+import { SQSClient } from '@aws-sdk/client-sqs';
+import {
+	saveLllmOutput,
+	sendPromptToBedrock,
+} from '@guardian/transcription-service-backend-common/src/llm';
+import { MetricsService } from '@guardian/transcription-service-backend-common/src/metrics';
+import { S3Client } from '@aws-sdk/client-s3';
+
+type SendLlmFailure = {
+	status: 'failure';
+	failureReason: string;
+};
+type SendLlmSuccess = {
+	status: 'success';
+};
+type SendLlmResult = SendLlmFailure | SendLlmSuccess;
+
+export const sendLlmResultIsSuccess = (
+	result: SendLlmResult,
+): result is { status: 'success' } => {
+	return result.status === 'success';
+};
+
+export const sendLlmJob = async (
+	id: string,
+	userEmail: string,
+	promptKey: string,
+	outputKey: string,
+	request: LlmRequestBody,
+	sqsClient: SQSClient,
+	config: TranscriptionConfig,
+): Promise<SendLlmResult> => {
+	const inputSignedUrl = await getSignedDownloadUrl(
+		config.aws,
+		config.app.sourceMediaBucket,
+		promptKey,
+		ONE_WEEK_IN_SECONDS,
+	);
+	const outputSignedUrl = await getSignedUploadUrl(
+		config.aws,
+		config.app.transcriptionOutputBucket,
+		userEmail,
+		ONE_WEEK_IN_SECONDS,
+		false,
+		outputKey,
+	);
+
+	const job: LLMJob = {
+		id,
+		jobType: 'llm',
+		originalFilename: `${id}.txt`,
+		inputSignedUrl,
+		sentTimestamp: new Date().toISOString(),
+		userEmail,
+		transcriptDestinationService: DestinationService.TranscriptionService,
+		combinedOutputUrl: { key: outputKey, url: outputSignedUrl },
+		backend: request.backend,
+	};
+
+	const sendResult = await sendMessage(
+		sqsClient,
+		config.app.gpuTaskQueueUrl,
+		JSON.stringify(job),
+		id,
+	);
+	if (isSqsFailure(sendResult)) {
+		return {
+			status: 'failure',
+			failureReason: sendResult.errorMsg || 'Failed to send llmb job to sqs',
+		};
+	}
+
+	logger.info('API successfully sent LLM job to task queue', {
+		id,
+		userEmail,
+		queue: config.app.gpuTaskQueueUrl,
+	});
+	return {
+		status: 'success',
+	};
+};
+
+export const bedrockLlmJob = async (
+	id: string,
+	userEmail: string,
+	outputKey: string,
+	request: LlmRequestBody,
+	config: TranscriptionConfig,
+	metricsService: MetricsService,
+	s3Client: S3Client,
+): Promise<SendLlmResult> => {
+	const bedrockResponse = await sendPromptToBedrock(request.prompt);
+	const s3Result = await putObject(
+		s3Client,
+		config.app.transcriptionOutputBucket,
+		outputKey,
+		bedrockResponse,
+	);
+	if (s3Result.httpStatusCode !== 200) {
+		return {
+			status: 'failure',
+			failureReason: `Failed to upload bedrock output to s3, status code ${s3Result.httpStatusCode}`,
+		};
+	}
+	const llmSuccess: LLMOutputSuccess = {
+		id,
+		userEmail,
+		outputKey,
+		status: 'LLM_SUCCESS',
+	};
+	const saveLlmSuccess = await saveLllmOutput(
+		config,
+		llmSuccess,
+		metricsService,
+	);
+	if (!saveLlmSuccess) {
+		return {
+			status: 'failure',
+			failureReason: 'Failed to save llm job to dynamo',
+		};
+	}
+	return {
+		status: 'success',
+	};
+};

--- a/packages/api/src/llm.ts
+++ b/packages/api/src/llm.ts
@@ -105,7 +105,10 @@ export const bedrockLlmJob = async (
 	metricsService: MetricsService,
 	s3Client: S3Client,
 ): Promise<SendLlmResult> => {
-	const bedrockResponse = await sendPromptToBedrock(request.prompt);
+	const bedrockResponse = await sendPromptToBedrock(
+		request.prompt,
+		config.bedrock.modelId,
+	);
 	const s3Result = await putObject(
 		s3Client,
 		config.app.transcriptionOutputBucket,

--- a/packages/backend-common/src/llm.ts
+++ b/packages/backend-common/src/llm.ts
@@ -1,3 +1,10 @@
+import { TranscriptionConfig } from './config';
+import {
+	LlmDynamoItem,
+	LLMOutputSuccess,
+} from '@guardian/transcription-service-common';
+import { FailureMetric, MetricsService } from './metrics';
+import { getDynamoClient, writeDynamoItem } from './dynamodb';
 import {
 	BedrockRuntimeClient,
 	ConverseCommand,
@@ -44,4 +51,39 @@ export const sendPromptToBedrock = async (
 	);
 
 	return content;
+};
+
+export const saveLllmOutput = async (
+	config: TranscriptionConfig,
+	llmOutput: LLMOutputSuccess,
+	metrics: MetricsService,
+) => {
+	const dynamoItem: LlmDynamoItem = {
+		id: llmOutput.id,
+		userEmail: llmOutput.userEmail,
+		status: 'LLM_SUCCESS',
+		outputKey: llmOutput.outputKey,
+		completedAt: new Date().toISOString(),
+	};
+
+	try {
+		await writeDynamoItem(
+			getDynamoClient(config.aws, config.dev?.localstackEndpoint),
+			config.app.tableName,
+			dynamoItem,
+		);
+
+		logger.info('Output handler saved LLM success to DynamoDB', {
+			id: llmOutput.id,
+			userEmail: llmOutput.userEmail,
+		});
+	} catch (error) {
+		logger.error(
+			'Failed to process LLM success message - data may be missing from dynamo',
+			error,
+		);
+		await metrics.putMetric(FailureMetric);
+		return false;
+	}
+	return true;
 };

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -17,10 +17,10 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
       "GuApiLambda",
       "GuPolicy",
       "GuPolicy",
+      "GuAllowPolicy",
       "GuCname",
       "GuLoggingStreamNameParameter",
       "GuPolicy",
-      "GuAllowPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
@@ -637,6 +637,9 @@ exports[`The TranscriptionService stack matches the snapshot 1`] = `
         },
         "PolicyName": "InvokeBedrockModels7C5463B9",
         "Roles": [
+          {
+            "Ref": "transcriptionserviceapiServiceRole0EF40E0F",
+          },
           {
             "Ref": "InstanceRoleTranscriptionserviceworkerA8AC6615",
           },

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -282,6 +282,12 @@ export class TranscriptionService extends GuStack {
 			}),
 		);
 
+		const bedrockPolicy = new GuAllowPolicy(this, 'InvokeBedrockModels', {
+			actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+			resources: [`arn:aws:bedrock:${props.env.region}::foundation-model/*`],
+		});
+		apiLambda.role?.attachInlinePolicy(bedrockPolicy);
+
 		const getParametersPolicy = new PolicyStatement({
 			effect: Effect.ALLOW,
 			actions: ['ssm:GetParameter', 'ssm:GetParametersByPath'],
@@ -419,15 +425,7 @@ export class TranscriptionService extends GuStack {
 						`arn:aws:s3:::${GuDistributionBucketParameter.getInstance(this).valueAsString}/${props.stack}/${props.stage}/transcription-service-models/*`,
 					],
 				}),
-				new GuAllowPolicy(this, 'InvokeBedrockModels', {
-					actions: [
-						'bedrock:InvokeModel',
-						'bedrock:InvokeModelWithResponseStream',
-					],
-					resources: [
-						`arn:aws:bedrock:${props.env.region}::foundation-model/*`,
-					],
-				}),
+				bedrockPolicy,
 			],
 		});
 		const vpc = GuVpc.fromIdParameter(

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -376,12 +376,12 @@ export const LlmPrompt = z.object({
 
 export type LlmPrompt = z.infer<typeof LlmPrompt>;
 
-export const llmRequestBody = z.object({
+export const LlmRequestBody = z.object({
 	prompt: LlmPrompt,
 	backend: LlmBackend,
 });
 
-export type LLMRequestBody = z.infer<typeof llmRequestBody>;
+export type LlmRequestBody = z.infer<typeof LlmRequestBody>;
 
 export const signedUrlRequestBody = z.object({
 	fileName: z.string(),

--- a/packages/output-handler/src/index.ts
+++ b/packages/output-handler/src/index.ts
@@ -24,7 +24,6 @@ import {
 	ABOUT_THIS_TOOL_YOUTUBE,
 	transcriptionOutputIsLLMSuccess,
 	transcriptionOutputIsLLMFailure,
-	LLMOutputSuccess,
 	LLMOutputFailure,
 	LlmDynamoItem,
 } from '@guardian/transcription-service-common';
@@ -35,6 +34,7 @@ import {
 } from '@guardian/transcription-service-backend-common/src/metrics';
 import { SESClient } from '@aws-sdk/client-ses';
 import { devTrigger } from './dev';
+import { saveLllmOutput } from '@guardian/transcription-service-backend-common/src/llm';
 
 const successMessageBody = (
 	transcriptId: string,
@@ -224,39 +224,6 @@ const handleMediaDownloadFailure = async (
 	}
 };
 
-const handleLLMSuccess = async (
-	config: TranscriptionConfig,
-	llmOutput: LLMOutputSuccess,
-	metrics: MetricsService,
-) => {
-	const dynamoItem: LlmDynamoItem = {
-		id: llmOutput.id,
-		userEmail: llmOutput.userEmail,
-		status: 'LLM_SUCCESS',
-		outputKey: llmOutput.outputKey,
-		completedAt: new Date().toISOString(),
-	};
-
-	try {
-		await writeDynamoItem(
-			getDynamoClient(config.aws, config.dev?.localstackEndpoint),
-			config.app.tableName,
-			dynamoItem,
-		);
-
-		logger.info('Output handler saved LLM success to DynamoDB', {
-			id: llmOutput.id,
-			userEmail: llmOutput.userEmail,
-		});
-	} catch (error) {
-		logger.error(
-			'Failed to process LLM success message - data may be missing from dynamo',
-			error,
-		);
-		await metrics.putMetric(FailureMetric);
-	}
-};
-
 const handleLLMFailure = async (
 	config: TranscriptionConfig,
 	llmOutput: LLMOutputFailure,
@@ -348,7 +315,7 @@ export const processMessage = async (event: unknown) => {
 			logger.info(
 				`Handling LLM success. Output: ${JSON.stringify(transcriptionOutput)}`,
 			);
-			await handleLLMSuccess(config, transcriptionOutput, metrics);
+			await saveLllmOutput(config, transcriptionOutput, metrics);
 		} else if (transcriptionOutputIsLLMFailure(transcriptionOutput)) {
 			logger.info(
 				`Handling LLM failure. Output: ${JSON.stringify(transcriptionOutput)}`,

--- a/packages/worker/src/llama-cpp.ts
+++ b/packages/worker/src/llama-cpp.ts
@@ -14,7 +14,7 @@ import {
 import { SQSClient } from '@aws-sdk/client-sqs';
 
 import { executePrompt } from './llama-server';
-import { sendPromptToBedrock } from './bedrock';
+import { sendPromptToBedrock } from '@guardian/transcription-service-backend-common/src/llm';
 
 export const getS3Keys = (id: string) => ({
 	promptKey: `llm-prompts/${id}.txt`,


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/transcription-service/pull/284 this PR makes it possible for the API to send prompt requests directly to bedrock rather than going via the transcription worker, resulting in a significant performance boost - everything can be done synchronously so that by the time the request returns we have a result.

Most of this PR is moving stuff around so that it's available in backend-common rather than just in the output-handler. I've also pulled some stuff out of the api index.ts file, which is getting a bit massive

## How has this change been tested?
Tested on CODE