### PR TITLE
Pin localstack version to version prior to license change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
-version: '3.8'
-
 services:
   localstack:
     container_name: '${LOCALSTACK_DOCKER_NAME:-localstack-main}'
-    image: localstack/localstack
+    image: localstack/localstack:4.12.0
     ports:
       - '127.0.0.1:4566:4566' # LocalStack Gateway
       - '127.0.0.1:4510-4559:4510-4559' # external services port range


### PR DESCRIPTION
## What does this change?

I pulled the latest localstack today and found that it wouldn't work without a license key. Blog post here https://blog.localstack.cloud/the-road-ahead-for-localstack/ 

Our options are:
 - buy a license
 - switch to a different product for local queues and dynamo tables
 - just use real AWS resources for DEV mode

Or do this - pin to an old version of localstack and put off the problem for another day

Also: Remove deprecated 'version' property that results in an annoying message every time you run docker compose.

## How has this change been tested?
Tested on my machine, verified that localstack starts without a license key