### PR TITLE
Tidy up model choice logic, add large model to fetch script

### DIFF
--- a/.github/workflows/fetch-models.yaml
+++ b/.github/workflows/fetch-models.yaml
@@ -90,7 +90,6 @@ jobs:
           python whisperx-model-fetch/download_whisperx_models.py \
             --whisper-models \
             --diarization-models \
-            --torch-align-models \
             --huggingface-token "$HUGGINGFACE_TOKEN"
 
       - name: Zip and upload models to s3

--- a/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/transcription-service.test.ts.snap
@@ -1283,8 +1283,8 @@ unzip /opt/dlami/nvme/models.zip -d /opt/dlami/nvme/
 rm -rf /home/ubuntu/.cache/torch /home/ubuntu/.cache/huggingface
 chown -R ubuntu:ubuntu /opt/dlami/nvme/models
 mkdir -p /home/ubuntu/.cache
-ln -s /opt/dlami/nvme/models/torch /home/ubuntu/.cache/torch
-ln -s /opt/dlami/nvme/models/huggingface /home/ubuntu/.cache/huggingface
+[ -d /opt/dlami/nvme/models/torch ] && ln -s /opt/dlami/nvme/models/torch /home/ubuntu/.cache/torch || true
+[ -d /opt/dlami/nvme/models/huggingface ] && ln -s /opt/dlami/nvme/models/huggingface /home/ubuntu/.cache/huggingface || true
 chown -h ubuntu:ubuntu /home/ubuntu/.cache/torch /home/ubuntu/.cache/huggingface
 aws s3 cp s3://",
                   {

--- a/packages/cdk/lib/transcription-service.ts
+++ b/packages/cdk/lib/transcription-service.ts
@@ -363,8 +363,9 @@ export class TranscriptionService extends GuStack {
 			`chown -R ubuntu:ubuntu /opt/dlami/nvme/models`,
 			// symlink nvme location to .cache so that we don't have to tell whisperx about the special /models folder
 			`mkdir -p /home/ubuntu/.cache`,
-			`ln -s /opt/dlami/nvme/models/torch /home/ubuntu/.cache/torch`,
-			`ln -s /opt/dlami/nvme/models/huggingface /home/ubuntu/.cache/huggingface`,
+			// create symlinks for torch/huggingface dirs if they exist in the downloaded folder
+			`[ -d /opt/dlami/nvme/models/torch ] && ln -s /opt/dlami/nvme/models/torch /home/ubuntu/.cache/torch || true`,
+			`[ -d /opt/dlami/nvme/models/huggingface ] && ln -s /opt/dlami/nvme/models/huggingface /home/ubuntu/.cache/huggingface || true`,
 			`chown -h ubuntu:ubuntu /home/ubuntu/.cache/torch /home/ubuntu/.cache/huggingface`,
 			// Set up transcription service worker
 			`aws s3 cp ${baseS3DistPath}/${workerApp}/transcription-service-worker_1.0.0_all.deb .`,

--- a/packages/worker/src/transcribe.ts
+++ b/packages/worker/src/transcribe.ts
@@ -37,7 +37,7 @@ interface FfmpegResult {
 	failed: boolean;
 }
 
-export type WhisperModel = 'medium' | 'tiny';
+export type WhisperModel = 'large' | 'tiny';
 
 export type WhisperBaseParams = {
 	containerId?: string;
@@ -194,8 +194,7 @@ export const runWhisperX = async (
 ) => {
 	const { wavPath, stage, diarize, huggingFaceToken } = whisperBaseParams;
 	const fileName = path.parse(wavPath).name;
-	const model =
-		languageCode === 'auto' || languageCode === 'en' ? 'large' : 'large';
+	const model = whisperBaseParams.model;
 	const languageCodeParam =
 		languageCode === 'auto' ? [] : ['--language', languageCode];
 	const translateParam = translate ? ['--task', 'translate'] : [];
@@ -384,7 +383,8 @@ export const processTranscriptionJob = async (
 	const whisperBaseParams: WhisperBaseParams = {
 		wavPath: wavPath,
 		file: fileToTranscribe,
-		model: config.app.stage === 'DEV' ? 'tiny' : 'medium',
+		// NOTE: if you change the models here, make sure you update download_whisperx_models accordingly
+		model: config.app.stage === 'DEV' ? 'tiny' : 'large',
 		engine: job.engine,
 		diarize: job.diarize,
 		stage: config.app.stage,

--- a/whisperx-model-fetch/download_whisperx_models.py
+++ b/whisperx-model-fetch/download_whisperx_models.py
@@ -108,8 +108,8 @@ def download_diarization_models(auth_token):
 WHISPER_MODELS = {
     "tiny": "Systran/faster-whisper-tiny",
     # "small": "Systran/faster-whisper-small",
-    "medium": "Systran/faster-whisper-medium",
-    # "large": "Systran/faster-whisper-large-v3",
+    # "medium": "Systran/faster-whisper-medium",
+    "large": "Systran/faster-whisper-large-v3",
 }
 
 


### PR DESCRIPTION
## What does this change?
Currently, the transcription service is set up to always use the 'large' model. But in the codebase it was very confusing because we have a 'model' property of WhiserBaseParams which was being ignored, and instead we had a ternary with 'large' on both sides.

I think we might as well just use the 'large' model for everything (in theory stuff in english would be fine with medium) as it's pretty fast still. 

This PR tidies up the logic so that the model property in `WhiserBaseParams` is respected. 

It also updates the fetch models script so that we actually install the large model - right now we can't start up new transcription worker boxes without internet access because the large model is missing

Finally, I've removed the `--torch-align-models` param from the github action that prepares the model artifact. We have `--no_align` set everywhere we use whisperx so we don't use these models

## How has this change been tested?
Testing it on CODE now...