### PR TITLE
Add download links for translation txt/srt files

### DIFF
--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -362,8 +362,9 @@ export class TranscriptionService extends GuStack {
 			`chown -R ubuntu:ubuntu /opt/dlami/nvme/models`,
 			// symlink nvme location to .cache so that we don't have to tell whisperx about the special /models folder
 			`mkdir -p /home/ubuntu/.cache`,
-			`ln -s /opt/dlami/nvme/models/torch /home/ubuntu/.cache/torch`,
-			`ln -s /opt/dlami/nvme/models/huggingface /home/ubuntu/.cache/huggingface`,
+			// create symlinks for torch/huggingface dirs if they exist in the downloaded folder
+			`[ -d /opt/dlami/nvme/models/torch ] && ln -s /opt/dlami/nvme/models/torch /home/ubuntu/.cache/torch || true`,
+			`[ -d /opt/dlami/nvme/models/huggingface ] && ln -s /opt/dlami/nvme/models/huggingface /home/ubuntu/.cache/huggingface || true`,
 			`chown -h ubuntu:ubuntu /home/ubuntu/.cache/torch /home/ubuntu/.cache/huggingface`,
 			// Set up transcription service worker
 			`aws s3 cp ${baseS3DistPath}/${workerApp}/transcription-service-worker_1.0.0_all.deb .`,

--- a/packages/client/src/components/ExportForm.tsx
+++ b/packages/client/src/components/ExportForm.tsx
@@ -335,7 +335,9 @@ const ExportForm = () => {
 				parsedTranscriptResp.data.transcript,
 			);
 			if (transcriptText) {
-				const filename = `${parsedTranscriptResp.data.item.originalFilename}.${format === 'text' ? 'txt' : 'srt'}`;
+				const extension =
+					format === 'text' || format === 'translation-text' ? 'txt' : 'srt';
+				const filename = `${parsedTranscriptResp.data.item.originalFilename}.${extension}`;
 				triggerFileDownload(transcriptText, filename);
 				setDownloadStatus(undefined);
 			} else {
@@ -345,6 +347,24 @@ const ExportForm = () => {
 			setDownloadStatus('Failed to download transcript');
 		}
 	};
+
+	const downloadButton = (
+		format: DocExportType,
+		label: string,
+		extraClassName: string = '',
+	) => (
+		<button
+			className={`font-medium text-cyan-600 hover:underline dark:text-cyan-500 ${extraClassName}`}
+			onClick={() =>
+				handleTranscriptDownload(
+					`/api/export/transcript?id=${transcriptId}&format=${format}`,
+					format,
+				)
+			}
+		>
+			{label}
+		</button>
+	);
 
 	const atLeastOneExport = () => exportTypesRequested.length > 0;
 
@@ -429,29 +449,14 @@ const ExportForm = () => {
 			<div className="flex flex-col mt-5">
 				<p className="font-light">
 					Alternatively, you can directly download the files to your computer:{' '}
-					<button
-						className="ml-1 font-medium text-cyan-600 hover:underline dark:text-cyan-500"
-						onClick={() =>
-							handleTranscriptDownload(
-								`/api/export/transcript?id=${transcriptId}&format=text`,
-								'text',
-							)
-						}
-					>
-						Transcript text
-					</button>
-					,{' '}
-					<button
-						className="font-medium text-cyan-600 hover:underline dark:text-cyan-500"
-						onClick={() =>
-							handleTranscriptDownload(
-								`/api/export/transcript?id=${transcriptId}&format=srt`,
-								'srt',
-							)
-						}
-					>
-						Transcript SRT
-					</button>
+					{downloadButton('text', 'Transcript text', 'ml-1')},{' '}
+					{downloadButton('srt', 'Transcript SRT')}
+					{includesTranslation && (
+						<>
+							, {downloadButton('translation-text', 'Translation text')},{' '}
+							{downloadButton('translation-srt', 'Translation SRT')}
+						</>
+					)}
 					{sourceMediaDownloadUrl && (
 						<>
 							,

--- a/packages/client/src/components/ExportForm.tsx
+++ b/packages/client/src/components/ExportForm.tsx
@@ -337,7 +337,10 @@ const ExportForm = () => {
 			if (transcriptText) {
 				const extension =
 					format === 'text' || format === 'translation-text' ? 'txt' : 'srt';
-				const filename = `${parsedTranscriptResp.data.item.originalFilename}.${extension}`;
+				const translationSuffix = isTranslationExport(format)
+					? '-translation'
+					: '';
+				const filename = `${parsedTranscriptResp.data.item.originalFilename}${translationSuffix}.${extension}`;
 				triggerFileDownload(transcriptText, filename);
 				setDownloadStatus(undefined);
 			} else {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -326,7 +326,7 @@ export type TranscriptIdentifier = z.infer<typeof TranscriptIdentifier>;
 
 export const TranscriptDownloadRequest = z.object({
 	id: z.string(),
-	format: z.union([z.literal('text'), z.literal('srt')]),
+	format: DocExportType,
 });
 export type TranscriptDownloadRequest = z.infer<
 	typeof TranscriptDownloadRequest


### PR DESCRIPTION
## What does this change?
This adds download links to the export page for the english translation of transcribed files. Previously these had been missed so that you could only ever download the files for the original language. As part of this work I've added a new `downloadButton` function to make these links a bit more DRY.

## How has this change been tested?
Tested on CODE

Before:
<img width="934" height="464" alt="Screenshot 2026-07-14 at 15 29 58" src="https://github.com/user-attachments/assets/97c12780-7cab-46c2-bc24-6e85e9e04661" />


After:
<img width="1081" height="470" alt="Screenshot 2026-07-14 at 15 32 46" src="https://github.com/user-attachments/assets/359993b1-c43d-43df-bd15-ea2ebb83bed0" />
