### PR TITLE
Make logs prettier when running transcription service locally

### DIFF
--- a/packages/backend-common/src/logging.ts
+++ b/packages/backend-common/src/logging.ts
@@ -21,7 +21,18 @@ interface LogEvent {
 	meta?: Record<string, string | number>;
 }
 
-const { combine, timestamp, json } = winston.format;
+const { combine, timestamp, json, simple, colorize } = winston.format;
+
+const isDev = process.env.STAGE === 'DEV';
+
+if (isDev) {
+	winston.addColors({
+		ERROR: 'red',
+		WARN: 'yellow',
+		INFO: 'green',
+		DEBUG: 'blue',
+	});
+}
 
 class ServerLogger {
 	underlyingLogger: winston.Logger;
@@ -39,7 +50,9 @@ class ServerLogger {
 				DEBUG: 3,
 			},
 			level: 'INFO',
-			format: combine(timestamp({ alias: '@timestamp' }), json()),
+			format: isDev
+				? combine(colorize(), timestamp({ format: 'HH:mm:ss' }), simple())
+				: combine(timestamp({ alias: '@timestamp' }), json()),
 			transports: [new winston.transports.Console()],
 		};
 


### PR DESCRIPTION
## What does this change?
We've just been logging out the JSON logs which are a pain to read. This makes them a bit nicer

Before:
```
{"@timestamp":"2026-06-30T14:46:01.255Z","attemptNumber":0,"level":"INFO","message":"Retrieved instance id: ","timestamp":"2026-06-30T14:46:01.255Z"}
{"@timestamp":"2026-06-30T14:46:01.259Z","attemptNumber":0,"level":"INFO","message":"Worker reading from queue http://localhost:4566/000000000000/transcription-service-gpu-task-queue-DEV.fifo","timestamp":"2026-06-30T14:46:01.259Z"}
{"@timestamp":"2026-06-30T14:46:01.259Z","attemptNumber":0,"level":"INFO","message":"worker polling http://localhost:4566/000000000000/transcription-service-gpu-task-queue-DEV.fifo for transcription task. Poll count = 1","timestamp":"2026-06-30T14:46:01.259Z"}
{"@timestamp":"2026-06-30T14:46:01.273Z","attemptNumber":0,"level":"INFO","message":"No messages available","timestamp":"2026-06-30T14:46:01.273Z"}
```

After:
```
INFO: Retrieved instance id:  {"attemptNumber":0,"timestamp":"15:45:46"}
INFO: Worker reading from queue http://localhost:4566/000000000000/transcription-service-gpu-task-queue-DEV.fifo {"attemptNumber":0,"timestamp":"15:45:46"}
INFO: worker polling http://localhost:4566/000000000000/transcription-service-gpu-task-queue-DEV.fifo for transcription task. Poll count = 1 {"attemptNumber":0,"timestamp":"15:45:46"}
INFO: No messages available {"attemptNumber":0,"timestamp":"15:45:46"}
```


## How has this change been tested?
Works on my machine!